### PR TITLE
v0.4.0 feat: rank for "guess the song", not just "guessong"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-07-29
+
+### Added
+
+- **Traditional Chinese landing page at `/zh`.** The site only ranked for the brand string "guessong" — a query nobody types unless they already know us. English head terms ("guess the song", "guess song") are a red ocean of Heardle clones, but the Chinese equivalents are not, and the audience is already here: the homepage hero has carried a Chinese line since launch. `/zh` is written natively rather than translated, and its `<h1>` is the keyword itself (`猜歌遊戲`) rather than the brand, because unlike `/` it has no brand identity to protect. Carries its own `HowTo` and `FAQPage` JSON-LD in `zh-TW`, and the homepage's Chinese hero line is now the crawl path into it, so the anchor text is the keyword instead of sitting next to it.
+- **`hreflang` annotations** across `/` and `/zh` (`en`, `zh-TW`, `x-default`), emitted both as `<link rel="alternate">` tags and in `sitemap.xml`. Both URLs carry the full annotation set — a one-sided declaration is a weaker signal than none — and the visible language switcher on `/zh` points at `/` to match what the annotation claims.
+- **`FAQPage` structured data on the homepage** and **`HowTo` on `/about`**, the latter generated from the existing `STEPS` array so the schema cannot drift from what the page actually renders.
+
+### Changed
+
+- **The homepage now has content for a search engine to read.** It was a setup form and roughly 50 words of prose, which left Google nothing to match "guess the song game" against except the brand string. Added a "What is GuessSong?" section and six FAQs — 588 words, all of it useful to a first-time visitor too, not keyword filler. The hero tagline ("Play a clip. Guess the song. Compete.") became an `<h2>` so the phrase people actually search for is a heading; the `<h1>` stays `GuessSong` and the hero is visually unchanged.
+- Titles and descriptions across `/` and `/about` lead with the generic phrase instead of the brand. `/about` is now "How to Play the Guess the Song Game".
+- Trimmed `keywords` from 22 entries to 11. Google has ignored the tag since 2009; the list is kept only because Bing still weighs it slightly, and a focused list is worth more there than a long one.
+- Added an explicit canonical for the homepage. It's a client component and can't export its own metadata, so it lives in the root layout.
+
+### Fixed
+
+- `/buzz` and `/j` are now disallowed in `robots.txt`. They're ephemeral room codes that 404 once the room's TTL expires, so crawling them spent budget on pages guaranteed to rot.
+
+### Known gaps
+
+- The root layout owns `<html lang="en">` and Next.js only lets the root layout render `<html>`, so `/zh` scopes its language with `lang="zh-Hant-TW"` on its `<main>` instead. `hreflang` is what Google keys off, so ranking is unaffected, but a screen reader that only checks the root element will read the page with an English voice. Fixing it properly means moving every route into a `(lang)` route group with per-locale root layouts.
+- Only `/` and `/zh` form an `hreflang` cluster. `/about` has no Chinese counterpart of its own — `/zh` covers that content — so it is deliberately left out rather than pointed at a page that isn't its translation.
+- `/zh` duplicates about 200 lines of CSS from `app/about/page.tsx`. That matches the project's per-page `<style>` block convention, but a third page in this style is the point where the shared rules should be extracted.
+
 ## [0.3.0] - 2026-07-29
 
 ### Added

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -3,12 +3,12 @@ import Link from "next/link";
 import { REPORT_PROBLEM_MAILTO } from "@/lib/contact";
 
 export const metadata: Metadata = {
-  title: "How to Play",
+  title: "How to Play the Guess the Song Game",
   description:
-    "Learn how GuessSong works: paste any public Spotify playlist, add players, play short clips, and guess the song — or merge everyone's playlists together with Mixed Playlist Mode. Free, open source, no login required.",
+    "How to play the guess the song game with friends: paste any public Spotify playlist, add players, play short clips and name the track. Includes Mixed Playlist Mode. Free, open source, no login required.",
   alternates: { canonical: "/about" },
   openGraph: {
-    title: "How to Play | GuessSong",
+    title: "How to Play the Guess the Song Game | GuessSong",
     description:
       "Paste a Spotify playlist, play short clips, guess the song. Now with Mixed Playlist Mode. Free, open source, no login required.",
   },
@@ -140,8 +140,30 @@ const MIXED_COLLECT = [
 ];
 
 export default function AboutPage() {
+  // Built from STEPS so the schema can never drift from what's on the page.
+  const howToLd = {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    name: "How to play the guess the song game",
+    description:
+      "Turn any public Spotify playlist into a guess the song party game in four steps.",
+    totalTime: "PT30S",
+    supply: [{ "@type": "HowToSupply", name: "A public Spotify playlist link" }],
+    tool: [{ "@type": "HowToTool", name: "Any device with a browser and speakers" }],
+    step: STEPS.map((s, i) => ({
+      "@type": "HowToStep",
+      position: i + 1,
+      name: s.title,
+      text: s.desc,
+    })),
+  };
+
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(howToLd) }}
+      />
       <style>{`
         @import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Outfit:wght@300;400;500;600;700&display=swap');
 
@@ -433,10 +455,12 @@ export default function AboutPage() {
               </span>
             </div>
             <h1 className="hero-title">GuessSong</h1>
-            <p style={{ color: "#999", fontSize: "17px", marginTop: "16px", fontWeight: 300, maxWidth: "520px", marginLeft: "auto", marginRight: "auto", lineHeight: 1.6 }}>
-              Turn any Spotify playlist into a party game. Play a short clip,
-              let everyone guess the song, and crown the music champion of the room.
-            </p>
+            {/* Same trick as the homepage: the H1 is brand-only, so the
+                searchable phrase lives in an <h2> right under it. */}
+            <h2 style={{ color: "#999", fontSize: "17px", marginTop: "16px", fontWeight: 300, maxWidth: "520px", marginLeft: "auto", marginRight: "auto", lineHeight: 1.6 }}>
+              Turn any Spotify playlist into a guess the song party game. Play a short
+              clip, let everyone name the track, and crown the music champion of the room.
+            </h2>
             <div style={{ display: "flex", gap: "12px", justifyContent: "center", flexWrap: "wrap", marginTop: "28px" }}>
               <Link href="/" className="cta-primary">
                 Play Now →

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,53 +9,50 @@ const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://www.guessong.app";
 export const metadata: Metadata = {
   metadataBase: new URL(BASE_URL),
   title: {
-    default: "GuessSong — Guess Song Party Game",
+    // The generic phrase carries the title, not the brand — nobody searches
+    // "guesssong" except people who already know us.
+    default: "Guess the Song — Free Music Guessing Party Game | GuessSong",
     template: "%s | GuessSong",
   },
   description:
-    "Play a clip, guess the song. GuessSong is a free guess song party game for any Spotify playlist — no login required, local multiplayer fun for friends and family.",
+    "Play a clip, guess the song. GuessSong is a free guess the song game that turns any Spotify playlist into a music quiz for parties — no login, no app, no sign-up.",
   keywords: [
-    "music guessing game",
-    "spotify party game",
-    "song guessing game",
-    "guess song",
-    "guess song game",
-    "music quiz",
-    "party game",
-    "local multiplayer",
-    "spotify playlist game",
     "guess the song",
+    "guess the song game",
+    "guess song",
+    "music guessing game",
+    "song guessing game",
     "name that tune",
-    "music trivia",
-    "song quiz",
-    "party music game",
-    "free online party game",
-    "friends game night",
-    "music game for parties",
-    "spotify trivia",
-    "猜歌",
+    "music quiz game",
+    "spotify playlist game",
+    "party game for friends",
     "猜歌遊戲",
-    "音樂猜謎遊戲",
-    "派對猜歌遊戲",
-    "spotify 猜歌",
+    "猜歌",
   ],
   authors: [{ name: "GuessSong" }],
   manifest: "/manifest.json",
   robots: { index: true, follow: true },
+  // The homepage is a client component and can't export its own metadata, so
+  // the canonical lives here. /about and /zh override it; the ephemeral room
+  // routes that also inherit it are disallowed in robots.ts.
+  alternates: {
+    canonical: "/",
+    languages: { en: "/", "zh-TW": "/zh", "x-default": "/" },
+  },
   openGraph: {
     type: "website",
     url: BASE_URL,
     siteName: "GuessSong",
-    title: "GuessSong — Guess Song Party Game",
+    title: "Guess the Song — Free Music Guessing Party Game",
     description:
-      "Play a clip, guess the song. A free guess song game for any Spotify playlist, no login required.",
+      "Play a clip, guess the song. A free guess the song game for any Spotify playlist — no login required.",
     images: [{ url: "/opengraph-image", width: 1200, height: 630 }],
   },
   twitter: {
     card: "summary_large_image",
-    title: "GuessSong — Guess Song Party Game",
+    title: "Guess the Song — Free Music Guessing Party Game",
     description:
-      "Play a clip, guess the song. A free guess song game for any Spotify playlist, no login required.",
+      "Play a clip, guess the song. A free guess the song game for any Spotify playlist — no login required.",
     images: ["/opengraph-image"],
   },
 };
@@ -73,12 +70,30 @@ export default function RootLayout({
     "@context": "https://schema.org",
     "@type": "WebApplication",
     name: "GuessSong",
-    alternateName: ["Guess Song", "Guess the Song", "猜歌", "猜歌遊戲"],
+    alternateName: [
+      "Guess the Song",
+      "Guess Song",
+      "Guess the Song Game",
+      "Music Guessing Game",
+      "猜歌",
+      "猜歌遊戲",
+    ],
     url: BASE_URL,
     description:
-      "A free guess song game for parties. Works with any Spotify playlist, no login required.",
+      "A free guess the song game for parties. Turns any Spotify playlist into a music guessing quiz — no login required.",
     applicationCategory: "GameApplication",
+    applicationSubCategory: "Music Quiz Game",
     operatingSystem: "Web",
+    browserRequirements: "Requires a modern browser with audio playback",
+    inLanguage: ["en", "zh-TW"],
+    isAccessibleForFree: true,
+    featureList: [
+      "Guess the song from a 5–30 second audio clip",
+      "Works with any public Spotify playlist",
+      "Mixed Playlist Mode — merge everyone's playlists into one round",
+      "Buzzer mode using players' phones",
+      "Local multiplayer, no accounts and no sign-up",
+    ],
     offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
   };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,6 +23,35 @@ const SONG_COUNTS: (number | "all")[] = [10, 20, 30, 50, "all"];
 const MIXED_SAMPLE_COUNTS = [5, 8, 10, 12];
 const MIXED_MIN_CONTRIBUTORS = 2;
 
+// Rendered on the page *and* emitted as FAQPage JSON-LD below — keep the two
+// in sync, Google penalises schema that doesn't match visible content.
+const FAQS: { q: string; a: string }[] = [
+  {
+    q: "How do you play the guess the song game?",
+    a: "One person hosts on a single screen. Paste a public Spotify playlist, add everyone's names, and the game plays a short clip (5 to 30 seconds) from a random track. Everyone shouts their guess out loud and the host taps whoever got it first: 3 points for the song title, 1 more for the album.",
+  },
+  {
+    q: "Do I need a Spotify account or a login?",
+    a: "No. GuessSong never asks anyone to sign in, and there are no accounts to create. It reads the track list from any public playlist link and plays a short preview clip of each song.",
+  },
+  {
+    q: "Is it free?",
+    a: "Yes, completely free and open source. There is nothing to install and nothing to pay for — it runs in the browser.",
+  },
+  {
+    q: "How many people can play?",
+    a: "As many as fit around one screen. GuessSong is a local party game: the host controls the music and the scoreboard, and everyone else just listens and guesses. You can also turn on Buzzer Mode so players buzz in from their own phones.",
+  },
+  {
+    q: "Can everyone use their own playlist?",
+    a: "Yes — that's Mixed Playlist Mode. Everyone submits their own playlist, GuessSong merges them into one pool and removes duplicates, and you get a bonus point for guessing whose playlist a track came from.",
+  },
+  {
+    q: "Why do some songs have no audio?",
+    a: "Spotify stopped providing preview clips for many tracks in late 2024, so GuessSong looks the song up on iTunes and Deezer instead. A small number of tracks have no preview anywhere and get skipped — playlists with mainstream music tend to work best.",
+  },
+];
+
 type SetupMode = "single" | "mixed";
 type MixedSubMode = "room" | "phone";
 
@@ -355,6 +384,20 @@ export default function SetupPage() {
 
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            mainEntity: FAQS.map((faq) => ({
+              "@type": "Question",
+              name: faq.q,
+              acceptedAnswer: { "@type": "Answer", text: faq.a },
+            })),
+          }),
+        }}
+      />
       <style>{`
         @import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Outfit:wght@300;400;500;600;700&display=swap');
 
@@ -536,6 +579,39 @@ export default function SetupPage() {
           margin-bottom: 10px;
         }
 
+        /* Crawlable prose. The setup form above is almost entirely UI chrome,
+           so without this the homepage has nothing for Google to match a
+           query like "guess the song game" against. */
+        .seo-section { margin-top: 44px; }
+        .seo-h2 {
+          font-size: 15px;
+          font-weight: 600;
+          color: #999;
+          margin-bottom: 10px;
+        }
+        .seo-p {
+          font-size: 13px;
+          font-weight: 300;
+          line-height: 1.7;
+          color: #666;
+        }
+        .seo-p + .seo-p { margin-top: 10px; }
+        .faq-list { margin-top: 12px; display: flex; flex-direction: column; gap: 14px; }
+        .faq-q {
+          font-size: 13px;
+          font-weight: 500;
+          color: #999;
+          margin-bottom: 4px;
+        }
+        .faq-a {
+          font-size: 13px;
+          font-weight: 300;
+          line-height: 1.7;
+          color: #666;
+        }
+        .faq-a a { color: #1DB954; }
+        .faq-a a:hover { text-decoration: underline; }
+
         .trial-divider {
           display: flex;
           align-items: center;
@@ -708,14 +784,24 @@ export default function SetupPage() {
               </span>
             </div>
             <h1 className="hero-title">GuessSong</h1>
-            <p style={{ color: "#666", fontSize: "15px", marginTop: "12px", fontWeight: 300 }}>
+            {/* This is an <h2>, not a <p>, so crawlers see the generic phrase
+                people actually search for — the H1 is brand-only. */}
+            <h2 style={{ color: "#666", fontSize: "15px", marginTop: "12px", fontWeight: 300 }}>
               Play a clip. Guess the song. Compete.
-            </p>
+            </h2>
             <p style={{ color: "#555", fontSize: "12px", marginTop: "8px" }}>
-              Paste any public Spotify playlist URL — no login required
+              The free music guessing game for any Spotify playlist — no login required
             </p>
+            {/* Crawl path to /zh with Chinese anchor text — that anchor is the
+                signal, so keep the keyword in the link, not around it. */}
             <p style={{ color: "#555", fontSize: "12px", marginTop: "4px" }}>
-              猜歌遊戲・派對音樂猜謎，適合朋友聚會
+              <a
+                href="/zh"
+                hrefLang="zh-TW"
+                style={{ color: "#666", textDecoration: "underline", textUnderlineOffset: "3px" }}
+              >
+                猜歌遊戲・派對音樂猜謎，適合朋友聚會
+              </a>
             </p>
             <p style={{ marginTop: "10px" }}>
               <a href="/about" className="link-btn">How to play →</a>
@@ -1113,6 +1199,37 @@ export default function SetupPage() {
               ))}
             </div>
           </div>
+
+          {/* Prose for search engines and first-time visitors alike. */}
+          <section className="seo-section">
+            <h2 className="seo-h2">What is GuessSong?</h2>
+            <p className="seo-p">
+              GuessSong is a free guess the song game for parties. The host pastes any
+              public Spotify playlist, the game plays a short clip from a random track,
+              and everyone races to name it out loud. No login, no app to install, no
+              accounts — one screen and a room full of people is all you need.
+            </p>
+            <p className="seo-p">
+              It works as a music quiz for game nights, road trips, classrooms and office
+              parties. Want everyone&apos;s taste in the mix? Mixed Playlist Mode merges
+              every player&apos;s playlist into one round.
+            </p>
+            <p style={{ marginTop: "14px" }}>
+              <a href="/about" className="link-btn">See how to play →</a>
+            </p>
+          </section>
+
+          <section className="seo-section">
+            <h2 className="seo-h2">Frequently asked questions</h2>
+            <div className="faq-list">
+              {FAQS.map((faq) => (
+                <div key={faq.q}>
+                  <h3 className="faq-q">{faq.q}</h3>
+                  <p className="faq-a">{faq.a}</p>
+                </div>
+              ))}
+            </div>
+          </section>
 
           {/* Footer */}
           <footer style={{ textAlign: "center", marginTop: "32px", paddingTop: "20px", borderTop: "1px solid var(--border)" }}>

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -7,7 +7,9 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: "*",
       allow: "/",
-      disallow: ["/game", "/api/", "/share"],
+      // /buzz and /j are ephemeral room codes — nothing to index, and crawling
+      // them just burns budget on pages that 404 once the room's TTL expires.
+      disallow: ["/game", "/api/", "/share", "/buzz", "/j"],
     },
     sitemap: `${BASE_URL}/sitemap.xml`,
   };

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,6 +2,14 @@ import type { MetadataRoute } from "next";
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://www.guessong.app";
 
