### PR TITLE
v0.2.0 feat: Mixed Playlist Mode — pass-the-phone, QR rooms, group taste card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-07-12
+
+### Added
+
+- **Mixed Playlist Mode** (v0–v2 of `dev_docs/guessong-mixed-playlist-spec.md`; v3 async quiz mode not started):
+  - **v0 — Pass This Phone**: zero-backend flow where players take turns entering their name + Spotify playlist URL on the host's device, with a masked "✓ added" confirmation between turns. Capped at 12 contributors with duplicate-name rejection, matching the server room's limits.
+  - **v1 — QR Code / Share Link room**: host creates a room (`POST /api/room`), players submit playlists via `/j/[code]` by scanning a QR code or receiving a shared link (`Share Join Link` button — same URL either way), host polls submission status and pulls the pooled tracks to start (`GET /api/room/[code]/pool`). Rooms are TTL'd (30 min) and gated behind at least 2 contributors. Backed by Upstash Redis in production, in-memory fallback for local dev. All four room routes are rate-limited per IP.
+  - **v1.5 — Guess-the-source scoring**: host scoring panel gained a third dimension, "+2 for guessing whose playlist a track came from." Every player is eligible, including the track's own contributor(s) — sampling means a contributor doesn't know which of their tracks made the pool, so they may not recognize their own track any faster than anyone else.
+  - **v2 — Group taste card**: a downloadable "Save Taste Card" image (alongside the existing "Save Results") showing shared tracks across playlists, "Most Obscure Taste," and "Most Mainstream" awards.
+  - New shared modules: `lib/mixed-playlist.ts` (cross-playlist fingerprint dedupe + fair per-contributor sampling), `lib/room.ts` + `lib/kv.ts` (room lifecycle + KV abstraction), `lib/rate-limit.ts`, `lib/round-history.ts`, `lib/taste-card.ts`, `lib/result-image.ts` (shared canvas card rendering).
+  - `Track.contributors` and `Track.popularity` added to the shared track shape; `GamePayload.mixedPlaylistMeta` added for pool provenance.
+
+### Fixed
+
+- `parseGamePayload`'s `playlistSource` fallback used a binary ternary (`"builtin" : "own"`) that would have silently misclassified the new `"mixed"` source as `"own"` on sessionStorage round-trip; replaced with an allow-list check.
+- `submitToRoom`/`consumeRoomPool` read-modify-wrote the whole room record with no atomicity — two players submitting close together could silently clobber each other, and a submission racing a host's "Start" could un-consume an already-started room. Both now re-read the record immediately before writing and retry on a lost write instead of failing silently.
+- `GET /api/room/[code]/status` and `GET /api/room/[code]/pool` had no rate limiting, unlike the other two room routes — an unthrottled client could enumerate the ~1M possible 4-char room codes and read active rooms' player names. Both now rate-limit per IP.
+- Room submissions stored the full raw Spotify API blob (`Track.rawJson`) per track; a full room could approach Upstash's per-value size limit and made every submission's write cost grow with room size. Submissions are now stripped before storage via the same `stripTrackForStorage` helper already used for sessionStorage.
+- `computeMostObscure` credited every contributor of a shared (multi-contributor) track whenever any correct source guess was made, even though the game has no record of which specific contributor was named — inflating the "Most Obscure Taste" stat for tracks that appear in multiple playlists. Now only single-contributor tracks count toward this award.
+- `downloadTasteCard`'s canvas height was hardcoded assuming both taste-card awards always render; when only one (or neither) applies, the shared image left unexplained blank space. Height now reflects the actual award count.
+- Room-full submissions returned `429` (rate-limit's status code) instead of `409` (conflict), making the two failure modes indistinguishable to a client.
+- Host-token comparison in `consumeRoomPool` used `!==` instead of a constant-time comparison.
+
+### Known gaps
+
+- The spec's fourth taste-card award, "most often mistaken for someone else," is not implemented — the host-scoring UI only records whether a source guess was *correct*, never who was guessed instead when it was wrong. Would need a new scoring-UI step to compute.
+- Manual "add track via search" fallback for non-Spotify users (KKBOX / YT Music / Apple Music) is deferred past v1's initial scope.
+- `getClientIp` trusts the client-supplied `X-Forwarded-For` header verbatim; on a deployment where the edge doesn't strip/overwrite it, rate limits could be bypassed by rotating the header per request.
+- The host's room state (`roomCode`/`hostToken`) lives only in React state — a page reload before starting the game orphans the room and any submissions already received.

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,12 +4,12 @@ import Link from "next/link";
 export const metadata: Metadata = {
   title: "How to Play",
   description:
-    "Learn how GuessSong works: paste any public Spotify playlist, add players, play short clips, and guess the song. Free, open source, no login required.",
+    "Learn how GuessSong works: paste any public Spotify playlist, add players, play short clips, and guess the song — or merge everyone's playlists together with Mixed Playlist Mode. Free, open source, no login required.",
   alternates: { canonical: "/about" },
   openGraph: {
     title: "How to Play | GuessSong",
     description:
-      "Paste a Spotify playlist, play short clips, guess the song. Free, open source, no login required.",
+      "Paste a Spotify playlist, play short clips, guess the song. Now with Mixed Playlist Mode. Free, open source, no login required.",
   },
 };
 
@@ -94,6 +94,11 @@ const FEATURES = [
     desc: "Your road-trip mix, K-pop hits, 80s classics — if it's a public Spotify playlist, it works.",
   },
   {
+    emoji: "🔀",
+    title: "Mixed Playlist Mode",
+    desc: "Merge everyone's playlists into one pool and see who can guess whose taste is playing.",
+  },
+  {
     emoji: "⚡",
     title: "Zero setup",
     desc: "Nothing to install, nothing stored on a server. All game state lives in your browser.",
@@ -104,6 +109,11 @@ const FEATURES = [
     desc: "5-second clips for the pros, 30 seconds for a chill night. Pick how many songs each round runs.",
   },
   {
+    emoji: "📷",
+    title: "QR code rooms",
+    desc: "No app to install — players scan a code and submit their own playlist from their own phone.",
+  },
+  {
     emoji: "🔎",
     title: "Smart audio fallback",
     desc: "When Spotify has no preview for a track, GuessSong automatically finds one on iTunes or Deezer.",
@@ -112,6 +122,19 @@ const FEATURES = [
     emoji: "🆓",
     title: "Free & open source",
     desc: "The whole thing is open code on GitHub. Fork it, remix it, host your own.",
+  },
+];
+
+const MIXED_COLLECT = [
+  {
+    emoji: "📱",
+    title: "Pass This Phone",
+    desc: 'No backend, no waiting. Each player takes the host\'s device, types their name and their Spotify playlist link, then passes it on — a masked "✓ added" confirms it without revealing their tracks to the room.',
+  },
+  {
+    emoji: "📷",
+    title: "QR Code Room",
+    desc: "The host taps Create Room and gets a 4-character code plus a QR code. Players scan it (or open the shared link) on their own phone, submit their playlist, and watch it appear on the host's screen live.",
   },
 ];
 
@@ -333,6 +356,15 @@ export default function AboutPage() {
         .fade-in-3 { animation-delay: 0.25s; }
         .fade-in-4 { animation-delay: 0.35s; }
         .fade-in-5 { animation-delay: 0.45s; }
+        .fade-in-6 { animation-delay: 0.55s; }
+
+        .taste-card-highlight {
+          display: flex;
+          gap: 16px;
+          align-items: flex-start;
+          padding: 22px 24px;
+        }
+        .taste-card-emoji { font-size: 24px; flex-shrink: 0; }
         @keyframes fadeUp {
           to { opacity: 1; transform: translateY(0); }
         }
@@ -418,8 +450,40 @@ export default function AboutPage() {
             </div>
           </section>
 
-          {/* Scoring */}
+          {/* Mixed Playlist Mode */}
           <section className="fade-in fade-in-3">
+            <p className="eyebrow" style={{ marginBottom: "8px" }}>New · Multiplayer</p>
+            <h2 className="section-title" style={{ marginBottom: "12px" }}>Mixed Playlist Mode 🔀</h2>
+            <p style={{ color: "#999", fontSize: "14px", fontWeight: 300, lineHeight: 1.6, marginBottom: "24px", maxWidth: "560px" }}>
+              Don&apos;t stop at one playlist — everyone brings their own. GuessSong merges
+              everyone&apos;s tracks into a single mixed pool, dedupes the overlaps, and turns
+              the round into a battle of taste: can you tell whose playlist a song came from?
+            </p>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: "12px", marginBottom: "12px" }}>
+              {MIXED_COLLECT.map((m) => (
+                <div key={m.title} className="card feature-card">
+                  <div className="feature-emoji" aria-hidden>{m.emoji}</div>
+                  <p className="feature-title">{m.title}</p>
+                  <p className="feature-desc">{m.desc}</p>
+                </div>
+              ))}
+            </div>
+            <div className="card taste-card-highlight">
+              <div className="taste-card-emoji" aria-hidden>🎴</div>
+              <div>
+                <p className="step-title" style={{ marginBottom: "4px" }}>Save a Taste Card</p>
+                <p className="step-desc">
+                  When the game ends, download a shareable Taste Card: the &ldquo;Shared Bangers&rdquo;
+                  every playlist had in common, plus two awards — Most Obscure Taste (whose
+                  picks were hardest for the room to guess) and Most Mainstream (highest average
+                  Spotify popularity).
+                </p>
+              </div>
+            </div>
+          </section>
+
+          {/* Scoring */}
+          <section className="fade-in fade-in-4">
             <p className="eyebrow" style={{ marginBottom: "8px" }}>Scoring</p>
             <h2 className="section-title" style={{ marginBottom: "12px" }}>The host is the judge</h2>
             <p style={{ color: "#999", fontSize: "14px", fontWeight: 300, lineHeight: 1.6, marginBottom: "20px", maxWidth: "560px" }}>
@@ -439,11 +503,18 @@ export default function AboutPage() {
                   <strong>Album name.</strong> A bonus for the true fans who know where the track lives.
                 </span>
               </div>
+              <div className="card score-row">
+                <span className="score-pts">+2</span>
+                <span className="score-label">
+                  <strong>Whose playlist?</strong> Mixed Playlist mode only — guess which player
+                  contributed the track for a bonus.
+                </span>
+              </div>
             </div>
           </section>
 
           {/* Features */}
-          <section className="fade-in fade-in-4">
+          <section className="fade-in fade-in-5">
             <p className="eyebrow" style={{ marginBottom: "8px" }}>Why GuessSong</p>
             <h2 className="section-title" style={{ marginBottom: "24px" }}>Built for game night, not for sign-ups</h2>
             <div className="feature-grid">
@@ -458,7 +529,7 @@ export default function AboutPage() {
           </section>
 
           {/* Star CTA */}
-          <section className="fade-in fade-in-5">
+          <section className="fade-in fade-in-6">
             <div className="star-banner">
               <div style={{ display: "inline-flex", color: "#ffd75e", marginBottom: "14px" }}>
                 <svg viewBox="0 0 24 24" fill="currentColor" width="32" height="32" aria-hidden>

--- a/app/api/room/[code]/pool/route.ts
+++ b/app/api/room/[code]/pool/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { consumeRoomPool, RoomError } from "@/lib/room";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { DEFAULT_SAMPLED_PER_PLAYER } from "@/types/room";
+
+// hostToken already gates the actual pool consumption, but this route is
+// still an unthrottled oracle for room-code existence/state without a
+// limit (see lib/rate-limit.ts's doc comment on the 4-char code space).
+const POOL_LIMIT = 20;
+const POOL_WINDOW_SECONDS = 10 * 60;
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ code: string }> }
+) {
+  const { code } = await params;
+
+  const ip = getClientIp(req);
+  const { allowed } = await rateLimit(`room:pool:${ip}`, POOL_LIMIT, POOL_WINDOW_SECONDS);
+  if (!allowed) {
+    return NextResponse.json({ error: "Too many attempts, please slow down" }, { status: 429 });
+  }
+
+  const rawSampledPerPlayer = req.nextUrl.searchParams.get("sampledPerPlayer");
+  const sampledPerPlayer = rawSampledPerPlayer
+    ? Number.parseInt(rawSampledPerPlayer, 10)
+    : DEFAULT_SAMPLED_PER_PLAYER;
+
+  if (!Number.isFinite(sampledPerPlayer) || sampledPerPlayer < 1) {
+    return NextResponse.json({ error: "Invalid sampledPerPlayer" }, { status: 400 });
+  }
+
+  const hostToken = req.headers.get("x-host-token") ?? "";
+
+  try {
+    const pool = await consumeRoomPool(code, sampledPerPlayer, hostToken);
+    return NextResponse.json(pool);
+  } catch (err: unknown) {
+    const status = err instanceof RoomError ? err.status : 500;
+    const message = err instanceof Error ? err.message : "Failed to load pool";
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/app/api/room/[code]/status/route.ts
+++ b/app/api/room/[code]/status/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getRoomStatus, RoomError } from "@/lib/room";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
+
+// Room codes are only 4 chars (~1M combos) — without a limit here, an
+// unthrottled client could enumerate the whole code space and read every
+// active room's player names. The host's own page polls this every 4s
+// (ROOM_POLL_INTERVAL_MS in app/page.tsx), i.e. up to 150 requests per
+// 10-minute window on its own — keep the limit comfortably above that.
+const STATUS_LIMIT = 200;
+const STATUS_WINDOW_SECONDS = 10 * 60;
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ code: string }> }
+) {
+  const { code } = await params;
+
+  const ip = getClientIp(req);
+  const { allowed } = await rateLimit(`room:status:${ip}`, STATUS_LIMIT, STATUS_WINDOW_SECONDS);
+  if (!allowed) {
+    return NextResponse.json({ error: "Too many attempts, please slow down" }, { status: 429 });
+  }
+
+  try {
+    const status = await getRoomStatus(code);
+    return NextResponse.json(status);
+  } catch (err: unknown) {
+    const status = err instanceof RoomError ? err.status : 500;
+    const message = err instanceof Error ? err.message : "Failed to load room status";
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/app/api/room/[code]/submit/route.ts
+++ b/app/api/room/[code]/submit/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { submitToRoom, RoomError } from "@/lib/room";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
+
+const SubmitSchema = z.object({
+  playerName: z.string().trim().min(1).max(24),
+  playlistUrl: z.string().trim().min(1),
+});
+
+const SUBMIT_LIMIT = 20;
+const SUBMIT_WINDOW_SECONDS = 10 * 60;
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ code: string }> }
+) {
+  const { code } = await params;
+
+  const ip = getClientIp(req);
+  // Keyed by IP only (not IP+code) so a scanner sweeping many codes from one
+  // IP still gets throttled, not just repeated guesses against one room.
+  const { allowed } = await rateLimit(`room:submit:${ip}`, SUBMIT_LIMIT, SUBMIT_WINDOW_SECONDS);
+  if (!allowed) {
+    return NextResponse.json({ error: "Too many attempts, please slow down" }, { status: 429 });
+  }
+
+  try {
+    const body = SubmitSchema.parse(await req.json());
+    const { trackCount } = await submitToRoom(code, body.playerName, body.playlistUrl);
+    return NextResponse.json({ ok: true, trackCount });
+  } catch (err: unknown) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: "Missing name or playlist URL" }, { status: 400 });
+    }
+    const status = err instanceof RoomError ? err.status : 500;
+    const message = err instanceof Error ? err.message : "Failed to submit playlist";
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/app/api/room/route.ts
+++ b/app/api/room/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createRoom, RoomError } from "@/lib/room";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
+
+const CREATE_ROOM_LIMIT = 10;
+const CREATE_ROOM_WINDOW_SECONDS = 10 * 60;
+
+export async function POST(req: NextRequest) {
+  const ip = getClientIp(req);
+  const { allowed } = await rateLimit(`room:create:${ip}`, CREATE_ROOM_LIMIT, CREATE_ROOM_WINDOW_SECONDS);
+  if (!allowed) {
+    return NextResponse.json({ error: "Too many rooms created, please slow down" }, { status: 429 });
+  }
+
+  try {
+    const { roomCode, expiresAt, hostToken } = await createRoom();
+    return NextResponse.json({ roomCode, expiresAt, hostToken });
+  } catch (err: unknown) {
+    const status = err instanceof RoomError ? err.status : 500;
+    const message = err instanceof Error ? err.message : "Failed to create room";
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -12,6 +12,15 @@ import {
   type GameMode,
   type GamePlayer as Player,
 } from "@/lib/game-session";
+import type { RoundHistoryEntry } from "@/lib/round-history";
+import { buildTasteCard } from "@/lib/taste-card";
+import {
+  createResultCanvas,
+  drawCardBackground,
+  drawCardHeader,
+  drawCardFooter,
+  shareOrDownloadCanvas,
+} from "@/lib/result-image";
 
 type Phase = "waiting" | "playing" | "guessing" | "revealed" | "finished";
 
@@ -50,10 +59,13 @@ export default function GamePage() {
   const [phase, setPhase] = useState<Phase>("waiting");
   const [roundWinner, setRoundWinner] = useState<string | null>(null);
   const [albumWinner, setAlbumWinner] = useState<string | null>(null);
+  const [sourceWinner, setSourceWinner] = useState<string | null>(null);
   const [progress, setProgress] = useState(0);
   const [scorePulse, setScorePulse] = useState<string | null>(null);
   const [pointsAwarded, setPointsAwarded] = useState(false);
   const [albumPointsAwarded, setAlbumPointsAwarded] = useState(false);
+  const [sourcePointsAwarded, setSourcePointsAwarded] = useState(false);
+  const [roundHistory, setRoundHistory] = useState<RoundHistoryEntry[]>([]);
   const [albumHintShown, setAlbumHintShown] = useState(false);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [noAudio, setNoAudio] = useState(false);
@@ -189,6 +201,18 @@ export default function GamePage() {
     setTimeout(() => setScorePulse(null), 600);
   }
 
+  /** Mixed Playlist Mode: +2 for guessing whose playlist the track came from. */
+  function awardSourcePoint(playerName: string) {
+    if (sourcePointsAwarded) return;
+    setSourceWinner(playerName);
+    setSourcePointsAwarded(true);
+    setScorePulse(playerName);
+    setPlayers((prev) =>
+      prev.map((p) => (p.name === playerName ? { ...p, score: p.score + 2 } : p))
+    );
+    setTimeout(() => setScorePulse(null), 600);
+  }
+
   /** Mark the current trial round as guessed correctly (+1, once per round). */
   function markTrialCorrect() {
     if (pointsAwarded) return;
@@ -219,6 +243,21 @@ export default function GamePage() {
       skipped: phase !== "revealed",
       playlist_source: playlistSource,
     });
+
+    const finishedTrack = tracks[currentIndex];
+    if (finishedTrack?.contributors && finishedTrack.contributors.length > 0) {
+      setRoundHistory((prev) => [
+        ...prev,
+        {
+          trackId: finishedTrack.id,
+          contributors: finishedTrack.contributors!,
+          songWinner: roundWinner,
+          albumWinner: albumWinner,
+          sourceWinner: sourceWinner,
+        },
+      ]);
+    }
+
     if (currentIndex + 1 >= tracks.length) {
       trackGameFinished();
       setPhase("finished");
@@ -227,9 +266,11 @@ export default function GamePage() {
       setPhase("waiting");
       setRoundWinner(null);
       setAlbumWinner(null);
+      setSourceWinner(null);
       setProgress(0);
       setPointsAwarded(false);
       setAlbumPointsAwarded(false);
+      setSourcePointsAwarded(false);
       setAlbumHintShown(false);
       setPreviewLoading(false);
       setNoAudio(false);
@@ -248,57 +289,20 @@ export default function GamePage() {
   }
 
   function downloadResultImage() {
-    const canvas = document.createElement("canvas");
-    const dpr = window.devicePixelRatio || 1;
     const W = 640;
     const rowH = 64;
     const headerH = 200;
     const footerH = 80;
     const H = headerH + sortedPlayers.length * rowH + footerH;
-    canvas.width = W * dpr;
-    canvas.height = H * dpr;
-    canvas.style.width = W + "px";
-    canvas.style.height = H + "px";
-    const ctx = canvas.getContext("2d")!;
-    ctx.scale(dpr, dpr);
+    const { canvas, ctx } = createResultCanvas(W, H);
 
-    // Background
-    ctx.fillStyle = "#111111";
-    ctx.fillRect(0, 0, W, H);
-
-    // Top accent bar
-    const accent = ctx.createLinearGradient(0, 0, W, 0);
-    accent.addColorStop(0, "#1DB954");
-    accent.addColorStop(1, "#0a8f3c");
-    ctx.fillStyle = accent;
-    ctx.fillRect(0, 0, W, 4);
-
-    // Title
-    ctx.fillStyle = "#1DB954";
-    ctx.font = "bold 13px sans-serif";
-    ctx.letterSpacing = "2px";
-    ctx.fillText("GUESS SONG", 40, 48);
-
-    // "Final Scores"
-    ctx.fillStyle = "#ffffff";
-    ctx.font = "bold 48px sans-serif";
-    ctx.letterSpacing = "1px";
-    ctx.fillText("Final Scores", 40, 100);
-
-    // Playlist name
-    ctx.fillStyle = "#666666";
-    ctx.font = "15px sans-serif";
-    ctx.letterSpacing = "0px";
-    const pName = playlistName.length > 50 ? playlistName.slice(0, 50) + "…" : playlistName;
-    ctx.fillText(pName, 40, 130);
-
-    // Divider
-    ctx.strokeStyle = "#222222";
-    ctx.lineWidth = 1;
-    ctx.beginPath();
-    ctx.moveTo(40, 155);
-    ctx.lineTo(W - 40, 155);
-    ctx.stroke();
+    drawCardBackground(ctx, W, H);
+    drawCardHeader(ctx, {
+      width: W,
+      kicker: "GUESS SONG",
+      title: "Final Scores",
+      subtitle: playlistName,
+    });
 
     // Player rows
     sortedPlayers.forEach((p, idx) => {
@@ -341,48 +345,101 @@ export default function GamePage() {
       ctx.fillText("pts", W - 40, y + rowH / 2 + 10);
     });
 
-    // Footer
     const footerY = headerH + sortedPlayers.length * rowH + 20;
-    ctx.strokeStyle = "#222";
-    ctx.beginPath();
-    ctx.moveTo(40, footerY);
-    ctx.lineTo(W - 40, footerY);
-    ctx.stroke();
-    ctx.font = "12px sans-serif";
-    ctx.fillStyle = "#444";
-    ctx.fillText("Played with GuessSong", 40, footerY + 30);
+    drawCardFooter(ctx, W, footerY);
+    shareOrDownloadCanvas(canvas, `guesssong-results-${Date.now()}.png`, "GuessSong results");
+  }
 
-    // Save: prefer the share sheet with an image file — on Android/iOS that
-    // offers "Save to Photos", and data-URL anchor downloads are unreliable
-    // inside installed PWAs (WebAPK). Fallback: blob URL download.
-    canvas.toBlob(async (blob) => {
-      if (!blob) return;
-      const file = new File([blob], `guesssong-results-${Date.now()}.png`, {
-        type: "image/png",
-      });
+  /** Mixed Playlist Mode (v2): the group taste card — shared bangers + awards. */
+  function downloadTasteCard() {
+    const tasteCard = buildTasteCard(tracks, roundHistory);
+    const W = 640;
+    const sharedTracks = tasteCard.sharedTracks.slice(0, 5);
+    const sharedRowH = 44;
+    const headerH = 200;
+    const sharedSectionH =
+      sharedTracks.length > 0 ? 40 + sharedTracks.length * sharedRowH + 20 : 0;
+    const awardCount = (tasteCard.mostObscure ? 1 : 0) + (tasteCard.mostMainstream ? 1 : 0);
+    const awardsSectionH = 40 + awardCount * 70 + 20;
+    const footerH = 80;
+    const H = headerH + sharedSectionH + awardsSectionH + footerH;
+    const { canvas, ctx } = createResultCanvas(W, H);
 
-      if (
-        typeof navigator.canShare === "function" &&
-        navigator.canShare({ files: [file] })
-      ) {
-        try {
-          await navigator.share({ files: [file], title: "GuessSong results" });
-          return;
-        } catch (e) {
-          // User closed the share sheet — not an error, don't force a download.
-          if (e instanceof DOMException && e.name === "AbortError") return;
+    drawCardBackground(ctx, W, H);
+    drawCardHeader(ctx, {
+      width: W,
+      kicker: "GUESS SONG",
+      title: "Taste Card",
+      subtitle: playlistName,
+    });
+
+    let y = headerH;
+
+    if (sharedTracks.length > 0) {
+      ctx.fillStyle = "#1DB954";
+      ctx.font = "bold 13px sans-serif";
+      ctx.letterSpacing = "1px";
+      ctx.fillText("SHARED BANGERS", 40, y + 24);
+      y += 40;
+
+      sharedTracks.forEach((t) => {
+        ctx.font = "600 16px sans-serif";
+        ctx.fillStyle = "#ffffff";
+        ctx.letterSpacing = "0px";
+        let nameText = t.name;
+        const maxNameW = W - 80;
+        while (ctx.measureText(nameText).width > maxNameW && nameText.length > 1) {
+          nameText = nameText.slice(0, -1);
         }
-      }
+        if (nameText !== t.name) nameText += "…";
+        ctx.fillText(nameText, 40, y + 20);
 
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.download = file.name;
-      link.href = url;
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-      setTimeout(() => URL.revokeObjectURL(url), 10_000);
-    }, "image/png");
+        ctx.font = "13px sans-serif";
+        ctx.fillStyle = "#666666";
+        ctx.fillText(t.contributors.join(" & "), 40, y + 38);
+
+        y += sharedRowH;
+      });
+      y += 20;
+    }
+
+    ctx.fillStyle = "#1DB954";
+    ctx.font = "bold 13px sans-serif";
+    ctx.letterSpacing = "1px";
+    ctx.fillText("AWARDS", 40, y + 24);
+    y += 40;
+
+    if (tasteCard.mostObscure) {
+      ctx.font = "13px sans-serif";
+      ctx.fillStyle = "#666666";
+      ctx.letterSpacing = "0px";
+      ctx.fillText("MOST OBSCURE TASTE", 40, y + 16);
+      ctx.font = "700 24px sans-serif";
+      ctx.fillStyle = "#ffffff";
+      ctx.fillText(
+        `${tasteCard.mostObscure.playerName} — ${Math.round(tasteCard.mostObscure.rate * 100)}% guessed`,
+        40,
+        y + 46
+      );
+      y += 70;
+    }
+
+    if (tasteCard.mostMainstream) {
+      ctx.font = "13px sans-serif";
+      ctx.fillStyle = "#666666";
+      ctx.fillText("MOST MAINSTREAM", 40, y + 16);
+      ctx.font = "700 24px sans-serif";
+      ctx.fillStyle = "#ffffff";
+      ctx.fillText(
+        `${tasteCard.mostMainstream.playerName} — ${Math.round(tasteCard.mostMainstream.averagePopularity)} popularity`,
+        40,
+        y + 46
+      );
+      y += 70;
+    }
+
+    drawCardFooter(ctx, W, y + 20);
+    shareOrDownloadCanvas(canvas, `guesssong-taste-card-${Date.now()}.png`, "GuessSong taste card");
   }
 
   const currentTrack = tracks[currentIndex];
@@ -1193,6 +1250,13 @@ export default function GamePage() {
                       {currentTrack.albumName}
                     </p>
                   )}
+                  {currentTrack?.contributors && currentTrack.contributors.length > 0 && (
+                    <p style={{ fontSize: "13px", color: "#1DB954", marginTop: "8px", fontWeight: 500 }}>
+                      {currentTrack.contributors.length > 1
+                        ? `From ${currentTrack.contributors.join(" & ")}'s playlists!`
+                        : `From ${currentTrack.contributors[0]}'s playlist`}
+                    </p>
+                  )}
                 </div>
 
                 {isTrial ? (
@@ -1256,6 +1320,36 @@ export default function GamePage() {
                     ) : (
                       <p style={{ textAlign: "center", color: "#1DB954", fontSize: "13px", marginBottom: "14px" }}>
                         {albumWinner ? `+1 pt → ${albumWinner}` : "No one scored"}
+                      </p>
+                    )}
+                  </>
+                )}
+
+                {/* Source scoring — 2 pts, Mixed Playlist Mode only. Every player is */}
+                {/* eligible, including this track's contributor(s) — sampling means a */}
+                {/* contributor doesn't know which of their tracks made the pool, so they */}
+                {/* may not recognize their own track any faster than anyone else. */}
+                {currentTrack?.contributors && currentTrack.contributors.length > 0 && (
+                  <>
+                    <p className="who-scored">Who guessed whose playlist this is? (+2 pts)</p>
+                    {!sourcePointsAwarded ? (
+                      <div className="player-picker" style={{ marginBottom: "14px" }}>
+                        {players.map((p) => (
+                          <button
+                            key={p.name}
+                            className="player-pick-btn"
+                            onClick={() => awardSourcePoint(p.name)}
+                          >
+                            {p.name}
+                          </button>
+                        ))}
+                        <button className="btn-ghost" onClick={() => setSourcePointsAwarded(true)}>
+                          No one
+                        </button>
+                      </div>
+                    ) : (
+                      <p style={{ textAlign: "center", color: "#1DB954", fontSize: "13px", marginBottom: "14px" }}>
+                        {sourceWinner ? `+2 pts → ${sourceWinner}` : "No one scored"}
                       </p>
                     )}
                   </>
@@ -1354,6 +1448,11 @@ export default function GamePage() {
                 <button className="btn-lg outline" onClick={downloadResultImage}>
                   Save Results
                 </button>
+                {playlistSource === "mixed" && (
+                  <button className="btn-lg outline" onClick={downloadTasteCard}>
+                    Save Taste Card
+                  </button>
+                )}
               </div>
             </div>
           )}

--- a/app/j/[code]/page.tsx
+++ b/app/j/[code]/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState } from "react";
+import { useParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type SubmitStatus = "idle" | "loading" | "done" | "error";
+
+export default function JoinRoomPage() {
+  const params = useParams<{ code: string }>();
+  const code = (params.code ?? "").toUpperCase();
+
+  const [name, setName] = useState("");
+  const [playlistUrl, setPlaylistUrl] = useState("");
+  const [status, setStatus] = useState<SubmitStatus>("idle");
+  const [trackCount, setTrackCount] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const isValidUrl =
+    playlistUrl.includes("spotify.com/playlist") || playlistUrl.includes("spotify:playlist:");
+  const canSubmit = name.trim().length > 0 && isValidUrl && status !== "loading";
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+    setStatus("loading");
+    setError(null);
+    try {
+      const res = await fetch(`/api/room/${code}/submit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ playerName: name, playlistUrl }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Couldn't submit your playlist");
+      setTrackCount(data.trackCount);
+      setStatus("done");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+      setStatus("error");
+    }
+  }
+
+  if (status === "done") {
+    return (
+      <main className="min-h-screen flex items-center justify-center p-6 bg-background text-foreground">
+        <Card className="w-full max-w-sm text-center">
+          <CardHeader>
+            <CardTitle className="text-[#1DB954]">✓ You&apos;re in!</CardTitle>
+            <CardDescription>
+              Received {trackCount} track{trackCount === 1 ? "" : "s"} from your playlist.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              You can close this page now — the host will start the game once everyone&apos;s in.
+              No one else can see your playlist.
+            </p>
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center p-6 bg-background text-foreground">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Join Room {code}</CardTitle>
+          <CardDescription>
+            Add your Spotify playlist — no one else will see it until the game starts.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="name">Your Name</Label>
+            <Input
+              id="name"
+              placeholder="Player name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={24}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="playlist">Your Spotify Playlist</Label>
+            <Input
+              id="playlist"
+              type="url"
+              placeholder="https://open.spotify.com/playlist/..."
+              value={playlistUrl}
+              onChange={(e) => setPlaylistUrl(e.target.value)}
+              spellCheck={false}
+            />
+          </div>
+          <Button onClick={handleSubmit} disabled={!canSubmit}>
+            {status === "loading" ? "Submitting..." : "Submit Playlist"}
+          </Button>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,15 +9,17 @@ const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://www.guessong.app";
 export const metadata: Metadata = {
   metadataBase: new URL(BASE_URL),
   title: {
-    default: "GuessSong — Spotify Party Game",
+    default: "GuessSong — Guess Song Party Game",
     template: "%s | GuessSong",
   },
   description:
-    "Play a clip, guess the song. A free music guessing game for parties — works with any Spotify playlist, no login required, local multiplayer fun for friends and family.",
+    "Play a clip, guess the song. GuessSong is a free guess song party game for any Spotify playlist — no login required, local multiplayer fun for friends and family.",
   keywords: [
     "music guessing game",
     "spotify party game",
     "song guessing game",
+    "guess song",
+    "guess song game",
     "music quiz",
     "party game",
     "local multiplayer",
@@ -31,6 +33,11 @@ export const metadata: Metadata = {
     "friends game night",
     "music game for parties",
     "spotify trivia",
+    "猜歌",
+    "猜歌遊戲",
+    "音樂猜謎遊戲",
+    "派對猜歌遊戲",
+    "spotify 猜歌",
   ],
   authors: [{ name: "GuessSong" }],
   manifest: "/manifest.json",
@@ -39,16 +46,16 @@ export const metadata: Metadata = {
     type: "website",
     url: BASE_URL,
     siteName: "GuessSong",
-    title: "GuessSong — Spotify Party Game",
+    title: "GuessSong — Guess Song Party Game",
     description:
-      "Play a clip, guess the song. Works with any Spotify playlist, no login required.",
+      "Play a clip, guess the song. A free guess song game for any Spotify playlist, no login required.",
     images: [{ url: "/opengraph-image", width: 1200, height: 630 }],
   },
   twitter: {
     card: "summary_large_image",
-    title: "GuessSong — Spotify Party Game",
+    title: "GuessSong — Guess Song Party Game",
     description:
-      "Play a clip, guess the song. Works with any Spotify playlist, no login required.",
+      "Play a clip, guess the song. A free guess song game for any Spotify playlist, no login required.",
     images: ["/opengraph-image"],
   },
 };
@@ -66,9 +73,10 @@ export default function RootLayout({
     "@context": "https://schema.org",
     "@type": "WebApplication",
     name: "GuessSong",
+    alternateName: ["Guess Song", "Guess the Song", "猜歌", "猜歌遊戲"],
     url: BASE_URL,
     description:
-      "A free music guessing game for parties. Works with any Spotify playlist, no login required.",
+      "A free guess song game for parties. Works with any Spotify playlist, no login required.",
     applicationCategory: "GameApplication",
     operatingSystem: "Web",
     offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -715,6 +715,9 @@ export default function SetupPage() {
             <p style={{ color: "#555", fontSize: "12px", marginTop: "8px" }}>
               Paste any public Spotify playlist URL — no login required
             </p>
+            <p style={{ color: "#555", fontSize: "12px", marginTop: "4px" }}>
+              猜歌遊戲・派對音樂猜謎，適合朋友聚會
+            </p>
             <p style={{ fontSize: "13px", marginTop: "6px" }}>
               <a
                 href="/about"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,28 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
+import QRCode from "qrcode";
+import type { Track } from "@/types";
+import { DEFAULT_SAMPLED_PER_PLAYER, type RoomSubmissionSummary, type RoomPoolResponse } from "@/types/room";
 import { trackEvent } from "@/lib/analytics";
 import { buildGamePayload, GAME_STORAGE_KEY } from "@/lib/game-session";
 import { BUILTIN_PLAYLISTS, type BuiltinPlaylist } from "@/lib/builtin-playlists";
 import { InstallBanner } from "@/components/install-banner";
+import {
+  MixedPlaylistCollector,
+  type MixedContribution,
+} from "@/components/mixed-playlist-collector";
+import { poolContributions } from "@/lib/mixed-playlist";
 
 const CLIP_DURATIONS = [5, 10, 15, 20, 30];
 const SONG_COUNTS: (number | "all")[] = [10, 20, 30, 50, "all"];
+const MIXED_SAMPLE_COUNTS = [5, 8, 10, 12];
+const MIXED_MIN_CONTRIBUTORS = 2;
+const ROOM_POLL_INTERVAL_MS = 4000;
+
+type SetupMode = "single" | "mixed";
+type MixedSubMode = "room" | "phone";
 
 function SpotifyIcon() {
   return (
@@ -49,20 +63,161 @@ function WaveformBg() {
 
 export default function SetupPage() {
   const router = useRouter();
+  const [setupMode, setSetupMode] = useState<SetupMode>("single");
   const [playlistUrl, setPlaylistUrl] = useState("");
   const [players, setPlayers] = useState<string[]>(["", ""]);
   const [clipDuration, setClipDuration] = useState(15);
   const [songCount, setSongCount] = useState<number | "all">(20);
+  const [mixedContributions, setMixedContributions] = useState<MixedContribution[]>([]);
+  const [sampledPerPlayer, setSampledPerPlayer] = useState(DEFAULT_SAMPLED_PER_PLAYER);
+  const [mixedSubMode, setMixedSubMode] = useState<MixedSubMode>("room");
+  const [roomCode, setRoomCode] = useState<string | null>(null);
+  const [hostToken, setHostToken] = useState<string | null>(null);
+  const [joinUrl, setJoinUrl] = useState<string | null>(null);
+  const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+  const [roomSubmissions, setRoomSubmissions] = useState<RoomSubmissionSummary[]>([]);
+  const [roomCreating, setRoomCreating] = useState(false);
+  const [roomStarting, setRoomStarting] = useState(false);
+  const [roomError, setRoomError] = useState<string | null>(null);
+  const [linkCopied, setLinkCopied] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [mounted, setMounted] = useState(false);
   const firstInputRef = useRef<HTMLInputElement>(null);
+  const roomPollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const roomSubmissionTotalRef = useRef(0);
+
+  function addMixedContribution(c: MixedContribution) {
+    setMixedContributions((prev) => [...prev, c]);
+  }
+
+  function removeMixedContribution(idx: number) {
+    setMixedContributions((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  function stopRoomPolling() {
+    if (roomPollIntervalRef.current) {
+      clearInterval(roomPollIntervalRef.current);
+      roomPollIntervalRef.current = null;
+    }
+  }
+
+  async function pollRoomStatus(code: string) {
+    try {
+      const res = await fetch(`/api/room/${code}/status`);
+      const data = await res.json();
+      if (!res.ok) return;
+      setRoomSubmissions(data.submissions);
+      if (data.total > roomSubmissionTotalRef.current) {
+        roomSubmissionTotalRef.current = data.total;
+        trackEvent("room_submission_received", { total: data.total });
+      }
+    } catch {
+      // Transient network hiccup while polling — the next tick retries.
+    }
+  }
+
+  async function handleCreateRoom() {
+    setRoomError(null);
+    setRoomCreating(true);
+    try {
+      const res = await fetch("/api/room", { method: "POST" });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to create room");
+
+      setRoomCode(data.roomCode);
+      setHostToken(data.hostToken);
+      roomSubmissionTotalRef.current = 0;
+      setRoomSubmissions([]);
+      trackEvent("room_created", {});
+
+      const url = `${window.location.origin}/j/${data.roomCode}`;
+      setJoinUrl(url);
+      const dataUrl = await QRCode.toDataURL(url, { margin: 1, width: 240 });
+      setQrDataUrl(dataUrl);
+
+      stopRoomPolling();
+      roomPollIntervalRef.current = setInterval(
+        () => pollRoomStatus(data.roomCode),
+        ROOM_POLL_INTERVAL_MS
+      );
+    } catch (e: unknown) {
+      setRoomError(e instanceof Error ? e.message : "Something went wrong");
+    } finally {
+      setRoomCreating(false);
+    }
+  }
+
+  async function handleShareJoinLink() {
+    if (!joinUrl) return;
+    if (typeof navigator.share === "function") {
+      try {
+        await navigator.share({ url: joinUrl, title: `Join room ${roomCode} on GuessSong` });
+        return;
+      } catch (e) {
+        // User closed the share sheet — not an error, fall through to copy.
+        if (e instanceof DOMException && e.name === "AbortError") return;
+      }
+    }
+    try {
+      await navigator.clipboard.writeText(joinUrl);
+      setLinkCopied(true);
+      setTimeout(() => setLinkCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable — the QR code and visible code remain usable.
+    }
+  }
+
+  async function handleRoomStart() {
+    if (!roomCode || !hostToken) return;
+    setRoomError(null);
+    setRoomStarting(true);
+    try {
+      const res = await fetch(`/api/room/${roomCode}/pool?sampledPerPlayer=${sampledPerPlayer}`, {
+        headers: { "x-host-token": hostToken },
+      });
+      const data: RoomPoolResponse & { error?: string } = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to start game");
+      stopRoomPolling();
+
+      const payload = buildGamePayload({
+        tracks: data.tracks,
+        players: data.players.map((name) => ({ name, score: 0 })),
+        playlistName: `${data.players.length}-Player Mix`,
+        clipDuration,
+        totalTracks: data.tracks.length,
+        playlistSource: "mixed",
+        mode: "party",
+        mixedPlaylistMeta: {
+          contributorNames: data.players,
+          sampledPerPlayer: data.sampledPerPlayer,
+        },
+      });
+      sessionStorage.setItem(GAME_STORAGE_KEY, JSON.stringify(payload));
+      trackEvent("game_started", {
+        player_count: data.players.length,
+        clip_duration: clipDuration,
+        song_count: data.tracks.length,
+        playlist_source: "mixed",
+      });
+      trackEvent("room_started", {
+        contributor_count: data.players.length,
+        unique_tracks: data.tracks.length,
+      });
+      router.push("/game");
+    } catch (e: unknown) {
+      setRoomError(e instanceof Error ? e.message : "Something went wrong");
+    } finally {
+      setRoomStarting(false);
+    }
+  }
 
   useEffect(() => {
     setMounted(true);
     // Prefill from the share target redirect (/share → /?playlist=...).
     const shared = new URLSearchParams(window.location.search).get("playlist");
     if (shared) setPlaylistUrl(shared);
+    return () => stopRoomPolling();
   }, []);
 
   const isValidSpotifyUrl = playlistUrl.includes("spotify.com/playlist") || playlistUrl.includes("spotify:playlist:");
@@ -120,6 +275,78 @@ export default function SetupPage() {
         clip_duration: clipDuration,
         song_count: limited.length,
         playlist_source: "own",
+      });
+      router.push("/game");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleMixedStart() {
+    setError(null);
+    if (mixedContributions.length < MIXED_MIN_CONTRIBUTORS) {
+      setError(`Add at least ${MIXED_MIN_CONTRIBUTORS} players' playlists to start`);
+      return;
+    }
+    setLoading(true);
+    trackEvent("playlist_submitted", { playlist_source: "mixed" });
+    try {
+      const results = await Promise.allSettled(
+        mixedContributions.map(async (c) => {
+          const res = await fetch("/api/playlist", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ url: c.playlistUrl }),
+          });
+          const data = await res.json();
+          if (!res.ok) throw new Error(data.error || "Failed to load playlist");
+          return { playerName: c.name, tracks: data.tracks as Track[] };
+        })
+      );
+
+      const failedNames = results
+        .map((r, i) => (r.status === "rejected" ? mixedContributions[i].name : null))
+        .filter((n): n is string => n !== null);
+      if (failedNames.length > 0) {
+        throw new Error(
+          `Couldn't load a playlist for: ${failedNames.join(", ")}. Remove or fix them and try again.`
+        );
+      }
+
+      const contributions = (
+        results as PromiseFulfilledResult<{ playerName: string; tracks: Track[] }>[]
+      ).map((r) => r.value);
+      const totalRawTracks = contributions.reduce((sum, c) => sum + c.tracks.length, 0);
+      const pooled = poolContributions(contributions, sampledPerPlayer);
+      const overlapCount = pooled.filter((t) => t.contributors.length > 1).length;
+
+      const payload = buildGamePayload({
+        tracks: pooled,
+        players: mixedContributions.map((c) => ({ name: c.name, score: 0 })),
+        playlistName: `${mixedContributions.length}-Player Mix`,
+        clipDuration,
+        totalTracks: pooled.length,
+        playlistSource: "mixed",
+        mode: "party",
+        mixedPlaylistMeta: {
+          contributorNames: mixedContributions.map((c) => c.name),
+          sampledPerPlayer,
+        },
+      });
+      sessionStorage.setItem(GAME_STORAGE_KEY, JSON.stringify(payload));
+      trackEvent("game_started", {
+        player_count: mixedContributions.length,
+        clip_duration: clipDuration,
+        song_count: pooled.length,
+        playlist_source: "mixed",
+      });
+      trackEvent("mixed_pool_built", {
+        contributor_count: mixedContributions.length,
+        unique_tracks: pooled.length,
+        total_raw_tracks: totalRawTracks,
+        overlap_count: overlapCount,
       });
       router.push("/game");
     } catch (e: unknown) {
@@ -516,80 +743,257 @@ export default function SetupPage() {
           {/* Card */}
           <div className={`card ${mounted ? "fade-in fade-in-2" : ""}`} style={{ padding: "28px", display: "flex", flexDirection: "column", gap: "24px" }}>
 
-            {/* Playlist URL */}
+            {/* Game Mode */}
             <div>
-              <p className="section-label">Spotify Playlist</p>
-              <div style={{ position: "relative" }}>
-                <input
-                  ref={firstInputRef}
-                  type="url"
-                  className={`url-input${isValidSpotifyUrl ? " valid" : ""}`}
-                  placeholder="https://open.spotify.com/playlist/..."
-                  value={playlistUrl}
-                  onChange={(e) => setPlaylistUrl(e.target.value)}
-                  spellCheck={false}
-                />
-                {isValidSpotifyUrl && (
-                  <span
-                    style={{
-                      position: "absolute",
-                      right: "14px",
-                      top: "50%",
-                      transform: "translateY(-50%)",
-                      color: "#1DB954",
-                    }}
-                  >
-                    <CheckIcon />
-                  </span>
-                )}
-              </div>
-              {isEditorial && (
-                <p
-                  style={{
-                    marginTop: "8px",
-                    fontSize: "12px",
-                    color: "#f59e0b",
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "6px",
-                  }}
+              <p className="section-label">Game Mode</p>
+              <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+                <button
+                  className={`pill${setupMode === "single" ? " active" : ""}`}
+                  onClick={() => setSetupMode("single")}
                 >
-                  <span>⚠</span> Editorial playlists (Discover Weekly, etc.) may not work
+                  Single Playlist
+                </button>
+                <button
+                  className={`pill${setupMode === "mixed" ? " active" : ""}`}
+                  onClick={() => setSetupMode("mixed")}
+                >
+                  Mixed Playlist 🔀
+                </button>
+              </div>
+              {setupMode === "mixed" && (
+                <p style={{ marginTop: "8px", fontSize: "12px", color: "#666" }}>
+                  Pass this phone around — everyone adds their own playlist, then we mix them together.
                 </p>
               )}
             </div>
 
-            {/* Players */}
-            <div>
-              <p className="section-label">Players</p>
-              <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-                {players.map((name, idx) => (
-                  <div key={idx} style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+            {setupMode === "single" ? (
+              <>
+                {/* Playlist URL */}
+                <div>
+                  <p className="section-label">Spotify Playlist</p>
+                  <div style={{ position: "relative" }}>
                     <input
-                      type="text"
-                      className="player-input"
-                      placeholder={`Player ${idx + 1}`}
-                      value={name}
-                      onChange={(e) => updatePlayer(idx, e.target.value)}
-                      maxLength={24}
+                      ref={firstInputRef}
+                      type="url"
+                      className={`url-input${isValidSpotifyUrl ? " valid" : ""}`}
+                      placeholder="https://open.spotify.com/playlist/..."
+                      value={playlistUrl}
+                      onChange={(e) => setPlaylistUrl(e.target.value)}
+                      spellCheck={false}
                     />
-                    {players.length > 1 && (
-                      <button
-                        className="remove-btn"
-                        onClick={() => removePlayer(idx)}
-                        aria-label={`Remove player ${idx + 1}`}
+                    {isValidSpotifyUrl && (
+                      <span
+                        style={{
+                          position: "absolute",
+                          right: "14px",
+                          top: "50%",
+                          transform: "translateY(-50%)",
+                          color: "#1DB954",
+                        }}
                       >
-                        ×
-                      </button>
+                        <CheckIcon />
+                      </span>
                     )}
                   </div>
-                ))}
-                <button className="add-player-btn" onClick={addPlayer}>
-                  <span style={{ fontSize: "18px", lineHeight: 1, fontWeight: 300 }}>+</span>
-                  Add Player
-                </button>
-              </div>
-            </div>
+                  {isEditorial && (
+                    <p
+                      style={{
+                        marginTop: "8px",
+                        fontSize: "12px",
+                        color: "#f59e0b",
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "6px",
+                      }}
+                    >
+                      <span>⚠</span> Editorial playlists (Discover Weekly, etc.) may not work
+                    </p>
+                  )}
+                </div>
+
+                {/* Players */}
+                <div>
+                  <p className="section-label">Players</p>
+                  <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+                    {players.map((name, idx) => (
+                      <div key={idx} style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+                        <input
+                          type="text"
+                          className="player-input"
+                          placeholder={`Player ${idx + 1}`}
+                          value={name}
+                          onChange={(e) => updatePlayer(idx, e.target.value)}
+                          maxLength={24}
+                        />
+                        {players.length > 1 && (
+                          <button
+                            className="remove-btn"
+                            onClick={() => removePlayer(idx)}
+                            aria-label={`Remove player ${idx + 1}`}
+                          >
+                            ×
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                    <button className="add-player-btn" onClick={addPlayer}>
+                      <span style={{ fontSize: "18px", lineHeight: 1, fontWeight: 300 }}>+</span>
+                      Add Player
+                    </button>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <>
+                {/* Collection sub-mode */}
+                <div>
+                  <p className="section-label">How to Collect</p>
+                  <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+                    <button
+                      className={`pill${mixedSubMode === "room" ? " active" : ""}`}
+                      onClick={() => setMixedSubMode("room")}
+                    >
+                      QR Code
+                    </button>
+                    <button
+                      className={`pill${mixedSubMode === "phone" ? " active" : ""}`}
+                      onClick={() => setMixedSubMode("phone")}
+                    >
+                      Pass This Phone
+                    </button>
+                  </div>
+                </div>
+
+                {mixedSubMode === "phone" ? (
+                  <div>
+                    <p className="section-label">Collect Playlists</p>
+                    <MixedPlaylistCollector
+                      contributions={mixedContributions}
+                      onAdd={addMixedContribution}
+                      onRemove={removeMixedContribution}
+                    />
+                  </div>
+                ) : (
+                  <div>
+                    <p className="section-label">Room</p>
+                    {!roomCode ? (
+                      <div className="card" style={{ padding: "24px", textAlign: "center" }}>
+                        <p style={{ fontSize: "13px", color: "#777", marginBottom: "16px" }}>
+                          Generate a QR code — players scan it to add their own playlist from
+                          their own phone.
+                        </p>
+                        <button
+                          className="start-btn"
+                          onClick={handleCreateRoom}
+                          disabled={roomCreating}
+                        >
+                          {roomCreating ? "Creating Room..." : "Create Room"}
+                        </button>
+                        {roomError && (
+                          <p style={{ marginTop: "10px", fontSize: "12px", color: "#fca5a5" }}>
+                            {roomError}
+                          </p>
+                        )}
+                      </div>
+                    ) : (
+                      <div className="card" style={{ padding: "24px", textAlign: "center" }}>
+                        <p
+                          style={{
+                            fontFamily: "'Bebas Neue', sans-serif",
+                            fontSize: "36px",
+                            letterSpacing: "0.12em",
+                            color: "#1DB954",
+                            marginBottom: "12px",
+                          }}
+                        >
+                          {roomCode}
+                        </p>
+                        {qrDataUrl && (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={qrDataUrl}
+                            alt={`QR code to join room ${roomCode}`}
+                            style={{
+                              width: "180px",
+                              height: "180px",
+                              margin: "0 auto 12px",
+                              borderRadius: "8px",
+                            }}
+                          />
+                        )}
+                        <button
+                          className="add-player-btn"
+                          onClick={handleShareJoinLink}
+                          style={{ marginBottom: "14px" }}
+                        >
+                          {linkCopied ? "✓ Link copied" : "Share Join Link"}
+                        </button>
+                        <p style={{ fontSize: "12px", color: "#666", marginBottom: "14px" }}>
+                          Can&apos;t scan? Send that link instead — it&apos;s the same thing.
+                        </p>
+                        <p style={{ fontSize: "12px", color: "#666", marginBottom: "14px" }}>
+                          {roomSubmissions.length} player
+                          {roomSubmissions.length === 1 ? "" : "s"} joined
+                        </p>
+                        {roomSubmissions.length > 0 && (
+                          <div
+                            style={{
+                              display: "flex",
+                              flexDirection: "column",
+                              gap: "8px",
+                              textAlign: "left",
+                            }}
+                          >
+                            {roomSubmissions.map((s) => (
+                              <div
+                                key={s.playerName}
+                                style={{
+                                  display: "flex",
+                                  justifyContent: "space-between",
+                                  background: "#1a1a1a",
+                                  border: "1px solid #2a2a2a",
+                                  borderRadius: "8px",
+                                  padding: "10px 14px",
+                                  fontSize: "14px",
+                                }}
+                              >
+                                <span>{s.playerName}</span>
+                                <span style={{ color: "#666" }}>{s.trackCount} tracks</span>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                        {roomError && (
+                          <p style={{ marginTop: "12px", fontSize: "12px", color: "#fca5a5" }}>
+                            {roomError}
+                          </p>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Songs per Player */}
+                <div>
+                  <p className="section-label">Songs Per Player</p>
+                  <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+                    {MIXED_SAMPLE_COUNTS.map((c) => (
+                      <button
+                        key={c}
+                        className={`pill${sampledPerPlayer === c ? " active" : ""}`}
+                        onClick={() => setSampledPerPlayer(c)}
+                      >
+                        {c}
+                      </button>
+                    ))}
+                  </div>
+                  <p style={{ marginTop: "8px", fontSize: "12px", color: "#666" }}>
+                    Caps how many tracks each player&apos;s playlist contributes, after duplicates are merged.
+                  </p>
+                </div>
+              </>
+            )}
 
             {/* Clip Duration */}
             <div>
@@ -607,38 +1011,68 @@ export default function SetupPage() {
               </div>
             </div>
 
-            {/* Number of Songs */}
-            <div>
-              <p className="section-label">Number of Songs</p>
-              <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
-                {SONG_COUNTS.map((c) => (
-                  <button
-                    key={c}
-                    className={`pill${songCount === c ? " active" : ""}`}
-                    onClick={() => setSongCount(c)}
-                  >
-                    {c === "all" ? "All" : c}
-                  </button>
-                ))}
+            {/* Number of Songs — single-playlist mode only; mixed mode uses per-player sampling instead */}
+            {setupMode === "single" && (
+              <div>
+                <p className="section-label">Number of Songs</p>
+                <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+                  {SONG_COUNTS.map((c) => (
+                    <button
+                      key={c}
+                      className={`pill${songCount === c ? " active" : ""}`}
+                      onClick={() => setSongCount(c)}
+                    >
+                      {c === "all" ? "All" : c}
+                    </button>
+                  ))}
+                </div>
+                <p style={{ marginTop: "8px", fontSize: "12px", color: "#666" }}>
+                  How many tracks to play from the shuffled playlist.
+                </p>
               </div>
-              <p style={{ marginTop: "8px", fontSize: "12px", color: "#666" }}>
-                How many tracks to play from the shuffled playlist.
-              </p>
-            </div>
+            )}
 
             {/* Start Button */}
             <div>
-              <button className="start-btn" onClick={handleStart} disabled={loading}>
-                {loading ? (
-                  <>
-                    <span className="spinner" />
-                    Loading playlist
-                    <span className="dot-pulse" />
-                  </>
-                ) : (
-                  "Start Game →"
-                )}
-              </button>
+              {(() => {
+                const isMixedPhone = setupMode === "mixed" && mixedSubMode === "phone";
+                const isMixedRoom = setupMode === "mixed" && mixedSubMode === "room";
+                const phoneShort = MIXED_MIN_CONTRIBUTORS - mixedContributions.length;
+                const roomShort = MIXED_MIN_CONTRIBUTORS - roomSubmissions.length;
+                const busy = loading || roomStarting;
+                const disabled =
+                  busy ||
+                  (isMixedPhone && mixedContributions.length < MIXED_MIN_CONTRIBUTORS) ||
+                  (isMixedRoom && (!roomCode || roomSubmissions.length < MIXED_MIN_CONTRIBUTORS));
+                const onClick = setupMode === "single"
+                  ? handleStart
+                  : isMixedPhone
+                  ? handleMixedStart
+                  : handleRoomStart;
+
+                let label: ReactNode = "Start Game →";
+                if (busy) {
+                  label = (
+                    <>
+                      <span className="spinner" />
+                      Loading playlist
+                      <span className="dot-pulse" />
+                    </>
+                  );
+                } else if (isMixedPhone && phoneShort > 0) {
+                  label = `Add ${phoneShort} more player${phoneShort === 1 ? "" : "s"} to start`;
+                } else if (isMixedRoom && !roomCode) {
+                  label = "Create a room first";
+                } else if (isMixedRoom && roomShort > 0) {
+                  label = `Waiting for ${roomShort} more player${roomShort === 1 ? "" : "s"}`;
+                }
+
+                return (
+                  <button className="start-btn" onClick={onClick} disabled={disabled}>
+                    {label}
+                  </button>
+                );
+              })()}
 
               {error && (
                 <div

--- a/components/mixed-playlist-collector.tsx
+++ b/components/mixed-playlist-collector.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { ROOM_MAX_SUBMISSIONS } from "@/types/room";
+
+export interface MixedContribution {
+  name: string;
+  playlistUrl: string;
+}
+
+interface MixedPlaylistCollectorProps {
+  contributions: MixedContribution[];
+  onAdd: (contribution: MixedContribution) => void;
+  onRemove: (index: number) => void;
+}
+
+/**
+ * v0 pass-the-phone collector: each player takes the host's device, enters
+ * their name + playlist URL, and hands it to the next person. The
+ * "just added" screen masks the form between turns — reuses app/page.tsx's
+ * global .card/.pill/.player-input/.url-input/.start-btn styles rather than
+ * declaring its own, since it only ever renders inside that page.
+ */
+export function MixedPlaylistCollector({
+  contributions,
+  onAdd,
+  onRemove,
+}: MixedPlaylistCollectorProps) {
+  const [name, setName] = useState("");
+  const [playlistUrl, setPlaylistUrl] = useState("");
+  const [justAdded, setJustAdded] = useState<string | null>(null);
+
+  const isValidUrl =
+    playlistUrl.includes("spotify.com/playlist") || playlistUrl.includes("spotify:playlist:");
+  const trimmedName = name.trim();
+  const isDuplicateName = contributions.some(
+    (c) => c.name.toLowerCase() === trimmedName.toLowerCase()
+  );
+  const isFull = contributions.length >= ROOM_MAX_SUBMISSIONS;
+  const canAdd = trimmedName.length > 0 && isValidUrl && !isDuplicateName && !isFull;
+
+  function handleAdd() {
+    if (!canAdd) return;
+    onAdd({ name: trimmedName, playlistUrl: playlistUrl.trim() });
+    setJustAdded(trimmedName);
+    setName("");
+    setPlaylistUrl("");
+  }
+
+  let form: ReactNode;
+  if (isFull) {
+    form = (
+      <div className="card" style={{ padding: "28px", textAlign: "center" }}>
+        <p style={{ fontSize: "16px", color: "#1DB954", fontWeight: 600, marginBottom: "6px" }}>
+          {ROOM_MAX_SUBMISSIONS} players joined — that&apos;s the max
+        </p>
+        <p style={{ fontSize: "13px", color: "#777" }}>Remove someone below to add another.</p>
+      </div>
+    );
+  } else if (justAdded) {
+    form = (
+      <div className="card" style={{ padding: "28px", textAlign: "center" }}>
+        <p style={{ fontSize: "16px", color: "#1DB954", fontWeight: 600, marginBottom: "6px" }}>
+          ✓ {justAdded}&apos;s playlist is in
+        </p>
+        <p style={{ fontSize: "13px", color: "#777", marginBottom: "20px" }}>
+          Pass the phone to the next player
+        </p>
+        <button className="start-btn" onClick={() => setJustAdded(null)}>
+          Next Player →
+        </button>
+      </div>
+    );
+  } else {
+    form = (
+      <div className="card" style={{ padding: "24px", display: "flex", flexDirection: "column", gap: "16px" }}>
+        <div>
+          <p className="section-label">Your Name</p>
+          <input
+            type="text"
+            className="player-input"
+            placeholder="Player name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            maxLength={24}
+            style={{ width: "100%" }}
+          />
+          {isDuplicateName && (
+            <p style={{ fontSize: "12px", color: "#e85555", marginTop: "6px" }}>
+              That name already joined — pick a different one.
+            </p>
+          )}
+        </div>
+        <div>
+          <p className="section-label">Your Spotify Playlist</p>
+          <div style={{ position: "relative" }}>
+            <input
+              type="url"
+              className={`url-input${isValidUrl ? " valid" : ""}`}
+              placeholder="https://open.spotify.com/playlist/..."
+              value={playlistUrl}
+              onChange={(e) => setPlaylistUrl(e.target.value)}
+              spellCheck={false}
+            />
+          </div>
+        </div>
+        <button className="start-btn" onClick={handleAdd} disabled={!canAdd}>
+          Add &amp; Pass Phone →
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {form}
+
+      {contributions.length > 0 && (
+        <div style={{ marginTop: "14px" }}>
+          <p className="section-label">
+            {contributions.length} player{contributions.length === 1 ? "" : "s"} joined
+          </p>
+          <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+            {contributions.map((c, idx) => (
+              <div
+                key={idx}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  background: "#1a1a1a",
+                  border: "1px solid #2a2a2a",
+                  borderRadius: "8px",
+                  padding: "10px 14px",
+                }}
+              >
+                <span style={{ flex: 1, fontSize: "14px" }}>{c.name}</span>
+                <button
+                  className="remove-btn"
+                  onClick={() => onRemove(idx)}
+                  aria-label={`Remove ${c.name}`}
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -7,7 +7,7 @@
  * window.gtag is unavailable (GA not configured, ad blocker, etc.).
  */
 
-export type PlaylistSource = "own" | "builtin";
+export type PlaylistSource = "own" | "builtin" | "mixed";
 export type ShareType = "track" | "album" | "artist" | "unknown";
 
 declare global {
@@ -56,6 +56,27 @@ export type AnalyticsEvent =
         track_name?: string;
         artist?: string;
       };
+    }
+  | {
+      name: "mixed_pool_built";
+      params: {
+        contributor_count: number;
+        unique_tracks: number;
+        total_raw_tracks: number;
+        overlap_count: number;
+      };
+    }
+  | {
+      name: "room_created";
+      params: Record<string, never>;
+    }
+  | {
+      name: "room_submission_received";
+      params: { total: number };
+    }
+  | {
+      name: "room_started";
+      params: { contributor_count: number; unique_tracks: number };
     }
   | {
       name: "pwa_install_prompt";

--- a/lib/game-session.ts
+++ b/lib/game-session.ts
@@ -6,6 +6,7 @@
 
 import type { Track } from "@/types";
 import type { PlaylistSource } from "@/lib/analytics";
+import { DEFAULT_SAMPLED_PER_PLAYER } from "@/types/room";
 
 export const GAME_STORAGE_KEY = "guesssong_game";
 
@@ -16,6 +17,12 @@ export interface GamePlayer {
   score: number;
 }
 
+/** Mixed Playlist Mode metadata — how the pool was assembled. */
+export interface MixedPlaylistMeta {
+  contributorNames: string[];
+  sampledPerPlayer: number;
+}
+
 export interface GamePayload {
   tracks: Track[];
   players: GamePlayer[];
@@ -24,6 +31,13 @@ export interface GamePayload {
   totalTracks: number;
   playlistSource: PlaylistSource;
   mode: GameMode;
+  mixedPlaylistMeta?: MixedPlaylistMeta;
+}
+
+const PLAYLIST_SOURCES: PlaylistSource[] = ["own", "builtin", "mixed"];
+
+function isPlaylistSource(value: unknown): value is PlaylistSource {
+  return typeof value === "string" && (PLAYLIST_SOURCES as string[]).includes(value);
 }
 
 /**
@@ -44,6 +58,7 @@ export interface BuildGamePayloadInput {
   totalTracks?: number;
   playlistSource: PlaylistSource;
   mode: GameMode;
+  mixedPlaylistMeta?: MixedPlaylistMeta;
 }
 
 export function buildGamePayload(input: BuildGamePayloadInput): GamePayload {
@@ -55,6 +70,7 @@ export function buildGamePayload(input: BuildGamePayloadInput): GamePayload {
     totalTracks: input.totalTracks ?? input.tracks.length,
     playlistSource: input.playlistSource,
     mode: input.mode,
+    ...(input.mixedPlaylistMeta ? { mixedPlaylistMeta: input.mixedPlaylistMeta } : {}),
   };
 }
 
@@ -87,13 +103,26 @@ export function parseGamePayload(raw: string): GamePayload | null {
   const tracks = Array.isArray(d.tracks) ? (d.tracks as Track[]) : [];
   const players = Array.isArray(d.players) ? (d.players as GamePlayer[]) : [];
 
+  const rawMeta = d.mixedPlaylistMeta as Record<string, unknown> | undefined;
+  const mixedPlaylistMeta: MixedPlaylistMeta | undefined =
+    rawMeta && typeof rawMeta === "object" && Array.isArray(rawMeta.contributorNames)
+      ? {
+          contributorNames: rawMeta.contributorNames as string[],
+          sampledPerPlayer:
+            typeof rawMeta.sampledPerPlayer === "number"
+              ? rawMeta.sampledPerPlayer
+              : DEFAULT_SAMPLED_PER_PLAYER,
+        }
+      : undefined;
+
   return {
     tracks,
     players,
     playlistName: typeof d.playlistName === "string" ? d.playlistName : "",
     clipDuration: typeof d.clipDuration === "number" ? d.clipDuration : 15,
     totalTracks: typeof d.totalTracks === "number" ? d.totalTracks : tracks.length,
-    playlistSource: d.playlistSource === "builtin" ? "builtin" : "own",
+    playlistSource: isPlaylistSource(d.playlistSource) ? d.playlistSource : "own",
     mode: d.mode === "trial" ? "trial" : "party",
+    ...(mixedPlaylistMeta ? { mixedPlaylistMeta } : {}),
   };
 }

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -1,0 +1,114 @@
+/**
+ * Minimal KV abstraction for Mixed Playlist Mode's room store. Uses Upstash
+ * Redis (via UPSTASH_REDIS_REST_URL/TOKEN) when configured; otherwise falls
+ * back to an in-process Map so local dev and tests don't need a real Redis
+ * instance. The in-memory fallback only survives within a single Node
+ * process — fine for `next dev`/`next start`, but NOT safe for multi-instance
+ * serverless deploys, which is why production must set the Upstash env vars.
+ */
+
+export interface KvStore {
+  get<T>(key: string): Promise<T | null>;
+  set(key: string, value: unknown, ttlSeconds: number): Promise<void>;
+  del(key: string): Promise<void>;
+  /**
+   * Atomically increments a counter and (re)starts its TTL on the first
+   * increment of a window. Used for rate limiting, where a get-then-set
+   * pair would race under concurrent requests.
+   */
+  incr(key: string, ttlSeconds: number): Promise<number>;
+}
+
+type MemoryEntry = { value: unknown; expiresAt: number };
+
+declare global {
+  // eslint-disable-next-line no-var -- global singleton, see getMemoryMap below
+  var __guesssongKvMemoryStore: Map<string, MemoryEntry> | undefined;
+}
+
+/**
+ * Next.js dev mode compiles each API route file as a separate on-demand
+ * bundle — a plain module-scope `Map` ends up as a distinct instance per
+ * route the first time it's compiled, so a room created via POST /api/room
+ * would be invisible to GET /api/room/[code]/status. Stashing the Map on
+ * `globalThis` (the real, single Node.js global) sidesteps that, the same
+ * way Prisma's dev-mode client singleton does.
+ */
+function getMemoryMap(): Map<string, MemoryEntry> {
+  if (!globalThis.__guesssongKvMemoryStore) {
+    globalThis.__guesssongKvMemoryStore = new Map();
+  }
+  return globalThis.__guesssongKvMemoryStore;
+}
+
+function createMemoryStore(): KvStore {
+  return {
+    async get<T>(key: string) {
+      const store = getMemoryMap();
+      const entry = store.get(key);
+      if (!entry) return null;
+      if (Date.now() > entry.expiresAt) {
+        store.delete(key);
+        return null;
+      }
+      return entry.value as T;
+    },
+    async set(key, value, ttlSeconds) {
+      getMemoryMap().set(key, { value, expiresAt: Date.now() + ttlSeconds * 1000 });
+    },
+    async del(key) {
+      getMemoryMap().delete(key);
+    },
+    async incr(key, ttlSeconds) {
+      const store = getMemoryMap();
+      const entry = store.get(key);
+      const now = Date.now();
+      if (!entry || now > entry.expiresAt) {
+        store.set(key, { value: 1, expiresAt: now + ttlSeconds * 1000 });
+        return 1;
+      }
+      const next = (entry.value as number) + 1;
+      store.set(key, { value: next, expiresAt: entry.expiresAt });
+      return next;
+    },
+  };
+}
+
+function hasUpstashEnv(): boolean {
+  return Boolean(process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN);
+}
+
+let upstashStore: KvStore | null = null;
+
+async function getUpstashStore(): Promise<KvStore> {
+  if (!upstashStore) {
+    const { Redis } = await import("@upstash/redis");
+    const redis = Redis.fromEnv();
+    upstashStore = {
+      async get<T>(key: string) {
+        return (await redis.get<T>(key)) ?? null;
+      },
+      async set(key, value, ttlSeconds) {
+        await redis.set(key, value, { ex: ttlSeconds });
+      },
+      async del(key) {
+        await redis.del(key);
+      },
+      async incr(key, ttlSeconds) {
+        const count = await redis.incr(key);
+        // Only the request that started this window sets its expiry, so
+        // later increments don't keep pushing the TTL back.
+        if (count === 1) await redis.expire(key, ttlSeconds);
+        return count;
+      },
+    };
+  }
+  return upstashStore;
+}
+
+const memoryStore = createMemoryStore();
+
+/** Returns the Upstash-backed store when configured, else the in-memory fallback. */
+export async function getKvStore(): Promise<KvStore> {
+  return hasUpstashEnv() ? getUpstashStore() : memoryStore;
+}

--- a/lib/mixed-playlist.ts
+++ b/lib/mixed-playlist.ts
@@ -1,0 +1,93 @@
+/**
+ * Mixed Playlist Mode pooling logic — dedupe multiple players' playlists into
+ * one pool with provenance, then fair-sample per contributor.
+ *
+ * Pure functions, no browser/server APIs, so they're unit-testable and
+ * reusable server-side (v1's /api/room/:code/pool route) without change.
+ */
+
+import type { Track } from "@/types";
+
+export interface PlaylistContribution {
+  playerName: string;
+  tracks: Track[];
+}
+
+export interface PooledTrack extends Track {
+  contributors: string[];
+}
+
+/**
+ * Normalize a track's name + primary artist into a cross-platform dedupe
+ * key. Strips remaster/live/feat. suffixes and punctuation/casing noise so
+ * the same song contributed from different playlists (or platforms, once
+ * non-Spotify sources exist) collapses to a single pooled track. This is a
+ * best-effort fingerprint, not exact matching — occasional over/under-merge
+ * is an accepted tradeoff for a "delight, not precision" feature.
+ */
+export function fingerprint(name: string, artists: string[]): string {
+  const normalize = (s: string) =>
+    s
+      .toLowerCase()
+      .replace(/[([]feat\.?[^)\]]*[)\]]/g, "")
+      .replace(/[-([].*?(remaster(ed)?|live|version|edit|mix|mono|stereo|deluxe)[^)\]]*[)\]]?/gi, "")
+      .replace(/[^a-z0-9]+/g, " ")
+      .trim();
+
+  const primaryArtist = artists[0] ?? "";
+  return `${normalize(name)}::${normalize(primaryArtist)}`;
+}
+
+function shuffle<T>(items: T[]): T[] {
+  const copy = [...items];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+/**
+ * Dedupe every contributor's tracks into one pool, merging `contributors`
+ * on shared tracks, then sample up to `sampledPerPlayer` tracks per
+ * contributor (a shared track counts against every one of its contributors'
+ * quotas — a track is only included once none of its contributors have hit
+ * their cap), and shuffle the final pool.
+ */
+export function poolContributions(
+  contributions: PlaylistContribution[],
+  sampledPerPlayer: number
+): PooledTrack[] {
+  const byFingerprint = new Map<string, PooledTrack>();
+
+  for (const { playerName, tracks } of contributions) {
+    for (const track of tracks) {
+      const fp = fingerprint(track.name, track.artists);
+      const existing = byFingerprint.get(fp);
+      if (existing) {
+        if (!existing.contributors.includes(playerName)) {
+          existing.contributors.push(playerName);
+        }
+      } else {
+        byFingerprint.set(fp, { ...track, contributors: [playerName] });
+      }
+    }
+  }
+
+  const shuffledPool = shuffle(Array.from(byFingerprint.values()));
+  const quota = new Map<string, number>();
+  const sampled: PooledTrack[] = [];
+
+  for (const track of shuffledPool) {
+    const hasRoom = track.contributors.every(
+      (name) => (quota.get(name) ?? 0) < sampledPerPlayer
+    );
+    if (!hasRoom) continue;
+    for (const name of track.contributors) {
+      quota.set(name, (quota.get(name) ?? 0) + 1);
+    }
+    sampled.push(track);
+  }
+
+  return shuffle(sampled);
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,31 @@
+/**
+ * Fixed-window rate limiting on top of lib/kv.ts's atomic incr. Not exact
+ * (a client can burst up to 2x limit across a window boundary) but cheap
+ * and good enough to blunt code-guessing/spam against the room endpoints —
+ * see lib/room.ts's 4-char code space.
+ */
+
+import { getKvStore } from "@/lib/kv";
+import type { NextRequest } from "next/server";
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+}
+
+export async function rateLimit(
+  identifier: string,
+  limit: number,
+  windowSeconds: number
+): Promise<RateLimitResult> {
+  const store = await getKvStore();
+  const count = await store.incr(`ratelimit:${identifier}`, windowSeconds);
+  return { allowed: count <= limit, remaining: Math.max(0, limit - count) };
+}
+
+/** Best-effort client IP from proxy headers; falls back to a shared bucket. */
+export function getClientIp(req: NextRequest): string {
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) return forwarded.split(",")[0].trim();
+  return req.headers.get("x-real-ip") ?? "unknown";
+}

--- a/lib/result-image.ts
+++ b/lib/result-image.ts
@@ -1,0 +1,130 @@
+/**
+ * Shared canvas helpers for GuessSong's downloadable result images (score
+ * card, taste card). Centralizes the DPR-aware canvas setup, header/footer
+ * chrome, and the share-sheet-or-download save flow so each card only needs
+ * to draw its own content rows.
+ */
+
+export interface ResultCanvas {
+  canvas: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+}
+
+export function createResultCanvas(width: number, height: number): ResultCanvas {
+  const canvas = document.createElement("canvas");
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = width * dpr;
+  canvas.height = height * dpr;
+  canvas.style.width = width + "px";
+  canvas.style.height = height + "px";
+  const ctx = canvas.getContext("2d")!;
+  ctx.scale(dpr, dpr);
+  return { canvas, ctx };
+}
+
+export function drawCardBackground(ctx: CanvasRenderingContext2D, width: number, height: number) {
+  ctx.fillStyle = "#111111";
+  ctx.fillRect(0, 0, width, height);
+
+  const accent = ctx.createLinearGradient(0, 0, width, 0);
+  accent.addColorStop(0, "#1DB954");
+  accent.addColorStop(1, "#0a8f3c");
+  ctx.fillStyle = accent;
+  ctx.fillRect(0, 0, width, 4);
+}
+
+export interface HeaderOptions {
+  width: number;
+  kicker: string;
+  title: string;
+  subtitle?: string;
+}
+
+/** Draws kicker/title/subtitle + divider, returns the y just below the divider. */
+export function drawCardHeader(ctx: CanvasRenderingContext2D, opts: HeaderOptions): number {
+  const { width, kicker, title, subtitle } = opts;
+
+  ctx.fillStyle = "#1DB954";
+  ctx.font = "bold 13px sans-serif";
+  ctx.letterSpacing = "2px";
+  ctx.fillText(kicker, 40, 48);
+
+  ctx.fillStyle = "#ffffff";
+  ctx.font = "bold 48px sans-serif";
+  ctx.letterSpacing = "1px";
+  ctx.fillText(title, 40, 100);
+
+  if (subtitle) {
+    ctx.fillStyle = "#666666";
+    ctx.font = "15px sans-serif";
+    ctx.letterSpacing = "0px";
+    const text = subtitle.length > 50 ? subtitle.slice(0, 50) + "…" : subtitle;
+    ctx.fillText(text, 40, 130);
+  }
+
+  ctx.strokeStyle = "#222222";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(40, 155);
+  ctx.lineTo(width - 40, 155);
+  ctx.stroke();
+
+  return 155;
+}
+
+/** Draws the footer divider + credit line at the given y. */
+export function drawCardFooter(ctx: CanvasRenderingContext2D, width: number, y: number) {
+  ctx.strokeStyle = "#222";
+  ctx.beginPath();
+  ctx.moveTo(40, y);
+  ctx.lineTo(width - 40, y);
+  ctx.stroke();
+  ctx.font = "12px sans-serif";
+  ctx.fillStyle = "#444";
+  ctx.fillText("Played with GuessSong", 40, y + 30);
+}
+
+/**
+ * Save: prefer the share sheet with an image file — on Android/iOS that
+ * offers "Save to Photos", and data-URL anchor downloads are unreliable
+ * inside installed PWAs (WebAPK). Fallback: blob URL download.
+ */
+export function shareOrDownloadCanvas(
+  canvas: HTMLCanvasElement,
+  filename: string,
+  shareTitle: string
+): Promise<void> {
+  return new Promise((resolve) => {
+    canvas.toBlob(async (blob) => {
+      if (!blob) {
+        resolve();
+        return;
+      }
+      const file = new File([blob], filename, { type: "image/png" });
+
+      if (typeof navigator.canShare === "function" && navigator.canShare({ files: [file] })) {
+        try {
+          await navigator.share({ files: [file], title: shareTitle });
+          resolve();
+          return;
+        } catch (e) {
+          // User closed the share sheet — not an error, don't force a download.
+          if (e instanceof DOMException && e.name === "AbortError") {
+            resolve();
+            return;
+          }
+        }
+      }
+
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.download = file.name;
+      link.href = url;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 10_000);
+      resolve();
+    }, "image/png");
+  });
+}

--- a/lib/room.ts
+++ b/lib/room.ts
@@ -1,0 +1,251 @@
+/**
+ * Server-only room mailbox for Mixed Playlist Mode's QR submission flow (v1).
+ * A room is a one-shot TTL'd inbox: players submit playlist URLs, the host
+ * polls status, then pulls+consumes the pool once. No realtime sync needed —
+ * polling is spec-approved (§4.2), so this stays on top of lib/kv.ts's KV
+ * abstraction rather than a WebSocket room.
+ */
+
+import { randomUUID, timingSafeEqual } from "node:crypto";
+import { getPlaylistWithTracks } from "@/lib/spotify";
+import { poolContributions } from "@/lib/mixed-playlist";
+import { getKvStore } from "@/lib/kv";
+import { stripTrackForStorage } from "@/lib/game-session";
+import type { Track } from "@/types";
+import {
+  ROOM_CODE_LENGTH,
+  ROOM_TTL_SECONDS,
+  ROOM_MAX_SUBMISSIONS,
+  type RoomStatusResponse,
+  type RoomPoolResponse,
+} from "@/types/room";
+
+// Excludes visually-confusable characters (0/O, 1/I/L) per spec §4.2.
+const ROOM_CODE_ALPHABET = "23456789ABCDEFGHJKMNPQRSTUVWXYZ";
+
+// submitToRoom/consumeRoomPool retry on a lost write race (see below) instead
+// of overwriting blind — this bounds how many times they'll retry before
+// giving up and telling the client to try again.
+const MAX_WRITE_ATTEMPTS = 5;
+
+interface RoomSubmission {
+  playerName: string;
+  tracks: Track[];
+}
+
+interface RoomRecord {
+  code: string;
+  hostToken: string;
+  createdAt: number;
+  expiresAt: number;
+  consumed: boolean;
+  /** Set only on the write that wins the consume race — see consumeRoomPool. */
+  consumedBy?: string;
+  submissions: RoomSubmission[];
+}
+
+export class RoomError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
+}
+
+function roomKey(code: string): string {
+  return `room:${code.toUpperCase()}`;
+}
+
+function generateRoomCode(): string {
+  let code = "";
+  for (let i = 0; i < ROOM_CODE_LENGTH; i++) {
+    code += ROOM_CODE_ALPHABET[Math.floor(Math.random() * ROOM_CODE_ALPHABET.length)];
+  }
+  return code;
+}
+
+function remainingTtlSeconds(record: RoomRecord): number {
+  return Math.max(1, Math.round((record.expiresAt - Date.now()) / 1000));
+}
+
+export async function createRoom(): Promise<{
+  roomCode: string;
+  expiresAt: number;
+  hostToken: string;
+}> {
+  const store = await getKvStore();
+  // Small retry loop for the unlikely event of a code collision.
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const code = generateRoomCode();
+    const existing = await store.get<RoomRecord>(roomKey(code));
+    if (existing) continue;
+
+    const now = Date.now();
+    const hostToken = randomUUID();
+    const record: RoomRecord = {
+      code,
+      hostToken,
+      createdAt: now,
+      expiresAt: now + ROOM_TTL_SECONDS * 1000,
+      consumed: false,
+      submissions: [],
+    };
+    await store.set(roomKey(code), record, ROOM_TTL_SECONDS);
+    return { roomCode: code, expiresAt: record.expiresAt, hostToken };
+  }
+  throw new RoomError("Could not allocate a room code, please try again", 500);
+}
+
+async function requireOpenRoom(code: string) {
+  const store = await getKvStore();
+  const record = await store.get<RoomRecord>(roomKey(code));
+  if (!record) throw new RoomError("Room not found or expired", 404);
+  if (record.consumed) throw new RoomError("This room has already started", 410);
+  return { store, record };
+}
+
+/**
+ * submitToRoom and consumeRoomPool both read-modify-write the whole room
+ * record — there's no CAS primitive on lib/kv.ts's get/set. Two requests
+ * landing close together (the common case for a QR-code room: a group
+ * scanning and submitting within the same few seconds) can otherwise race:
+ * both read the same base record, both write, and the loser's change is
+ * silently dropped. Guard against that by re-reading the record immediately
+ * before every write and verifying afterward that our own change actually
+ * persisted; if a concurrent writer clobbered us, retry against the fresh
+ * state instead of failing (or worse, succeeding) silently.
+ */
+export async function submitToRoom(
+  code: string,
+  playerName: string,
+  playlistUrl: string
+): Promise<{ trackCount: number }> {
+  // Validate the room is currently open before doing the slow network work
+  // below, so a request against a dead room fails fast.
+  await requireOpenRoom(code);
+
+  const trimmedName = playerName.trim();
+  if (!trimmedName) throw new RoomError("Name is required", 422);
+
+  let tracks: Track[];
+  try {
+    ({ tracks } = await getPlaylistWithTracks(playlistUrl));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to load playlist";
+    throw new RoomError(message, 422);
+  }
+  if (tracks.length < 1) {
+    throw new RoomError("This playlist has no tracks", 422);
+  }
+  const strippedTracks = tracks.map(stripTrackForStorage);
+
+  const store = await getKvStore();
+  for (let attempt = 0; attempt < MAX_WRITE_ATTEMPTS; attempt++) {
+    const fresh = await store.get<RoomRecord>(roomKey(code));
+    if (!fresh) throw new RoomError("Room not found or expired", 404);
+    if (fresh.consumed) throw new RoomError("This room has already started", 410);
+    if (
+      fresh.submissions.some(
+        (s) => s.playerName.toLowerCase() === trimmedName.toLowerCase()
+      )
+    ) {
+      throw new RoomError("That name is already taken in this room", 409);
+    }
+    if (fresh.submissions.length >= ROOM_MAX_SUBMISSIONS) {
+      throw new RoomError("This room is full", 409);
+    }
+
+    const updated: RoomRecord = {
+      ...fresh,
+      submissions: [...fresh.submissions, { playerName: trimmedName, tracks: strippedTracks }],
+    };
+    await store.set(roomKey(code), updated, remainingTtlSeconds(updated));
+
+    // Did our write survive, or did a concurrent submitToRoom overwrite it
+    // with a copy that doesn't include us? Check for our own entry rather
+    // than trusting the write call succeeded.
+    const verify = await store.get<RoomRecord>(roomKey(code));
+    const persisted = verify?.submissions.some(
+      (s) => s.playerName.toLowerCase() === trimmedName.toLowerCase()
+    );
+    if (persisted) {
+      return { trackCount: tracks.length };
+    }
+    // Lost the race — retry against whatever the winner left behind.
+  }
+  throw new RoomError("Room is busy, please try again", 409);
+}
+
+export async function getRoomStatus(code: string): Promise<RoomStatusResponse> {
+  const store = await getKvStore();
+  const record = await store.get<RoomRecord>(roomKey(code));
+  if (!record) throw new RoomError("Room not found or expired", 404);
+
+  return {
+    submissions: record.submissions.map((s) => ({
+      playerName: s.playerName,
+      trackCount: s.tracks.length,
+    })),
+    total: record.submissions.length,
+    expiresAt: record.expiresAt,
+  };
+}
+
+export async function consumeRoomPool(
+  code: string,
+  sampledPerPlayer: number,
+  hostToken: string
+): Promise<RoomPoolResponse> {
+  const store = await getKvStore();
+  // Unique per call, not per room: identifies which of two concurrent
+  // consumeRoomPool attempts (e.g. a double-tapped Start button) actually
+  // won the write race, so the loser gets a clean 410 instead of a second,
+  // differently-shuffled pool.
+  const attemptId = randomUUID();
+
+  for (let attempt = 0; attempt < MAX_WRITE_ATTEMPTS; attempt++) {
+    const fresh = await store.get<RoomRecord>(roomKey(code));
+    if (!fresh) throw new RoomError("Room not found or expired", 404);
+    if (fresh.consumed) throw new RoomError("This room has already started", 410);
+    if (!timingSafeEqualStrings(fresh.hostToken, hostToken)) {
+      throw new RoomError("Only the room's host can start the game", 403);
+    }
+    if (fresh.submissions.length < 1) {
+      throw new RoomError("No submissions yet", 422);
+    }
+
+    const tracks = poolContributions(
+      fresh.submissions.map((s) => ({ playerName: s.playerName, tracks: s.tracks })),
+      sampledPerPlayer
+    );
+
+    const updated: RoomRecord = { ...fresh, consumed: true, consumedBy: attemptId };
+    await store.set(roomKey(code), updated, remainingTtlSeconds(updated));
+
+    const verify = await store.get<RoomRecord>(roomKey(code));
+    if (verify?.consumedBy === attemptId) {
+      return {
+        tracks,
+        players: fresh.submissions.map((s) => s.playerName),
+        sampledPerPlayer,
+      };
+    }
+    // A concurrent consumeRoomPool call won — this room is now consumed by
+    // them, so re-reading will hit the `fresh.consumed` guard above and
+    // throw 410 on the next iteration.
+  }
+  throw new RoomError("Room is busy, please try again", 409);
+}
+
+/** Constant-time comparison so wrong host-token guesses can't be timed. */
+function timingSafeEqualStrings(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    // Compare against a same-length buffer anyway so the failure path takes
+    // roughly the same time as a length-matched mismatch.
+    timingSafeEqual(bufA, Buffer.alloc(bufA.length));
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}

--- a/lib/round-history.ts
+++ b/lib/round-history.ts
@@ -1,0 +1,13 @@
+/**
+ * Per-round scoring record for Mixed Playlist Mode, kept only for tracks
+ * that have `contributors` (i.e. mixed-mode rounds). Not consumed yet —
+ * seeded in v1.5 so v2's group taste card can compute its awards without
+ * re-deriving history that's otherwise lost the moment a round resets.
+ */
+export interface RoundHistoryEntry {
+  trackId: string;
+  contributors: string[];
+  songWinner: string | null;
+  albumWinner: string | null;
+  sourceWinner: string | null;
+}

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -40,6 +40,7 @@ export interface SpotifyTrack {
   artists: Array<{ name: string }>;
   duration_ms: number;
   preview_url: string | null; // 30-second preview URL
+  popularity?: number; // 0-100, used by the Mixed Playlist Mode taste card
   album: {
     name: string;
     images: Array<{ url: string }>;
@@ -175,6 +176,7 @@ export function convertSpotifyTrack(spotifyTrack: SpotifyTrack): Track {
     albumName: spotifyTrack.album.name,
     albumImageUrl: spotifyTrack.album.images[0]?.url,
     previewUrl: spotifyTrack.preview_url || null, // Store preview URL
+    popularity: spotifyTrack.popularity,
     rawJson: spotifyTrack as unknown as Record<string, unknown>,
     createdAt: new Date().toISOString(),
   };

--- a/lib/taste-card.ts
+++ b/lib/taste-card.ts
@@ -1,0 +1,111 @@
+/**
+ * Mixed Playlist Mode group taste card (v2) — pure functions computing
+ * awards from the pooled tracks + round history. Spec §7 lists four awards;
+ * "most often mistaken for someone else" is dropped from this cut because
+ * the host-judged scoring UI (v1.5) only records whether a source guess was
+ * *correct*, never who was guessed instead when it was wrong — there's no
+ * data to compute it from without adding a new host input step.
+ */
+
+import type { Track } from "@/types";
+import type { RoundHistoryEntry } from "@/lib/round-history";
+
+export interface SharedTrack {
+  trackId: string;
+  name: string;
+  artists: string[];
+  contributors: string[];
+}
+
+export interface ObscureAward {
+  playerName: string;
+  correctAttributions: number;
+  totalTracks: number;
+  /** 0-1, lower = more obscure (fewer correct source guesses). */
+  rate: number;
+}
+
+export interface MainstreamAward {
+  playerName: string;
+  averagePopularity: number;
+}
+
+export interface TasteCard {
+  /** Tracks that showed up in more than one player's playlist. */
+  sharedTracks: SharedTrack[];
+  /** Whose tracks were least often correctly attributed back to them. */
+  mostObscure: ObscureAward | null;
+  /** Whose contributed tracks have the highest average Spotify popularity. */
+  mostMainstream: MainstreamAward | null;
+}
+
+export function findSharedTracks(tracks: Track[]): SharedTrack[] {
+  return tracks
+    .filter((t) => t.contributors && t.contributors.length > 1)
+    .map((t) => ({
+      trackId: t.id,
+      name: t.name,
+      artists: t.artists,
+      contributors: t.contributors as string[],
+    }));
+}
+
+export function computeMostObscure(history: RoundHistoryEntry[]): ObscureAward | null {
+  const totals = new Map<string, number>();
+  const correct = new Map<string, number>();
+
+  for (const entry of history) {
+    // A correct source guess only tells us *someone* named the right
+    // playlist — the game doesn't record which contributor's name was
+    // actually said. For a track shared by multiple contributors that's
+    // ambiguous (crediting all of them would inflate everyone's rate), so
+    // only single-contributor tracks count toward this stat.
+    if (entry.contributors.length !== 1) continue;
+    const [contributor] = entry.contributors;
+    totals.set(contributor, (totals.get(contributor) ?? 0) + 1);
+    if (entry.sourceWinner !== null) {
+      correct.set(contributor, (correct.get(contributor) ?? 0) + 1);
+    }
+  }
+
+  let best: ObscureAward | null = null;
+  for (const [playerName, totalTracks] of totals) {
+    const correctAttributions = correct.get(playerName) ?? 0;
+    const rate = correctAttributions / totalTracks;
+    if (!best || rate < best.rate) {
+      best = { playerName, correctAttributions, totalTracks, rate };
+    }
+  }
+  return best;
+}
+
+export function computeMostMainstream(tracks: Track[]): MainstreamAward | null {
+  const totals = new Map<string, { sum: number; count: number }>();
+
+  for (const track of tracks) {
+    if (typeof track.popularity !== "number" || !track.contributors) continue;
+    for (const contributor of track.contributors) {
+      const agg = totals.get(contributor) ?? { sum: 0, count: 0 };
+      agg.sum += track.popularity;
+      agg.count += 1;
+      totals.set(contributor, agg);
+    }
+  }
+
+  let best: MainstreamAward | null = null;
+  for (const [playerName, { sum, count }] of totals) {
+    const averagePopularity = sum / count;
+    if (!best || averagePopularity > best.averagePopularity) {
+      best = { playerName, averagePopularity };
+    }
+  }
+  return best;
+}
+
+export function buildTasteCard(tracks: Track[], history: RoundHistoryEntry[]): TasteCard {
+  return {
+    sharedTracks: findSharedTracks(tracks),
+    mostObscure: computeMostObscure(history),
+    mostMainstream: computeMostMainstream(tracks),
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
   "name": "spotify-guess-web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spotify-guess-web",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@upstash/redis": "^1.38.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.0",
         "next": "^15.0.0",
+        "qrcode": "^1.5.4",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "tailwind-merge": "^2.2.0",
@@ -22,6 +24,7 @@
       "devDependencies": {
         "@next/env": "^16.0.3",
         "@types/node": "^20.10.0",
+        "@types/qrcode": "^1.5.6",
         "@types/react": "^18.2.42",
         "@types/react-dom": "^18.2.17",
         "autoprefixer": "^10.4.16",
@@ -1641,6 +1644,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "18.3.26",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
@@ -2238,6 +2251,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.8",
@@ -2877,6 +2899,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -2986,6 +3017,51 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -3177,6 +3253,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -3242,6 +3327,12 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -4223,6 +4314,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -6006,6 +6106,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -6042,7 +6151,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6136,6 +6244,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -6336,6 +6453,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6453,6 +6587,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6462,6 +6605,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -6676,6 +6825,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -7708,6 +7863,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
     "node_modules/undici": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
@@ -8131,6 +8292,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
@@ -8297,6 +8464,119 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify-guess-web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 8000",
@@ -12,9 +12,11 @@
   "dependencies": {
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@upstash/redis": "^1.38.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.0",
     "next": "^15.0.0",
+    "qrcode": "^1.5.4",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "tailwind-merge": "^2.2.0",
@@ -24,6 +26,7 @@
   "devDependencies": {
     "@next/env": "^16.0.3",
     "@types/node": "^20.10.0",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^18.2.42",
     "@types/react-dom": "^18.2.17",
     "autoprefixer": "^10.4.16",

--- a/tests/game-session.test.ts
+++ b/tests/game-session.test.ts
@@ -97,6 +97,42 @@ describe("buildGamePayload", () => {
     const parsed = parseGamePayload(JSON.stringify(payload));
     expect(parsed).toEqual(payload);
   });
+
+  it("builds a mixed/party payload carrying mixedPlaylistMeta", () => {
+    const payload = buildGamePayload({
+      tracks: [makeTrack({ id: "a", contributors: ["Alice", "Bob"] })],
+      players: [
+        { name: "Alice", score: 0 },
+        { name: "Bob", score: 0 },
+      ],
+      playlistName: "2-Player Mix",
+      clipDuration: 10,
+      playlistSource: "mixed",
+      mode: "party",
+      mixedPlaylistMeta: { contributorNames: ["Alice", "Bob"], sampledPerPlayer: 8 },
+    });
+
+    expect(payload.playlistSource).toBe("mixed");
+    expect(payload.mixedPlaylistMeta).toEqual({
+      contributorNames: ["Alice", "Bob"],
+      sampledPerPlayer: 8,
+    });
+    expect(payload.tracks[0].contributors).toEqual(["Alice", "Bob"]);
+  });
+
+  it("round-trips mixedPlaylistMeta through JSON + parseGamePayload", () => {
+    const payload = buildGamePayload({
+      tracks: [makeTrack({ contributors: ["Alice"] })],
+      players: [{ name: "Alice", score: 0 }],
+      playlistName: "1-Player Mix",
+      clipDuration: 10,
+      playlistSource: "mixed",
+      mode: "party",
+      mixedPlaylistMeta: { contributorNames: ["Alice"], sampledPerPlayer: 8 },
+    });
+    const parsed = parseGamePayload(JSON.stringify(payload));
+    expect(parsed).toEqual(payload);
+  });
 });
 
 describe("parseGamePayload", () => {
@@ -136,6 +172,11 @@ describe("parseGamePayload", () => {
     );
     expect(parsed!.playlistSource).toBe("builtin");
     expect(parsed!.mode).toBe("trial");
+  });
+
+  it("parses explicit mixed playlistSource", () => {
+    const parsed = parseGamePayload(JSON.stringify({ tracks: [], playlistSource: "mixed" }));
+    expect(parsed!.playlistSource).toBe("mixed");
   });
 
   it("falls back to defaults for unknown enum values", () => {

--- a/tests/kv.test.ts
+++ b/tests/kv.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { getKvStore } from "@/lib/kv";
+
+const redisMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+  incr: vi.fn(),
+  expire: vi.fn(),
+}));
+
+vi.mock("@upstash/redis", () => ({
+  Redis: { fromEnv: () => redisMock },
+}));
+
+describe("getKvStore (in-memory fallback)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("round-trips a value through get/set", async () => {
+    const store = await getKvStore();
+    await store.set("k1", { hello: "world" }, 60);
+    expect(await store.get("k1")).toEqual({ hello: "world" });
+  });
+
+  it("returns null for a key that was never set", async () => {
+    const store = await getKvStore();
+    expect(await store.get("does-not-exist")).toBeNull();
+  });
+
+  it("deletes a key", async () => {
+    const store = await getKvStore();
+    await store.set("k2", "value", 60);
+    await store.del("k2");
+    expect(await store.get("k2")).toBeNull();
+  });
+
+  it("expires a key once its TTL has elapsed", async () => {
+    vi.useFakeTimers();
+    const store = await getKvStore();
+    await store.set("k3", "value", 1);
+    vi.advanceTimersByTime(1500);
+    expect(await store.get("k3")).toBeNull();
+  });
+
+  it("increments a counter and returns the running count", async () => {
+    const store = await getKvStore();
+    expect(await store.incr("counter1", 60)).toBe(1);
+    expect(await store.incr("counter1", 60)).toBe(2);
+    expect(await store.incr("counter1", 60)).toBe(3);
+  });
+
+  it("resets the counter once its TTL has elapsed", async () => {
+    vi.useFakeTimers();
+    const store = await getKvStore();
+    expect(await store.incr("counter2", 1)).toBe(1);
+    vi.advanceTimersByTime(1500);
+    expect(await store.incr("counter2", 1)).toBe(1);
+  });
+
+  it("shares state across separate getKvStore() calls", async () => {
+    // Regression: the memory store must live on globalThis, not a plain
+    // module-scope variable — Next.js dev mode compiles each API route file
+    // as its own bundle, so a module-scope Map ends up as a distinct
+    // instance per route the first time it's compiled. That made a room
+    // created via POST /api/room invisible to GET /api/room/[code]/status.
+    const storeA = await getKvStore();
+    await storeA.set("shared-key", "shared-value", 60);
+    const storeB = await getKvStore();
+    expect(await storeB.get("shared-key")).toBe("shared-value");
+  });
+});
+
+describe("getKvStore (Upstash backend)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("UPSTASH_REDIS_REST_URL", "https://example.upstash.io");
+    vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "test-token");
+    Object.values(redisMock).forEach((fn) => fn.mockReset());
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("routes to Upstash when the env vars are set", async () => {
+    redisMock.get.mockResolvedValue({ hello: "world" });
+    const { getKvStore: freshGetKvStore } = await import("@/lib/kv");
+    const store = await freshGetKvStore();
+    const value = await store.get("k1");
+    expect(redisMock.get).toHaveBeenCalledWith("k1");
+    expect(value).toEqual({ hello: "world" });
+  });
+
+  it("returns null when Upstash has no value for the key", async () => {
+    redisMock.get.mockResolvedValue(null);
+    const { getKvStore: freshGetKvStore } = await import("@/lib/kv");
+    const store = await freshGetKvStore();
+    expect(await store.get("missing")).toBeNull();
+  });
+
+  it("sets a value with the given TTL", async () => {
+    const { getKvStore: freshGetKvStore } = await import("@/lib/kv");
+    const store = await freshGetKvStore();
+    await store.set("k2", "value", 120);
+    expect(redisMock.set).toHaveBeenCalledWith("k2", "value", { ex: 120 });
+  });
+
+  it("deletes a key", async () => {
+    const { getKvStore: freshGetKvStore } = await import("@/lib/kv");
+    const store = await freshGetKvStore();
+    await store.del("k3");
+    expect(redisMock.del).toHaveBeenCalledWith("k3");
+  });
+
+  it("only sets the TTL on the first increment of a window, not later ones", async () => {
+    // Regression: a get-then-set pair for rate limiting would race under
+    // concurrent requests — incr() must rely on Redis's atomic INCR, and
+    // only the request that starts a fresh window should reset its expiry,
+    // or every increment would keep pushing the window back indefinitely.
+    const { getKvStore: freshGetKvStore } = await import("@/lib/kv");
+    const store = await freshGetKvStore();
+
+    redisMock.incr.mockResolvedValueOnce(1);
+    const first = await store.incr("counter", 60);
+    expect(first).toBe(1);
+    expect(redisMock.expire).toHaveBeenCalledWith("counter", 60);
+
+    redisMock.expire.mockClear();
+    redisMock.incr.mockResolvedValueOnce(2);
+    const second = await store.incr("counter", 60);
+    expect(second).toBe(2);
+    expect(redisMock.expire).not.toHaveBeenCalled();
+  });
+});

--- a/tests/mixed-playlist.test.ts
+++ b/tests/mixed-playlist.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { fingerprint, poolContributions, type PlaylistContribution } from "@/lib/mixed-playlist";
+import type { Track } from "@/types";
+
+function makeTrack(overrides: Partial<Track> = {}): Track {
+  return {
+    id: "t1",
+    name: "Song",
+    artists: ["Artist"],
+    durationMs: 200000,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("fingerprint", () => {
+  it("is case- and whitespace-insensitive", () => {
+    expect(fingerprint("Blinding Lights", ["The Weeknd"])).toBe(
+      fingerprint("blinding lights", ["the weeknd"])
+    );
+  });
+
+  it("collapses remaster/live/version suffixes to the same key", () => {
+    const base = fingerprint("Come Together", ["The Beatles"]);
+    expect(fingerprint("Come Together - Remastered 2009", ["The Beatles"])).toBe(base);
+    expect(fingerprint("Come Together (Live)", ["The Beatles"])).toBe(base);
+  });
+
+  it("strips feat. credits from the title", () => {
+    expect(fingerprint("Song (feat. Someone)", ["Artist"])).toBe(
+      fingerprint("Song", ["Artist"])
+    );
+  });
+
+  it("only keys off the primary artist", () => {
+    expect(fingerprint("Song", ["Artist A", "Artist B"])).toBe(
+      fingerprint("Song", ["Artist A"])
+    );
+  });
+
+  it("distinguishes different songs", () => {
+    expect(fingerprint("Song One", ["Artist"])).not.toBe(fingerprint("Song Two", ["Artist"]));
+  });
+});
+
+describe("poolContributions", () => {
+  it("merges a shared track's contributors instead of duplicating it", () => {
+    const shared = makeTrack({ id: "shared", name: "Shared Song", artists: ["Someone"] });
+    const contributions: PlaylistContribution[] = [
+      { playerName: "Alice", tracks: [shared] },
+      { playerName: "Bob", tracks: [{ ...shared, id: "shared-bob-copy" }] },
+    ];
+
+    const pooled = poolContributions(contributions, 8);
+
+    expect(pooled).toHaveLength(1);
+    expect(pooled[0].contributors.sort()).toEqual(["Alice", "Bob"]);
+  });
+
+  it("caps each contributor at sampledPerPlayer tracks", () => {
+    const bigPlaylist: Track[] = Array.from({ length: 50 }, (_, i) =>
+      makeTrack({ id: `big-${i}`, name: `Big Song ${i}`, artists: [`Artist ${i}`] })
+    );
+    const smallPlaylist: Track[] = Array.from({ length: 5 }, (_, i) =>
+      makeTrack({ id: `small-${i}`, name: `Small Song ${i}`, artists: [`Small Artist ${i}`] })
+    );
+    const contributions: PlaylistContribution[] = [
+      { playerName: "BigLister", tracks: bigPlaylist },
+      { playerName: "SmallLister", tracks: smallPlaylist },
+    ];
+
+    const pooled = poolContributions(contributions, 8);
+
+    const bigCount = pooled.filter((t) => t.contributors.includes("BigLister")).length;
+    const smallCount = pooled.filter((t) => t.contributors.includes("SmallLister")).length;
+    expect(bigCount).toBeLessThanOrEqual(8);
+    expect(smallCount).toBeLessThanOrEqual(5);
+  });
+
+  it("counts a shared track against every one of its contributors' quotas", () => {
+    const shared = makeTrack({ id: "shared", name: "Shared Song", artists: ["Someone"] });
+    const aloneTracks: Track[] = Array.from({ length: 10 }, (_, i) =>
+      makeTrack({ id: `a-${i}`, name: `Solo Song ${i}`, artists: [`Solo Artist ${i}`] })
+    );
+    const contributions: PlaylistContribution[] = [
+      { playerName: "Alice", tracks: [shared, ...aloneTracks] },
+      { playerName: "Bob", tracks: [{ ...shared, id: "shared-bob-copy" }] },
+    ];
+
+    const pooled = poolContributions(contributions, 3);
+
+    const aliceCount = pooled.filter((t) => t.contributors.includes("Alice")).length;
+    expect(aliceCount).toBeLessThanOrEqual(3);
+  });
+
+  it("returns an empty pool for no contributions", () => {
+    expect(poolContributions([], 8)).toEqual([]);
+  });
+});

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
+
+describe("rateLimit", () => {
+  it("allows requests up to the limit, then blocks", async () => {
+    const id = `test-${Math.random()}`;
+    for (let i = 0; i < 3; i++) {
+      const result = await rateLimit(id, 3, 60);
+      expect(result.allowed).toBe(true);
+    }
+    const blocked = await rateLimit(id, 3, 60);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.remaining).toBe(0);
+  });
+
+  it("keeps separate counters per identifier", async () => {
+    const a = `a-${Math.random()}`;
+    const b = `b-${Math.random()}`;
+    await rateLimit(a, 1, 60);
+    const resultA = await rateLimit(a, 1, 60);
+    const resultB = await rateLimit(b, 1, 60);
+    expect(resultA.allowed).toBe(false);
+    expect(resultB.allowed).toBe(true);
+  });
+});
+
+describe("getClientIp", () => {
+  it("reads the first address from x-forwarded-for", () => {
+    const req = new NextRequest("http://localhost/api/room", {
+      headers: { "x-forwarded-for": "1.2.3.4, 5.6.7.8" },
+    });
+    expect(getClientIp(req)).toBe("1.2.3.4");
+  });
+
+  it("falls back to x-real-ip, then unknown", () => {
+    const withRealIp = new NextRequest("http://localhost/api/room", {
+      headers: { "x-real-ip": "9.9.9.9" },
+    });
+    expect(getClientIp(withRealIp)).toBe("9.9.9.9");
+
+    const withNeither = new NextRequest("http://localhost/api/room");
+    expect(getClientIp(withNeither)).toBe("unknown");
+  });
+});

--- a/tests/room.test.ts
+++ b/tests/room.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as spotify from "@/lib/spotify";
+import type { SpotifyPlaylist } from "@/lib/spotify";
+import { createRoom, submitToRoom, getRoomStatus, consumeRoomPool } from "@/lib/room";
+import type { Track } from "@/types";
+
+vi.mock("@/lib/spotify", () => ({
+  getPlaylistWithTracks: vi.fn(),
+}));
+
+const FAKE_PLAYLIST: SpotifyPlaylist = {
+  id: "p",
+  name: "P",
+  tracks: { items: [], total: 0 },
+};
+
+function makeTrack(overrides: Partial<Track> = {}): Track {
+  return {
+    id: "t1",
+    name: "Song",
+    artists: ["Artist"],
+    durationMs: 200000,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("room lifecycle", () => {
+  beforeEach(() => {
+    vi.mocked(spotify.getPlaylistWithTracks).mockReset();
+  });
+
+  it("creates a room with a 4-char code, future expiry, and a host token", async () => {
+    const { roomCode, expiresAt, hostToken } = await createRoom();
+    expect(roomCode).toHaveLength(4);
+    expect(expiresAt).toBeGreaterThan(Date.now());
+    expect(hostToken).toBeTruthy();
+  });
+
+  it("issues a different host token per room", async () => {
+    const a = await createRoom();
+    const b = await createRoom();
+    expect(a.hostToken).not.toBe(b.hostToken);
+  });
+
+  it("submits a playlist and returns its track count", async () => {
+    vi.mocked(spotify.getPlaylistWithTracks).mockResolvedValue({
+      playlist: FAKE_PLAYLIST,
+      tracks: [makeTrack({ id: "a" }), makeTrack({ id: "b" })],
+    });
+    const { roomCode } = await createRoom();
+    const result = await submitToRoom(roomCode, "Alice", "https://open.spotify.com/playlist/abc");
+    expect(result.trackCount).toBe(2);
+  });
+
+  it("rejects a duplicate name (case-insensitive) in the same room", async () => {
+    vi.mocked(spotify.getPlaylistWithTracks).mockResolvedValue({
+      playlist: FAKE_PLAYLIST,
+      tracks: [makeTrack()],
+    });
+    const { roomCode } = await createRoom();
+    await submitToRoom(roomCode, "Alice", "url1");
+    await expect(submitToRoom(roomCode, "alice", "url2")).rejects.toMatchObject({ status: 409 });
+  });
+
+  it("rejects submission to an unknown room", async () => {
+    await expect(submitToRoom("ZZZZ", "Alice", "url")).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("propagates playlist parse failures as 422", async () => {
+    vi.mocked(spotify.getPlaylistWithTracks).mockRejectedValue(new Error("bad playlist"));
+    const { roomCode } = await createRoom();
+    await expect(submitToRoom(roomCode, "Alice", "bad-url")).rejects.toMatchObject({
+      status: 422,
+    });
+  });
+
+  it("status reports only names and track counts, never track contents", async () => {
+    vi.mocked(spotify.getPlaylistWithTracks).mockResolvedValue({
+      playlist: FAKE_PLAYLIST,
+      tracks: [makeTrack({ id: "a" }), makeTrack({ id: "b" }), makeTrack({ id: "c" })],
+    });
+    const { roomCode } = await createRoom();
+    await submitToRoom(roomCode, "Alice", "url");
+    const status = await getRoomStatus(roomCode);
+    expect(status.submissions).toEqual([{ playerName: "Alice", trackCount: 3 }]);
+    expect(status.total).toBe(1);
+    expect(JSON.stringify(status)).not.toContain("Song");
+  });
+
+  it("pools submissions, marks the room consumed, and blocks further activity", async () => {
+    vi.mocked(spotify.getPlaylistWithTracks)
+      .mockResolvedValueOnce({ playlist: FAKE_PLAYLIST, tracks: [makeTrack({ id: "a", name: "A" })] })
+      .mockResolvedValueOnce({ playlist: FAKE_PLAYLIST, tracks: [makeTrack({ id: "b", name: "B" })] });
+    const { roomCode, hostToken } = await createRoom();
+    await submitToRoom(roomCode, "Alice", "url1");
+    await submitToRoom(roomCode, "Bob", "url2");
+
+    const pool = await consumeRoomPool(roomCode, 8, hostToken);
+    expect(pool.players.slice().sort()).toEqual(["Alice", "Bob"]);
+    expect(pool.tracks).toHaveLength(2);
+
+    await expect(submitToRoom(roomCode, "Carol", "url3")).rejects.toMatchObject({ status: 410 });
+    await expect(consumeRoomPool(roomCode, 8, hostToken)).rejects.toMatchObject({ status: 410 });
+  });
+
+  it("rejects pool consumption with no submissions yet", async () => {
+    const { roomCode, hostToken } = await createRoom();
+    await expect(consumeRoomPool(roomCode, 8, hostToken)).rejects.toMatchObject({ status: 422 });
+  });
+
+  it("rejects pool consumption with a wrong or missing host token", async () => {
+    vi.mocked(spotify.getPlaylistWithTracks).mockResolvedValue({
+      playlist: FAKE_PLAYLIST,
+      tracks: [makeTrack()],
+    });
+    const { roomCode } = await createRoom();
+    await submitToRoom(roomCode, "Alice", "url1");
+
+    await expect(consumeRoomPool(roomCode, 8, "wrong-token")).rejects.toMatchObject({ status: 403 });
+    await expect(consumeRoomPool(roomCode, 8, "")).rejects.toMatchObject({ status: 403 });
+  });
+
+  it("does not lose a submission when two players submit at nearly the same time", async () => {
+    const { roomCode } = await createRoom();
+
+    // Alice's request stalls on the Spotify fetch (the slow part of
+    // submitToRoom) while Bob's request runs to completion first — this
+    // reproduces the interleaving that used to silently drop whichever
+    // submission wrote last against a stale in-memory copy of the record.
+    let resolveAlice!: (v: Awaited<ReturnType<typeof spotify.getPlaylistWithTracks>>) => void;
+    const alicePending = new Promise<Awaited<ReturnType<typeof spotify.getPlaylistWithTracks>>>(
+      (resolve) => {
+        resolveAlice = resolve;
+      }
+    );
+    vi.mocked(spotify.getPlaylistWithTracks)
+      .mockImplementationOnce(() => alicePending)
+      .mockResolvedValueOnce({ playlist: FAKE_PLAYLIST, tracks: [makeTrack({ id: "b" })] });
+
+    const submitAlice = submitToRoom(roomCode, "Alice", "url-alice");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await submitToRoom(roomCode, "Bob", "url-bob");
+    resolveAlice({ playlist: FAKE_PLAYLIST, tracks: [makeTrack({ id: "a" })] });
+    await submitAlice;
+
+    const status = await getRoomStatus(roomCode);
+    expect(status.submissions.map((s) => s.playerName).sort()).toEqual(["Alice", "Bob"]);
+  });
+
+  it("only lets one of two concurrent pool-consume calls succeed", async () => {
+    vi.mocked(spotify.getPlaylistWithTracks)
+      .mockResolvedValueOnce({ playlist: FAKE_PLAYLIST, tracks: [makeTrack({ id: "a" })] })
+      .mockResolvedValueOnce({ playlist: FAKE_PLAYLIST, tracks: [makeTrack({ id: "b" })] });
+    const { roomCode, hostToken } = await createRoom();
+    await submitToRoom(roomCode, "Alice", "url1");
+    await submitToRoom(roomCode, "Bob", "url2");
+
+    const [first, second] = await Promise.allSettled([
+      consumeRoomPool(roomCode, 8, hostToken),
+      consumeRoomPool(roomCode, 8, hostToken),
+    ]);
+
+    const outcomes = [first, second];
+    expect(outcomes.filter((r) => r.status === "fulfilled")).toHaveLength(1);
+    const rejected = outcomes.find((r) => r.status === "rejected");
+    expect(rejected && (rejected as PromiseRejectedResult).reason).toMatchObject({ status: 410 });
+  });
+});

--- a/tests/taste-card.test.ts
+++ b/tests/taste-card.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  findSharedTracks,
+  computeMostObscure,
+  computeMostMainstream,
+  buildTasteCard,
+} from "@/lib/taste-card";
+import type { Track } from "@/types";
+import type { RoundHistoryEntry } from "@/lib/round-history";
+
+function makeTrack(overrides: Partial<Track> = {}): Track {
+  return {
+    id: "t1",
+    name: "Song",
+    artists: ["Artist"],
+    durationMs: 200000,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("findSharedTracks", () => {
+  it("returns only tracks with more than one contributor", () => {
+    const tracks = [
+      makeTrack({ id: "a", contributors: ["Alice", "Bob"] }),
+      makeTrack({ id: "b", contributors: ["Alice"] }),
+      makeTrack({ id: "c", contributors: ["Bob", "Carol"] }),
+    ];
+    const shared = findSharedTracks(tracks);
+    expect(shared.map((t) => t.trackId).sort()).toEqual(["a", "c"]);
+  });
+
+  it("returns an empty array when no tracks are shared", () => {
+    const tracks = [makeTrack({ id: "a", contributors: ["Alice"] })];
+    expect(findSharedTracks(tracks)).toEqual([]);
+  });
+});
+
+describe("computeMostObscure", () => {
+  it("picks the contributor with the lowest correct-source-guess rate", () => {
+    const history: RoundHistoryEntry[] = [
+      { trackId: "a", contributors: ["Alice"], songWinner: null, albumWinner: null, sourceWinner: "Bob" },
+      { trackId: "b", contributors: ["Alice"], songWinner: null, albumWinner: null, sourceWinner: null },
+      { trackId: "c", contributors: ["Bob"], songWinner: null, albumWinner: null, sourceWinner: "Alice" },
+      { trackId: "d", contributors: ["Bob"], songWinner: null, albumWinner: null, sourceWinner: "Alice" },
+    ];
+    // Alice: 1/2 correct (0.5). Bob: 2/2 correct (1.0). Alice is more obscure.
+    const result = computeMostObscure(history);
+    expect(result?.playerName).toBe("Alice");
+    expect(result?.rate).toBe(0.5);
+    expect(result?.totalTracks).toBe(2);
+  });
+
+  it("excludes shared (multi-contributor) tracks — no way to know which contributor was guessed", () => {
+    const history: RoundHistoryEntry[] = [
+      { trackId: "a", contributors: ["Alice", "Bob"], songWinner: null, albumWinner: null, sourceWinner: "Carol" },
+    ];
+    // A correct guess on a track shared by Alice and Bob doesn't say which
+    // of them was actually named, so it can't be credited to either without
+    // guessing — the track is excluded from both players' totals entirely.
+    expect(computeMostObscure(history)).toBeNull();
+  });
+
+  it("only counts single-contributor tracks when a history mixes shared and solo tracks", () => {
+    const history: RoundHistoryEntry[] = [
+      { trackId: "a", contributors: ["Alice", "Bob"], songWinner: null, albumWinner: null, sourceWinner: "Carol" },
+      { trackId: "b", contributors: ["Alice"], songWinner: null, albumWinner: null, sourceWinner: "Alice" },
+    ];
+    const result = computeMostObscure(history);
+    expect(result?.playerName).toBe("Alice");
+    expect(result?.totalTracks).toBe(1);
+    expect(result?.rate).toBe(1);
+  });
+
+  it("returns null with no history", () => {
+    expect(computeMostObscure([])).toBeNull();
+  });
+});
+
+describe("computeMostMainstream", () => {
+  it("picks the contributor with the highest average popularity", () => {
+    const tracks = [
+      makeTrack({ id: "a", contributors: ["Alice"], popularity: 90 }),
+      makeTrack({ id: "b", contributors: ["Alice"], popularity: 70 }),
+      makeTrack({ id: "c", contributors: ["Bob"], popularity: 20 }),
+    ];
+    const result = computeMostMainstream(tracks);
+    expect(result?.playerName).toBe("Alice");
+    expect(result?.averagePopularity).toBe(80);
+  });
+
+  it("ignores tracks without a popularity value", () => {
+    const tracks = [
+      makeTrack({ id: "a", contributors: ["Alice"] }),
+      makeTrack({ id: "b", contributors: ["Bob"], popularity: 50 }),
+    ];
+    const result = computeMostMainstream(tracks);
+    expect(result?.playerName).toBe("Bob");
+  });
+
+  it("returns null when no track has popularity data", () => {
+    const tracks = [makeTrack({ id: "a", contributors: ["Alice"] })];
+    expect(computeMostMainstream(tracks)).toBeNull();
+  });
+});
+
+describe("buildTasteCard", () => {
+  it("assembles all three awards together", () => {
+    const tracks = [
+      makeTrack({ id: "a", contributors: ["Alice", "Bob"], popularity: 80 }),
+      makeTrack({ id: "b", contributors: ["Bob"], popularity: 40 }),
+    ];
+    const history: RoundHistoryEntry[] = [
+      { trackId: "a", contributors: ["Alice", "Bob"], songWinner: null, albumWinner: null, sourceWinner: "Carol" },
+      { trackId: "b", contributors: ["Bob"], songWinner: null, albumWinner: null, sourceWinner: null },
+    ];
+    const card = buildTasteCard(tracks, history);
+    expect(card.sharedTracks).toHaveLength(1);
+    expect(card.mostObscure?.playerName).toBe("Bob");
+    expect(card.mostMainstream?.playerName).toBe("Alice");
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -8,4 +8,8 @@ export interface Track {
   previewUrl?: string | null;
   rawJson?: Record<string, unknown>;
   createdAt: string;
+  /** Mixed Playlist Mode: names of players whose playlist contained this track. */
+  contributors?: string[];
+  /** Spotify's 0-100 popularity score — used for the v2 "most mainstream" taste card award. */
+  popularity?: number;
 }

--- a/types/room.ts
+++ b/types/room.ts
@@ -1,0 +1,42 @@
+import type { PooledTrack } from "@/lib/mixed-playlist";
+
+/** Wire contract for the Mixed Playlist Mode room mailbox (/api/room/*). */
+
+export const ROOM_CODE_LENGTH = 4;
+export const ROOM_TTL_SECONDS = 30 * 60;
+export const ROOM_MAX_SUBMISSIONS = 12;
+export const DEFAULT_SAMPLED_PER_PLAYER = 8;
+
+export interface RoomSubmissionSummary {
+  playerName: string;
+  trackCount: number;
+}
+
+export interface CreateRoomResponse {
+  roomCode: string;
+  expiresAt: number;
+  /** Secret held only by the creator; required to consume the room's pool. */
+  hostToken: string;
+}
+
+export interface SubmitRoomRequest {
+  playerName: string;
+  playlistUrl: string;
+}
+
+export interface SubmitRoomResponse {
+  ok: true;
+  trackCount: number;
+}
+
+export interface RoomStatusResponse {
+  submissions: RoomSubmissionSummary[];
+  total: number;
+  expiresAt: number;
+}
+
+export interface RoomPoolResponse {
+  tracks: PooledTrack[];
+  players: string[];
+  sampledPerPlayer: number;
+}


### PR DESCRIPTION
## Summary

Adds **Mixed Playlist Mode** — players contribute their own Spotify playlists into a shared pool instead of everyone guessing from one person's playlist. Two ways to contribute:

- **Pass This Phone** (v0): players take turns on the host's device, no backend required.
- **QR Code Room** (v1): host creates a TTL'd room, players scan a QR code / open a share link to submit from their own phone (`app/j/[code]`), host pulls the pool once everyone's in.

Also adds:
- **Guess-the-source scoring** (v1.5): +2 pts for correctly guessing whose playlist a track came from.
- **Group taste card** (v2): a shareable image showing shared tracks across playlists plus "Most Obscure Taste" and "Most Mainstream" awards.

## Plan Completion

Audited against `dev_docs/guessong-mixed-playlist-implementation-plan.md`: **27/28 items DONE**, 1 CHANGED (Upstash Redis instead of literal Vercel KV — same TTL-room-store goal, different provider), 2 UNVERIFIABLE (fingerprint accuracy is an accepted design limitation from the plan itself; production Upstash env-var provisioning on Vercel is external to this diff — the code already falls back gracefully to in-memory storage when unset).

## Pre-landing review

Dispatched 5 parallel specialist reviews (testing, maintainability, security, performance, API contract) plus a red-team pass given the diff size. All 5 CRITICAL findings and the flagged cheap/mechanical fixes were addressed before this PR:

- **Race condition**: `submitToRoom`/`consumeRoomPool` did a plain read-modify-write on the whole room record — two players submitting close together (the exact scenario a QR-code room produces) could silently clobber each other, or un-consume an already-started room. Now re-reads immediately before writing and retries on a lost write, verified with new regression tests.
- **Room enumeration**: `GET /api/room/[code]/status` and `GET /api/room/[code]/pool` had no rate limiting, unlike the other two room routes — added, matching the existing pattern.
- **Storage bloat**: room submissions stored the full raw Spotify API blob per track; a full room risked approaching Upstash's per-value size limit. Now stripped via the existing `stripTrackForStorage` helper.
- **Unbounded phone-pass bursts**: no cap on how many playlists one person could add via pass-the-phone, risking exhaustion of the app's shared Spotify API token. Capped and deduped to match the server room's limits.
- **Zero test coverage on the production KV backend**: `lib/kv.ts`'s Upstash-backed store (vs. the in-memory dev fallback) had no tests. Added, including a regression test for the "only the first `incr()` in a window sets the TTL" rate-limiting invariant.
- Plus: room-full now returns 409 instead of a misleading 429; a taste-card scoring bug that over-credited shared tracks' contributors; a canvas-height calculation bug that could leave blank space on the shared result image; constant-time host-token comparison; a default value deduped from 3 places to 1.

## Known follow-ups (not blocking)

- `getClientIp` trusts client-supplied `X-Forwarded-For` verbatim; depends on the deploy target's edge stripping it.
- Host room state (`roomCode`/`hostToken`) lives only in React state — a page reload before starting orphans the room.
- `GET /api/room/[code]/pool` mutates state on a GET; a POST would be more correct REST semantics.
- A few maintainability items from the review (unused wire-contract types in `types/room.ts`, some duplicated handler logic in `app/page.tsx`) were left as-is to keep this PR scoped.

## Test plan

- [x] `npm test` — 92/92 passing (10 files)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — production build succeeds
- [x] Live smoke test against the dev server: room create/status/submit/pool guard rails (404/422/403/410) all verified; confirmed the new rate limit on `/status` triggers 429 at exactly the configured threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)