### PR TITLE
docs: document Upstash env vars and add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Required — Spotify Client Credentials flow, no redirect URI needed.
+# Get these at https://developer.spotify.com/dashboard
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+
+# Optional — defaults to https://www.guessong.app if unset
+NEXT_PUBLIC_BASE_URL=
+
+# Optional — enables GA4 when set
+NEXT_PUBLIC_GA_MEASUREMENT_ID=
+
+# Optional for local dev (falls back to an in-memory store), but REQUIRED on
+# serverless/multi-instance deploys (e.g. Vercel) — backs the QR-code room
+# store used by Mixed Playlist Mode (lib/kv.ts). Get a free database at
+# https://upstash.com
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=

--- a/README.md
+++ b/README.md
@@ -46,9 +46,15 @@ Create a `.env.local` file:
 ```env
 SPOTIFY_CLIENT_ID=your_spotify_client_id
 SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
+
+# Optional — only needed for production deploys, see note below
+UPSTASH_REDIS_REST_URL=your_upstash_redis_rest_url
+UPSTASH_REDIS_REST_TOKEN=your_upstash_redis_rest_token
 ```
 
-Get credentials at [developer.spotify.com](https://developer.spotify.com/dashboard) — create an app and copy the Client ID and Secret. No redirect URI needed (Client Credentials flow only).
+Get Spotify credentials at [developer.spotify.com](https://developer.spotify.com/dashboard) — create an app and copy the Client ID and Secret. No redirect URI needed (Client Credentials flow only).
+
+`UPSTASH_REDIS_REST_URL`/`TOKEN` back the QR-code room store used by Mixed Playlist Mode (`lib/kv.ts`). Leave them unset for local dev — the app falls back to an in-memory store that works fine on a single `next dev` process. **On a serverless/multi-instance deploy (e.g. Vercel) you must set these**, otherwise a room created on one instance can be invisible to a request that lands on another. Get a free database at [upstash.com](https://upstash.com).
 
 ### 3. Run the dev server
 


### PR DESCRIPTION
## Summary
- Add `.env.example` covering every env var the app reads (Spotify, base URL, GA4, Upstash)
- Document in README that `UPSTASH_REDIS_REST_URL`/`TOKEN` are optional for local dev (in-memory KV fallback) but required on serverless/multi-instance deploys, since Mixed Playlist Mode's room store (`lib/kv.ts`) otherwise won't be visible across instances

## Test plan
- [x] Docs-only change, no code touched