+// Every URL in a language cluster has to carry the full annotation set —
+// a one-sided declaration is a weaker signal than none.
+const LANGUAGE_ALTERNATES = {
+  en: BASE_URL,
+  "zh-TW": `${BASE_URL}/zh`,
+  "x-default": BASE_URL,
+};
+
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
@@ -9,12 +17,20 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 1,
+      alternates: { languages: LANGUAGE_ALTERNATES },
     },
     {
       url: `${BASE_URL}/about`,
       lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/zh`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.9,
+      alternates: { languages: LANGUAGE_ALTERNATES },
     },
   ];
 }

--- a/app/zh/page.tsx
+++ b/app/zh/page.tsx
@@ -1,0 +1,433 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { REPORT_PROBLEM_MAILTO } from "@/lib/contact";
+
+export const metadata: Metadata = {
+  // Unlike the English pages, the H1 here IS the keyword — /zh is not the brand
+  // landing page, so nothing has to be reserved for "GuessSong".
+  title: "猜歌遊戲 — 用 Spotify 歌單玩的免費派對遊戲",
+  description:
+    "免費線上猜歌遊戲。貼上任何公開的 Spotify 歌單，播放 5 到 30 秒的片段，大家搶答歌名。不用登入、不用下載 App，聚會、尾牙、家庭聚餐都能玩。",
+  keywords: [
+    "猜歌遊戲",
+    "猜歌",
+    "線上猜歌",
+    "spotify 猜歌",
+    "音樂猜謎",
+    "派對遊戲",
+    "聚會遊戲",
+    "團康遊戲",
+    "尾牙遊戲",
+  ],
+  alternates: {
+    canonical: "/zh",
+    languages: { en: "/", "zh-TW": "/zh", "x-default": "/" },
+  },
+  openGraph: {
+    title: "猜歌遊戲 — 用 Spotify 歌單玩的免費派對遊戲",
+    description:
+      "貼上 Spotify 歌單，播放歌曲片段，大家搶答歌名。不用登入、不用下載，打開就能玩。",
+    locale: "zh_TW",
+  },
+};
+
+const GITHUB_URL = "https://github.com/Waynting/GuessSong";
+
+const STEPS = [
+  {
+    num: "01",
+    title: "貼上歌單",
+    desc: "複製任何公開 Spotify 歌單的分享連結貼進去就好。不用登入 Spotify、不用註冊帳號，遊戲會自動讀出歌單裡的曲目。",
+  },
+  {
+    num: "02",
+    title: "輸入玩家名字",
+    desc: "把在場每個人的名字打進去。GuessSong 是同一個螢幕的團康遊戲：一個人當主持人，其他人對著螢幕搶答。",
+  },
+  {
+    num: "03",
+    title: "播放片段",
+    desc: "主持人按下播放，隨機一首歌的片段就會響起，長度 5 到 30 秒自己選。沒有歌名、沒有封面，只有聲音。",
+  },
+  {
+    num: "04",
+    title: "搶答計分",
+    desc: "大家直接喊出答案，主持人點一下最先答對的人。計分板會一路累積到分出勝負。",
+  },
+];
+
+const FEATURES = [
+  { emoji: "🔓", title: "免登入", desc: "不用 Spotify 帳號、不用註冊，打開網頁就能開始。" },
+  { emoji: "🎧", title: "任何公開歌單", desc: "KTV 熱門、韓團、八零年代金曲，只要是公開歌單都能用。" },
+  { emoji: "🔀", title: "混合歌單模式", desc: "每個人丟自己的歌單，合併成一池，猜猜這首是誰放的。" },
+  { emoji: "⚡", title: "零安裝", desc: "沒有要下載的東西，遊戲進度都留在你自己的瀏覽器裡。" },
+  { emoji: "🎚️", title: "難度自己調", desc: "高手玩 5 秒，輕鬆場開 30 秒。每輪要幾首也自己決定。" },
+  { emoji: "📷", title: "掃 QR Code 加入", desc: "玩家用自己的手機掃碼，就能交出自己的歌單或按鈴搶答。" },
+];
+
+const FAQS: { q: string; a: string }[] = [
+  {
+    q: "猜歌遊戲怎麼玩？",
+    a: "一個人當主持人、用一個螢幕就好。貼上公開的 Spotify 歌單、輸入大家的名字，遊戲會播放隨機一首歌 5 到 30 秒的片段。所有人直接喊出答案，主持人點一下最先答對的人：答對歌名 3 分，再答出專輯名多 1 分。",
+  },
+  {
+    q: "需要 Spotify 帳號或登入嗎？",
+    a: "不用。GuessSong 完全不需要登入，也沒有帳號要註冊。它只會讀取公開歌單的曲目清單，然後播放每首歌的試聽片段。",
+  },
+  {
+    q: "要錢嗎？",
+    a: "完全免費，而且是開源專案。沒有東西要安裝、沒有東西要付費，直接在瀏覽器裡跑。",
+  },
+  {
+    q: "幾個人可以玩？",
+    a: "一個螢幕圍得下幾個人就幾個人。主持人控制音樂和計分板，其他人負責聽和搶答。也可以開啟搶答器模式，讓玩家用自己的手機按鈴搶答。",
+  },
+  {
+    q: "可以每個人都用自己的歌單嗎？",
+    a: "可以，那就是混合歌單模式。每個人交出自己的歌單，GuessSong 會合併成一池並去掉重複的歌，猜中「這首是誰放的」還能加分。",
+  },
+  {
+    q: "為什麼有些歌沒有聲音？",
+    a: "Spotify 在 2024 年底停止提供大部分歌曲的試聽片段，所以 GuessSong 會改去 iTunes 和 Deezer 找。少數歌曲在哪裡都找不到片段就會被跳過，選擇主流一點的歌單通常效果最好。",
+  },
+];
+
+function SpotifyIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20" aria-hidden>
+      <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
+    </svg>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18" aria-hidden>
+      <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+    </svg>
+  );
+}
+
+export default function ZhPage() {
+  const jsonLd = [
+    {
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      inLanguage: "zh-TW",
+      name: "猜歌遊戲怎麼玩",
+      description: "把任何公開的 Spotify 歌單變成派對猜歌遊戲，四個步驟。",
+      step: STEPS.map((s, i) => ({
+        "@type": "HowToStep",
+        position: i + 1,
+        name: s.title,
+        text: s.desc,
+      })),
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      inLanguage: "zh-TW",
+      mainEntity: FAQS.map((f) => ({
+        "@type": "Question",
+        name: f.q,
+        acceptedAnswer: { "@type": "Answer", text: f.a },
+      })),
+    },
+  ];
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <style>{`
+        @import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Outfit:wght@300;400;500;600;700&display=swap');
+
+        :root {
+          --green: #1DB954;
+          --bg: #111111;
+          --surface: #1a1a1a;
+          --surface2: #222222;
+          --border: #2a2a2a;
+          --text: #f0f0f0;
+          --muted: #777;
+        }
+
+        body { background: var(--bg); font-family: 'Outfit', sans-serif; color: var(--text); }
+
+        /* Bebas Neue has no CJK glyphs, so Chinese headings fall back to the
+           system CJK face. Weight carries the hierarchy instead of the display
+           font. */
+        .zh-hero-title {
+          font-size: clamp(2.4rem, 7vw, 4.2rem);
+          font-weight: 700;
+          letter-spacing: 0.04em;
+          line-height: 1.15;
+          background: linear-gradient(135deg, #ffffff 0%, #aaffc8 40%, #1DB954 100%);
+          -webkit-background-clip: text;
+          -webkit-text-fill-color: transparent;
+          background-clip: text;
+        }
+        .zh-section-title {
+          font-size: clamp(1.4rem, 3.4vw, 2rem);
+          font-weight: 700;
+          letter-spacing: 0.03em;
+          line-height: 1.3;
+          color: var(--text);
+        }
+        .zh-eyebrow {
+          font-size: 12px;
+          font-weight: 600;
+          letter-spacing: 0.14em;
+          color: var(--green);
+        }
+        .zh-lede {
+          color: #999;
+          font-size: 16px;
+          font-weight: 300;
+          line-height: 1.85;
+          max-width: 540px;
+          margin: 16px auto 0;
+        }
+
+        .card {
+          background: var(--surface);
+          border: 1px solid var(--border);
+          border-radius: 16px;
+        }
+
+        .cta-primary {
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+          padding: 14px 28px;
+          background: var(--green);
+          color: #000;
+          font-size: 16px;
+          font-weight: 700;
+          border-radius: 12px;
+          text-decoration: none;
+          letter-spacing: 0.03em;
+          transition: background 0.15s, transform 0.1s, box-shadow 0.15s;
+          box-shadow: 0 4px 24px rgba(29,185,84,0.3);
+        }
+        .cta-primary:hover {
+          background: #1ed760;
+          box-shadow: 0 4px 32px rgba(29,185,84,0.5);
+          transform: translateY(-1px);
+        }
+        .cta-secondary {
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+          padding: 14px 28px;
+          background: var(--surface2);
+          color: var(--text);
+          font-size: 16px;
+          font-weight: 600;
+          border: 1.5px solid var(--border);
+          border-radius: 12px;
+          text-decoration: none;
+          transition: border-color 0.15s, transform 0.1s, background 0.15s;
+        }
+        .cta-secondary:hover {
+          border-color: var(--green);
+          background: rgba(29,185,84,0.06);
+          transform: translateY(-1px);
+        }
+
+        .step-card { display: flex; gap: 18px; align-items: flex-start; padding: 22px 24px; }
+        .step-num {
+          font-family: 'Bebas Neue', sans-serif;
+          font-size: 34px;
+          line-height: 1;
+          color: var(--green);
+          opacity: 0.9;
+          flex-shrink: 0;
+          width: 44px;
+        }
+        .step-title { font-size: 17px; font-weight: 600; color: var(--text); margin-bottom: 6px; }
+        .step-desc { font-size: 14px; color: #999; line-height: 1.85; font-weight: 300; }
+
+        .feature-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 12px; }
+        .feature-card { padding: 20px; }
+        .feature-emoji { font-size: 24px; margin-bottom: 10px; }
+        .feature-title { font-size: 15px; font-weight: 600; color: var(--text); margin-bottom: 6px; }
+        .feature-desc { font-size: 13px; color: #999; line-height: 1.8; font-weight: 300; }
+
+        .score-row { display: flex; align-items: center; gap: 14px; padding: 16px 20px; }
+        .score-pts {
+          font-family: 'Bebas Neue', sans-serif;
+          font-size: 28px;
+          line-height: 1;
+          color: var(--green);
+          flex-shrink: 0;
+          width: 58px;
+        }
+        .score-label { font-size: 14px; color: #ccc; line-height: 1.75; font-weight: 300; }
+        .score-label strong { color: var(--text); font-weight: 600; }
+
+        .faq-q { font-size: 15px; font-weight: 600; color: var(--text); margin-bottom: 6px; }
+        .faq-a { font-size: 14px; color: #999; line-height: 1.85; font-weight: 300; }
+
+        .link-btn {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          padding: 8px 16px;
+          border-radius: 999px;
+          border: 1.5px solid rgba(29,185,84,0.35);
+          background: rgba(29,185,84,0.06);
+          color: var(--green);
+          font-size: 13px;
+          font-weight: 600;
+          text-decoration: none;
+          transition: border-color 0.15s, background 0.15s;
+        }
+        .link-btn:hover { border-color: var(--green); background: rgba(29,185,84,0.12); }
+
+        .noise-overlay {
+          position: fixed;
+          inset: 0;
+          pointer-events: none;
+          background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+          opacity: 0.025;
+        }
+      `}</style>
+
+      <div className="noise-overlay" aria-hidden />
+
+      {/* The root layout owns <html lang="en">, so scope the language here.
+          hreflang in metadata is what Google actually keys off. */}
+      <main
+        lang="zh-Hant-TW"
+        style={{
+          minHeight: "100vh",
+          display: "flex",
+          justifyContent: "center",
+          padding: "72px 20px 48px",
+          position: "relative",
+        }}
+      >
+        <div style={{ width: "100%", maxWidth: "760px", display: "flex", flexDirection: "column", gap: "72px" }}>
+
+          <header style={{ textAlign: "center" }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: "10px", marginBottom: "14px" }}>
+              <span style={{ color: "#1DB954", display: "inline-flex" }}>
+                <SpotifyIcon />
+              </span>
+              <span style={{ fontSize: "13px", fontWeight: 500, color: "#777", letterSpacing: "0.08em" }}>
+                免費開源派對遊戲
+              </span>
+            </div>
+            <h1 className="zh-hero-title">猜歌遊戲</h1>
+            <p className="zh-lede">
+              貼上任何公開的 Spotify 歌單，播放一小段音樂，大家搶答歌名。
+              不用登入、不用下載 App，一個螢幕加一群人就能開始。
+            </p>
+            <div style={{ display: "flex", gap: "12px", justifyContent: "center", flexWrap: "wrap", marginTop: "28px" }}>
+              <Link href="/" className="cta-primary">開始遊戲 →</Link>
+              {/* Points at "/" to match the en hreflang above — a switcher that
+                  disagrees with the annotation is a mixed signal. */}
+              <Link href="/" hrefLang="en" className="cta-secondary">English</Link>
+            </div>
+          </header>
+
+          <section>
+            <p className="zh-eyebrow" style={{ marginBottom: "10px" }}>怎麼玩</p>
+            <h2 className="zh-section-title" style={{ marginBottom: "24px" }}>從歌單到開場，三十秒</h2>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))", gap: "12px" }}>
+              {STEPS.map((step) => (
+                <div key={step.num} className="card step-card">
+                  <span className="step-num">{step.num}</span>
+                  <div>
+                    <p className="step-title">{step.title}</p>
+                    <p className="step-desc">{step.desc}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <p className="zh-eyebrow" style={{ marginBottom: "10px" }}>新功能 · 多人</p>
+            <h2 className="zh-section-title" style={{ marginBottom: "14px" }}>混合歌單模式 🔀</h2>
+            <p className="step-desc" style={{ maxWidth: "560px", marginBottom: "20px" }}>
+              不用只放一個人的歌單。每個人交出自己的歌單，GuessSong 會合併成一池、
+              去掉重複的歌，然後變成一場品味大戰：你分得出這首是誰放的嗎？
+              遊戲結束還能下載一張「品味卡」，看看大家的共同愛歌，以及誰的品味最冷門、誰最主流。
+            </p>
+          </section>
+
+          <section>
+            <p className="zh-eyebrow" style={{ marginBottom: "10px" }}>計分</p>
+            <h2 className="zh-section-title" style={{ marginBottom: "14px" }}>主持人就是裁判</h2>
+            <p className="step-desc" style={{ maxWidth: "560px", marginBottom: "20px" }}>
+              不用打字、不用跟自動選字吵架。玩家直接喊出答案，主持人點一下最先答對的人。
+            </p>
+            <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+              <div className="card score-row">
+                <span className="score-pts">+3</span>
+                <span className="score-label"><strong>歌名。</strong>第一個喊出歌名的人拿大分。</span>
+              </div>
+              <div className="card score-row">
+                <span className="score-pts">+1</span>
+                <span className="score-label"><strong>專輯名。</strong>連專輯都知道的鐵粉加分。</span>
+              </div>
+              <div className="card score-row">
+                <span className="score-pts">+2</span>
+                <span className="score-label"><strong>這是誰的歌單？</strong>混合歌單模式限定，猜中是誰放的再加分。</span>
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <p className="zh-eyebrow" style={{ marginBottom: "10px" }}>為什麼用 GuessSong</p>
+            <h2 className="zh-section-title" style={{ marginBottom: "24px" }}>為了聚會而做，不是為了收帳號</h2>
+            <div className="feature-grid">
+              {FEATURES.map((f) => (
+                <div key={f.title} className="card feature-card">
+                  <div className="feature-emoji" aria-hidden>{f.emoji}</div>
+                  <p className="feature-title">{f.title}</p>
+                  <p className="feature-desc">{f.desc}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <p className="zh-eyebrow" style={{ marginBottom: "10px" }}>常見問題</p>
+            <h2 className="zh-section-title" style={{ marginBottom: "24px" }}>大家最常問的</h2>
+            <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
+              {FAQS.map((faq) => (
+                <div key={faq.q}>
+                  <h3 className="faq-q">{faq.q}</h3>
+                  <p className="faq-a">{faq.a}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section style={{ textAlign: "center" }}>
+            <h2 className="zh-section-title" style={{ marginBottom: "14px" }}>準備好開場了嗎？</h2>
+            <p className="step-desc" style={{ maxWidth: "420px", margin: "0 auto 24px" }}>
+              GuessSong 免費且開源。如果它讓你的聚會更好玩，去 GitHub 給一顆星是最好的道謝方式。
+            </p>
+            <div style={{ display: "flex", gap: "12px", justifyContent: "center", flexWrap: "wrap" }}>
+              <Link href="/" className="cta-primary">開始遊戲 →</Link>
+              <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer" className="cta-secondary">
+                <span style={{ color: "#ffd75e", display: "inline-flex" }}><GitHubIcon /></span>
+                在 GitHub 給星
+              </a>
+            </div>
+          </section>
+
+          <footer style={{ textAlign: "center", paddingTop: "20px", borderTop: "1px solid var(--border)" }}>
+            <a href={REPORT_PROBLEM_MAILTO} className="link-btn">回報問題</a>
+          </footer>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify-guess-web",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 8000",


### PR DESCRIPTION
## Why

The site ranks for the brand string `guessong` and essentially nothing else. That query is only typed by people who already know the site, so it converts existing users rather than finding new ones. Three things caused it:

1. **The `keywords` meta tag was doing nothing.** Google has ignored it since 2009. All 22 entries were dead weight.
2. **The homepage had ~50 crawlable words.** It's a setup form. There was no prose for Google to match `guess the song game` against, so the brand string was the only thing that could rank.
3. **`<h1>` was brand-only** on both indexable pages, and `/about`'s title didn't contain the phrase either.

## What changed

**Homepage content — the biggest lever.** Added a "What is GuessSong?" section and six FAQs. 50 words → 588. It reads as help for a first-time visitor, not keyword filler, and the FAQs double as `FAQPage` JSON-LD generated from the same array the page renders.

**Traditional Chinese landing page at `/zh`.** English head terms are a red ocean of Heardle clones. The Chinese equivalents are not, and the audience is already here — the hero has carried a Chinese line since launch. Written natively, not translated. Its `<h1>` is the keyword itself (`猜歌遊戲`) rather than the brand, because unlike `/` it has no brand identity to protect. The homepage's Chinese hero line is now the crawl path into it, so the keyword is the anchor text instead of sitting next to it.

**Headings.** Hero tagline `<p>` → `<h2>` on `/` and `/about`. The `<h1>` stays `GuessSong` and the hero is visually unchanged — verified by screenshot at 1280px and 375px.

**hreflang** across `/` and `/zh` (`en`, `zh-TW`, `x-default`), in both `<link>` tags and `sitemap.xml`. Both URLs carry the full annotation set, and the visible language switcher on `/zh` points at `/` to match what the annotation claims.

**`HowTo` schema on `/about`**, generated from the existing `STEPS` array so it can't drift from the rendered page.

**`robots.txt`:** disallow `/buzz` and `/j` — ephemeral room codes that 404 once the room's TTL expires.

## Verification

- `npm run lint` clean, `npm test` 160/160, `npm run build` succeeds
- Prerendered HTML checked for title, canonical, hreflang reciprocity, heading structure, and JSON-LD types on `/`, `/about`, `/zh`
- Homepage word count 50 → 588; `/zh` at 1030 CJK characters
- Screenshots at 1280×900 and 375×812, no console errors

## Known gaps

- The root layout owns `<html lang="en">` and Next.js only lets the root layout render `<html>`, so `/zh` scopes its language with `lang="zh-Hant-TW"` on `<main>`. `hreflang` is what Google keys off so ranking is unaffected, but a screen reader checking only the root element reads the page with an English voice. The proper fix is moving every route into a `(lang)` route group with per-locale root layouts.
- `/about` is deliberately outside the hreflang cluster — `/zh` covers that content, and pointing `/about` at a page that isn't its translation is a worse signal than omitting it.
- `/zh` duplicates ~200 lines of CSS from `app/about/page.tsx`. That matches the per-page `<style>` block convention, but a third page in this style is where the shared rules should be extracted.

## Before merging

Check that Vercel's `NEXT_PUBLIC_BASE_URL` is either unset or `https://www.guessong.app`. Canonical URLs, hreflang targets, and `sitemap.xml` all derive from it, so a wrong value there propagates to every annotation this PR adds.

## After deploying

Submit `/`, `/about`, and `/zh` for indexing in Search Console, and validate the FAQ and HowTo schema with the Rich Results Test.

Realistic expectation: `guess the song` won't move — Heardle clones own it. The wins to watch for are long-tail English (`guess the song game with spotify playlist`) and Chinese (`猜歌遊戲`), typically showing up in Search Console impressions over 2–6 weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)