### PR TITLE
fix: stop /api/playlist exhausting Spotify's shared quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`429 QUOTA_EXCEEDED` from Spotify on `/api/playlist`.** Nothing anywhere cached a playlist: `getPlaylistWithTracks` went to the network on every single call, so the same URL re-paginated in full on every host retry, every room submit, and for every player in a room who pasted the same link. Meanwhile Spotify's quota is per *client id* — one budget shared by the whole user base — while every limiter in `lib/rate-limit.ts` is keyed by IP, so N phones each got a fresh allowance against it. Five compounding causes, fixed together:
+  - **`lib/playlist-cache.ts` (new)** — KV cache keyed by playlist id, 6h on a hit. A repeat load now costs zero upstream calls. Reads and writes are wrapped so a KV outage degrades to "slower", never "broken", the same contract `app/api/preview/route.ts` follows. This is not a reversal of the token cache's deliberate no-KV decision (`lib/spotify.ts`): a token has no fallback, a playlist does.
+  - **In-flight coalescing** in the same module. One Mixed-mode Start fires a request per contributor and a QR room gets a burst of simultaneous submits; duplicate URLs in either used to mean duplicate pagination, because the cache write lands too late to help its own siblings.
+  - **A 429 cooldown**, in KV so every lambda instance sees it. Without it a throttled window is self-sustaining — every host sees an error, every host retries, the retries keep the quota pinned. One 429 now parks all *uncached* loads for the duration Spotify asked for (clamped to 30s–15min); cached playlists keep serving, so a party already mid-game is unaffected by someone else's throttling.
+  - **A proactive global budget** (`SPOTIFY_MAX_LOADS_PER_MINUTE`, default 40), a KV `incr` counter shared across instances. The cooldown above is reactive — it only helps once Spotify has already refused something. This is the half that stops us getting there: a spike, a scripted client, or a dozen rooms starting at once is refused here rather than spending the quota to find out. Counted in *loads*, not requests; one cold load is 1 metadata call plus up to 5 track pages, so the default works out to roughly 240 upstream requests a minute. Fails **open** on a KV error — losing the safety net has to mean "back to how it was", not "nobody can play".
+  - **`limit=50` → `limit=100`** in `fetchPlaylistTracks`, Spotify's documented maximum. Every playlist was costing exactly twice the requests it needed to.
+  - **`MAX_PLAYLIST_TRACKS = 500`**, replacing an unbounded `while (data.next)` loop. A 4,000-track playlist was 40 upstream requests for a game that then plays at most 50 of them.
+
+### Added
+
+- **Random sampling for oversized playlists.** A playlist longer than `MAX_PLAYLIST_TRACKS` is no longer read front-to-back: the first page reports the real length, and the rest of the page budget goes on randomly chosen pages spread across the whole playlist. Taking the first 500 of a 4,000-track playlist would mean the same songs every single game, and whatever the owner happened to add first. Sampling is by *page* rather than by track, because a page is what a request buys and sampling finer would cost more requests — the one thing this whole change exists to avoid. Page 0 is always among the candidates, since reading it is how the length is discovered, so the first 100 tracks are slightly over-represented; everything after them is uniform. Playlists that fit are still read whole and in order.
+  - Sampled entries cache for 1h rather than 6h. The TTL is also how long everyone is stuck with the same draw, and six hours of it would undo the point of sampling.
+  - `shuffle()` is Fisher-Yates. `Array#sort` with a random comparator, which the setup page still uses for its own shuffle, is not a uniform permutation.
+- **Cache hit-rate instrumentation.** Hit/miss counters in KV, bucketed by day, held a week, readable via `getCacheStats()`. The running rate is logged on every *miss* rather than every load: once the cache is working, misses are the rare case, so the instrumentation gets quieter exactly as things get healthier and a sudden run of lines is itself the signal. Previously "did this work" could only be answered by the absence of 429s, which is indistinguishable from a quiet evening.
+
+### Changed
+
+- `getPlaylistWithTracks` ties its two concurrent calls to an `AbortController`. `Promise.all` rejects on the first failure and the route returns, but the losing half used to keep paginating afterwards — spending quota on a request nobody was waiting for, and emitting `console.error` with no request context. That is the whole explanation for "Spotify tracks fetch error" appearing under `/api/preview` in the production logs; `/api/preview` never called Spotify at all.
+- `/api/playlist` returns **429 and 404 as themselves** instead of flattening every upstream failure into `400 + message`, and sets `Retry-After` on a 429. The client could not previously tell "your playlist is wrong" from "we are throttled", so the UI told throttled hosts to check their URL was public — sending them straight back into retrying against a spent quota. The 429 message now says the URL is fine and gives a wait.
+- `submitToRoom` runs the duplicate-name and room-full checks against the record it already holds *before* fetching the playlist. Those rejections used to cost a full pagination and then answer 409. The authoritative re-check inside the write loop is unchanged; both now share `assertCanJoin`.
+- Mixed mode's Start button loads contributor playlists two at a time (`MIXED_FETCH_CONCURRENCY`) instead of all 12 at once, and reports a 429 as a wait rather than as "remove or fix" the contributor's playlist.
+- `/api/playlist` responses no longer carry `rawJson`. Every consumer already dropped it via `stripTrackForStorage`; keeping it made cache entries and response bodies roughly an order of magnitude larger than they needed to be.
+
+### Known gaps
+
+- `SPOTIFY_MAX_LOADS_PER_MINUTE`'s default of 40 is a guess. The right value depends on which quota tier the Spotify app is on, which the code cannot find out — hence the env var. Watch the hit-rate log for a week and tune.
+- The global budget is a fixed window, so it can pass up to 2× the limit across a window boundary, same caveat as `lib/rate-limit.ts`. Acceptable: the cooldown catches the overshoot.
+- `MAX_PLAYLIST_TRACKS` makes "All" mean "a random 500". Invisible for any playlist a party would realistically use, but it is a real behaviour change, and `truncated` is returned but not yet surfaced anywhere in the UI — a host with a 4,000-track playlist gets no indication they're playing a sample.
+- Hit rate is logged and readable in-process but has no endpoint, so checking it means grepping Vercel logs. Deliberate: an endpoint would need an auth story for what is currently a two-line grep.
+
 ## [1.0.0] - 2026-07-30
 
 The 1.0 line is drawn here rather than at a feature: the party game, Buzzer Mode,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,23 @@ There *is* server-side storage, but it is deliberately narrow: a KV layer (`lib/
 
 **Every route is IP rate limited** via `lib/rate-limit.ts` (fixed window on top of `lib/kv.ts`'s atomic `incr`). When adding a route, follow the existing pattern: module-level `X_LIMIT` / `X_WINDOW_SECONDS` constants, then `rateLimit()` → 429 before any expensive work.
 
-Two caches keep upstream request volume flat as traffic grows, both of which matter because serverless egress IPs are shared and upstream APIs throttle per IP:
-- **Preview cache** (`app/api/preview/route.ts`) — KV, keyed by Spotify track id. Hits live 30 days, misses 7. Caching misses is the point: tracks with no preview anywhere are the most repeatedly queried, and each uncached miss costs 5 upstream calls.
-- **Spotify token cache** (`lib/spotify.ts`) — module scope, so per-lambda-instance rather than global. Deliberately *not* in KV, so `/api/playlist` keeps zero KV dependency and can't be taken down by an Upstash outage. A 401 clears the cache and retries once.
+Three caches keep upstream request volume flat as traffic grows:
+- **Preview cache** (`app/api/preview/route.ts`) — KV, keyed by Spotify track id. Hits live 30 days, misses 7. Caching misses is the point: tracks with no preview anywhere are the most repeatedly queried, and each uncached miss costs 5 upstream calls. Matters because serverless egress IPs are shared and iTunes/Deezer throttle per IP.
+- **Playlist cache** (`lib/playlist-cache.ts`) — KV, keyed by playlist id. 6h on a full playlist, 1h on a sampled one. **Every caller must go through `loadPlaylist`, never `getPlaylistWithTracks` directly** — a single uncached path is enough to put the shared quota back at risk.
+- **Spotify token cache** (`lib/spotify.ts`) — module scope, so per-lambda-instance rather than global. Deliberately *not* in KV: a token is the one thing with no fallback, so a KV outage on that path would take down playlist loading entirely. A 401 clears the cache and retries once.
+
+### Spotify's quota is per app, not per IP
+
+This is the constraint the whole playlist path is shaped around, and it is the opposite of how `lib/rate-limit.ts` works. Spotify throttles on the **client id**, so every visitor shares one budget, while every route limiter is keyed by IP and hands each new visitor a fresh allowance. Per-IP limits bound one abusive client; they do nothing about aggregate load. `lib/playlist-cache.ts` is what bounds the aggregate, in three layers:
+
+- **Cache** — a repeat playlist costs zero upstream calls.
+- **In-flight coalescing** — concurrent loads of the same playlist collapse into one fetch, per lambda instance. Mixed mode fires one request per contributor from one click, and a QR room gets a burst of simultaneous submits; the cache write lands too late to help those siblings.
+- **Global budget** (`SPOTIFY_MAX_LOADS_PER_MINUTE`) — a KV `incr` counter shared across instances, refusing new playlists *before* Spotify does. Fails open on a KV error: losing the safety net must mean "back to how it was", not "nobody can play".
+- **429 cooldown** — when Spotify does refuse, all uncached loads are parked for `Retry-After` (clamped 30s–15min), in KV so every instance sees it. Without this a throttled window is self-sustaining: every host errors, every host retries, the retries keep the quota pinned. Cached playlists keep serving throughout, so a party mid-game is unaffected by someone else's throttling.
+
+Two rules that follow from this, and are easy to undo by accident:
+- **Never flatten an upstream 429 into a generic 400.** The client has to be able to tell "your playlist is wrong" from "we are throttled" — the original bug told throttled hosts to check their URL was public, which sent them straight back into retrying.
+- **`fetchPlaylistTracks` reads at most `MAX_PLAYLIST_TRACKS` (500), sampling random pages when a playlist is bigger.** Following `next` unbounded made one big playlist cost 40+ requests for a game that plays at most 50 songs. Cache hit rate is logged on every miss (`[playlist-cache] miss … rate=…`) and readable via `getCacheStats()`.
 
 ### Scoring
 
@@ -61,6 +75,7 @@ SPOTIFY_CLIENT_ID / SPOTIFY_CLIENT_SECRET   # Required — Client Credentials on
 UPSTASH_REDIS_REST_URL / _TOKEN             # Required in production — see below
 NEXT_PUBLIC_BASE_URL                        # Optional — defaults to https://www.guessong.app
 NEXT_PUBLIC_GA_MEASUREMENT_ID               # Optional — enables GA4
+SPOTIFY_MAX_LOADS_PER_MINUTE                # Optional — global upstream ceiling, default 40
 ```
 
 Without the Upstash pair, `lib/kv.ts` falls back to an in-process `Map`. That is fine for `next dev` and tests, but **not** for multi-instance serverless deploys: rooms created by one lambda would be invisible to another, rate limit counters would reset per instance, and the preview cache would lose most of its hit rate.

--- a/app/api/playlist/route.ts
+++ b/app/api/playlist/route.ts
@@ -1,13 +1,29 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getPlaylistWithTracks } from "@/lib/spotify";
+import { loadPlaylist } from "@/lib/playlist-cache";
+import { SpotifyApiError } from "@/lib/spotify";
 import { enforceRateLimit } from "@/lib/rate-limit";
 
-// The most expensive route we have: one playlist load pages through every
-// track (50 per request), so a 500-track playlist is 10+ upstream calls.
-// Generous enough for a host trying several playlists back to back, tight
-// enough that it can't be used to burn the Spotify quota.
+// Still the most expensive route we have, but no longer unbounded: loads go
+// through lib/playlist-cache.ts, so a repeat of the same playlist costs zero
+// upstream calls and a cold one is capped at MAX_PLAYLIST_TRACKS.
+//
+// Note this limit is per IP while Spotify's quota is per app — it bounds one
+// abusive client, not the site. The cache and the cooldown in playlist-cache
+// are what bound the aggregate.
 const PLAYLIST_LIMIT = 30;
 const PLAYLIST_WINDOW_SECONDS = 10 * 60;
+
+/**
+ * Upstream failures used to be flattened into `400 + message`, which meant the
+ * client could not tell "your playlist is wrong" from "we are throttled" — so
+ * the UI told throttled hosts to check their URL, and they retried into an
+ * already-spent quota. Pass the meaningful statuses through instead.
+ */
+function statusFor(err: unknown): number {
+  if (!(err instanceof SpotifyApiError)) return 400;
+  if (err.status === 429 || err.status === 404) return err.status;
+  return 400;
+}
 
 export async function POST(req: NextRequest) {
   const limited = await enforceRateLimit(
@@ -27,7 +43,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Missing playlist URL" }, { status: 400 });
     }
 
-    const { playlist, tracks } = await getPlaylistWithTracks(url);
+    const { name, tracks, totalTracks, truncated } = await loadPlaylist(url);
 
     if (tracks.length < 1) {
       return NextResponse.json(
@@ -36,14 +52,17 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    return NextResponse.json({
-      name: playlist.name,
-      tracks,
-      totalTracks: tracks.length,
-    });
+    return NextResponse.json({ name, tracks, totalTracks, truncated });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : "Failed to fetch playlist";
-    console.error("[/api/playlist]", message);
-    return NextResponse.json({ error: message }, { status: 400 });
+    const status = statusFor(err);
+    console.error("[/api/playlist]", status, message);
+
+    const headers =
+      err instanceof SpotifyApiError && err.status === 429 && err.retryAfterSeconds
+        ? { "Retry-After": String(Math.ceil(err.retryAfterSeconds)) }
+        : undefined;
+
+    return NextResponse.json({ error: message }, { status, headers });
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,48 @@ const SONG_COUNTS: (number | "all")[] = [10, 20, 30, 50, "all"];
 const MIXED_SAMPLE_COUNTS = [5, 8, 10, 12];
 const MIXED_MIN_CONTRIBUTORS = 2;
 
+/**
+ * How many /api/playlist loads Mixed mode has in flight at once.
+ *
+ * One Start click fans out to one request per contributor — up to 12 — and
+ * each of those pages through a playlist against a Spotify quota shared by the
+ * entire site. Firing them all simultaneously is what put three POSTs inside
+ * the same second in the production logs. Two at a time keeps the wall-clock
+ * respectable while giving the server-side cache a chance to be warm for the
+ * later ones, which matters whenever two friends contribute the same playlist.
+ */
+const MIXED_FETCH_CONCURRENCY = 2;
+
+/**
+ * Promise.allSettled with a ceiling on how many run at once. Results stay in
+ * input order, because the caller maps rejections back to contributor names by
+ * index to build its error message.
+ */
+async function settleWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<R>
+): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = new Array(items.length);
+  let next = 0;
+
+  async function run(): Promise<void> {
+    while (next < items.length) {
+      const index = next++;
+      try {
+        results[index] = { status: "fulfilled", value: await worker(items[index], index) };
+      } catch (reason) {
+        results[index] = { status: "rejected", reason };
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => run())
+  );
+  return results;
+}
+
 // Rendered on the page *and* emitted as FAQPage JSON-LD below — keep the two
 // in sync, Google penalises schema that doesn't match visible content.
 const FAQS: { q: string; a: string }[] = [
@@ -298,18 +340,42 @@ export default function SetupPage() {
     setLoading(true);
     trackEvent("playlist_submitted", { playlist_source: "mixed" });
     try {
-      const results = await Promise.allSettled(
-        mixedContributions.map(async (c) => {
+      const results = await settleWithConcurrency(
+        mixedContributions,
+        MIXED_FETCH_CONCURRENCY,
+        async (c) => {
           const res = await fetch("/api/playlist", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ url: c.playlistUrl }),
           });
           const data = await res.json();
-          if (!res.ok) throw new Error(data.error || "Failed to load playlist");
+          if (!res.ok) {
+            const err = new Error(data.error || "Failed to load playlist");
+            // Carried so the summary below can tell "this playlist is broken"
+            // apart from "Spotify is throttling the whole site".
+            (err as Error & { status?: number }).status = res.status;
+            throw err;
+          }
           return { playerName: c.name, tracks: data.tracks as Track[] };
-        })
+        }
       );
+
+      // A 429 is not the contributor's fault, and telling someone to "remove
+      // or fix" a perfectly good playlist sends them straight back to retrying,
+      // which is what keeps the shared quota spent. Surface the wait instead.
+      const throttled = results.find(
+        (r): r is PromiseRejectedResult =>
+          r.status === "rejected" &&
+          (r.reason as { status?: number } | undefined)?.status === 429
+      );
+      if (throttled) {
+        throw new Error(
+          throttled.reason instanceof Error
+            ? throttled.reason.message
+            : "Spotify is rate limiting us right now. Please try again in a minute."
+        );
+      }
 
       const failedNames = results
         .map((r, i) => (r.status === "rejected" ? mixedContributions[i].name : null))

--- a/lib/playlist-cache.ts
+++ b/lib/playlist-cache.ts
@@ -1,0 +1,396 @@
+/**
+ * Cache and admission control in front of Spotify playlist loads.
+ *
+ * Spotify's client-credentials quota is per *app*, not per user or per IP.
+ * Every rate limiter in this codebase is keyed by IP (lib/rate-limit.ts), so
+ * N players from N phones each got a fresh allowance against one shared
+ * upstream budget — and nothing anywhere cached a playlist. The same URL
+ * re-paginated in full on every submit, every retry, and every player in a
+ * room who happened to paste the same link. That is what produced
+ * `429 QUOTA_EXCEEDED`.
+ *
+ * Three layers, cheapest first:
+ *
+ *   loadPlaylist ─→ KV cache ─────── hit ──→ return (zero upstream calls)
+ *                       │ miss
+ *                       ├─ in-flight map ── hit ──→ await the existing fetch
+ *                       │ miss
+ *                       ├─ cooldown gate ── open ─→ throw 429 immediately
+ *                       │ closed
+ *                       └─ Spotify ─→ store ─→ return
+ *
+ * The cooldown is the layer that actually lets the quota recover. Without it
+ * a throttled window is self-sustaining: every host sees an error, every host
+ * retries, and the retries keep the quota pinned. One 429 from Spotify parks
+ * *all* uncached loads for the duration it asked for.
+ *
+ * Every KV call is wrapped. A cache outage must degrade to "slower", never to
+ * "broken" — same contract as app/api/preview/route.ts, which this follows.
+ */
+
+import { getKvStore } from "@/lib/kv";
+import {
+  getPlaylistWithTracks,
+  isSpotifyEditorial,
+  parsePlaylistUrl,
+  SpotifyApiError,
+} from "@/lib/spotify";
+import { stripTrackForStorage } from "@/lib/game-session";
+import type { Track } from "@/types";
+
+/**
+ * Bump when the cached shape changes. Entries are TTL'd rather than migrated,
+ * so an old-shape read would otherwise be handed to callers as a valid hit.
+ */
+const CACHE_VERSION = "v1";
+
+/**
+ * Long enough that a party spends zero upstream requests after the first load
+ * — including the host reloading, re-pasting, or every player in a room
+ * submitting the same popular playlist — and short enough that a host who adds
+ * songs mid-afternoon sees them tonight.
+ */
+const HIT_TTL_SECONDS = 6 * 60 * 60;
+
+/**
+ * Shorter, for playlists too big to read whole. Those are cached as a *random
+ * sample* of MAX_PLAYLIST_TRACKS, so the TTL is also how long everyone is
+ * stuck with the same draw. Six hours would mean a 4,000-track playlist plays
+ * the same 500 songs all evening, which is the thing sampling exists to avoid;
+ * an hour still absorbs a party's worth of retries and reloads.
+ */
+const SAMPLED_TTL_SECONDS = 60 * 60;
+
+/**
+ * Negative caching, deliberately much shorter than the preview cache's.
+ * A 404 here usually means "public playlist, wrong link" or "the owner made it
+ * private", both of which a host fixes within minutes; caching that for days
+ * would keep telling them their fixed playlist is broken. Ten minutes is
+ * enough to absorb the burst of retries a bad paste generates.
+ */
+const NOT_FOUND_TTL_SECONDS = 10 * 60;
+
+const COOLDOWN_KEY = "spotify:cooldown";
+
+/**
+ * Proactive ceiling on how many playlist loads the *whole site* sends upstream
+ * per minute, shared across lambda instances via KV's atomic incr.
+ *
+ * The cooldown below is reactive — it only helps once Spotify has already
+ * refused something. This is the half that stops us reaching that point: a
+ * traffic spike, a scripted client, or a dozen rooms starting at once gets
+ * refused here rather than spending the app's quota to find out.
+ *
+ * The number is in *loads*, not requests. One cold load costs 1 metadata call
+ * plus up to MAX_TRACK_PAGES track pages, so the default 40 works out to a
+ * ceiling of roughly 240 upstream requests a minute. Cache hits never reach
+ * here, so this bounds genuinely-new playlists only. Env-overridable because
+ * the right value depends on which quota tier the Spotify app is on, and that
+ * is not something the code can find out.
+ */
+const GLOBAL_LOAD_WINDOW_SECONDS = 60;
+const DEFAULT_GLOBAL_LOAD_LIMIT = 40;
+const BUDGET_KEY = "spotify:budget";
+
+/**
+ * Spotify's Retry-After on QUOTA_EXCEEDED is sometimes enormous (hours) and
+ * sometimes absent. Clamp both ends: never park the whole site for longer than
+ * a party would wait, never hammer straight back into a spent quota either.
+ */
+const MIN_COOLDOWN_SECONDS = 30;
+const MAX_COOLDOWN_SECONDS = 15 * 60;
+const DEFAULT_COOLDOWN_SECONDS = 60;
+
+export interface LoadedPlaylist {
+  name: string;
+  tracks: Track[];
+  totalTracks: number;
+  /** True when the playlist is longer than MAX_PLAYLIST_TRACKS. */
+  truncated: boolean;
+}
+
+type CacheEntry =
+  | { kind: "hit"; name: string; tracks: Track[]; truncated: boolean }
+  | { kind: "missing"; message: string; status: number };
+
+function cacheKey(playlistId: string): string {
+  return `playlist:${CACHE_VERSION}:${playlistId}`;
+}
+
+async function readCache(playlistId: string): Promise<CacheEntry | null> {
+  try {
+    const store = await getKvStore();
+    return await store.get<CacheEntry>(cacheKey(playlistId));
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(
+  playlistId: string,
+  entry: CacheEntry,
+  ttlSeconds: number
+): Promise<void> {
+  try {
+    const store = await getKvStore();
+    await store.set(cacheKey(playlistId), entry, ttlSeconds);
+  } catch {
+    // Swallowed: the caller already has its answer, and failing the request
+    // over a cache write would turn a degraded cache into a broken game.
+  }
+}
+
+async function readCooldownUntil(): Promise<number | null> {
+  try {
+    const store = await getKvStore();
+    const entry = await store.get<{ until: number }>(COOLDOWN_KEY);
+    return typeof entry?.until === "number" ? entry.until : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Records that Spotify is throttling the app. Stored in KV rather than module
+ * scope on purpose — unlike the token cache, this is only useful if every
+ * lambda instance sees it. A per-instance cooldown would park one instance
+ * while the rest carried on spending the quota it is trying to protect.
+ */
+async function startCooldown(retryAfterSeconds?: number): Promise<number> {
+  const seconds = Math.min(
+    MAX_COOLDOWN_SECONDS,
+    Math.max(MIN_COOLDOWN_SECONDS, retryAfterSeconds ?? DEFAULT_COOLDOWN_SECONDS)
+  );
+  const until = Date.now() + seconds * 1000;
+  try {
+    const store = await getKvStore();
+    await store.set(COOLDOWN_KEY, { until }, seconds);
+  } catch {
+    // Best effort. Losing the cooldown costs us the coordinated backoff, not
+    // correctness — each request still fails on its own 429.
+  }
+  return seconds;
+}
+
+function globalLoadLimit(): number {
+  const configured = Number(process.env.SPOTIFY_MAX_LOADS_PER_MINUTE);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_GLOBAL_LOAD_LIMIT;
+}
+
+/**
+ * Claims one slot in the current minute's global budget. Returns false when
+ * the window is spent.
+ *
+ * Fails *open* on a KV error: the budget is a safety net, and losing the net
+ * has to mean "back to how it was", not "nobody can load a playlist". The
+ * cooldown still catches the resulting 429 if we overshoot.
+ */
+async function claimGlobalBudget(): Promise<boolean> {
+  try {
+    const store = await getKvStore();
+    const used = await store.incr(BUDGET_KEY, GLOBAL_LOAD_WINDOW_SECONDS);
+    return used <= globalLoadLimit();
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Hit/miss counters, bucketed by day and held for a week.
+ *
+ * Without these, "did the cache work" can only be answered by watching for the
+ * absence of 429s, which is indistinguishable from a quiet evening. The rate
+ * is logged on every miss rather than on every load: misses are the rare case
+ * once the cache is doing its job, so the instrumentation gets quieter exactly
+ * as things get healthier, and a sudden run of lines is itself the signal.
+ */
+function statsKey(kind: "hit" | "miss"): string {
+  const day = new Date().toISOString().slice(0, 10);
+  return `playlist:stats:${day}:${kind}`;
+}
+
+const STATS_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+async function recordHit(): Promise<void> {
+  try {
+    const store = await getKvStore();
+    await store.incr(statsKey("hit"), STATS_TTL_SECONDS);
+  } catch {
+    // Instrumentation must never be able to fail a request.
+  }
+}
+
+async function recordMiss(playlistId: string): Promise<void> {
+  try {
+    const store = await getKvStore();
+    const misses = await store.incr(statsKey("miss"), STATS_TTL_SECONDS);
+    const hits = (await store.get<number>(statsKey("hit"))) ?? 0;
+    const rate = hits + misses > 0 ? hits / (hits + misses) : 0;
+    console.log(
+      `[playlist-cache] miss id=${playlistId} hits=${hits} misses=${misses} rate=${rate.toFixed(3)}`
+    );
+  } catch {
+    // Instrumentation must never be able to fail a request.
+  }
+}
+
+/** Today's counters, for anything that wants to read the rate back. */
+export async function getCacheStats(): Promise<{
+  hits: number;
+  misses: number;
+  hitRate: number;
+}> {
+  const store = await getKvStore();
+  const hits = (await store.get<number>(statsKey("hit"))) ?? 0;
+  const misses = (await store.get<number>(statsKey("miss"))) ?? 0;
+  const total = hits + misses;
+  return { hits, misses, hitRate: total > 0 ? hits / total : 0 };
+}
+
+function cooldownError(secondsRemaining: number): SpotifyApiError {
+  return new SpotifyApiError(
+    `Spotify is rate limiting us right now. Try again in about ${secondsRemaining}s — your playlist URL is fine.`,
+    429,
+    secondsRemaining
+  );
+}
+
+/**
+ * Coalesces concurrent loads of the same playlist within one lambda instance.
+ *
+ * Mixed Playlist Mode fires one request per contributor from a single click,
+ * and a QR room gets a burst of submits as everyone scans at once. Duplicated
+ * URLs in either of those used to mean duplicated pagination, because the KV
+ * write only lands after the first fetch finishes — too late for its own
+ * siblings. Per-instance rather than distributed: a cross-instance lock would
+ * need a primitive lib/kv.ts doesn't have, for a shrinking share of the win
+ * now that results are cached.
+ */
+const inFlight = new Map<string, Promise<LoadedPlaylist>>();
+
+function toLoaded(entry: Extract<CacheEntry, { kind: "hit" }>): LoadedPlaylist {
+  return {
+    name: entry.name,
+    tracks: entry.tracks,
+    totalTracks: entry.tracks.length,
+    truncated: entry.truncated,
+  };
+}
+
+async function fetchAndCache(
+  playlistId: string,
+  playlistUrl: string
+): Promise<LoadedPlaylist> {
+  const cooldownUntil = await readCooldownUntil();
+  if (cooldownUntil && Date.now() < cooldownUntil) {
+    throw cooldownError(Math.ceil((cooldownUntil - Date.now()) / 1000));
+  }
+
+  if (!(await claimGlobalBudget())) {
+    throw new SpotifyApiError(
+      "Too many new playlists are being loaded across the site right now. Please try again in a minute — your playlist URL is fine.",
+      429,
+      GLOBAL_LOAD_WINDOW_SECONDS
+    );
+  }
+
+  await recordMiss(playlistId);
+
+  try {
+    const { playlist, tracks, truncated } = await getPlaylistWithTracks(playlistUrl);
+
+    // rawJson is the entire Spotify track object and nothing reads it — every
+    // consumer runs it through stripTrackForStorage before use. Dropping it
+    // here keeps cache entries (and the /api/playlist response body) roughly
+    // an order of magnitude smaller.
+    const stripped = tracks.map(stripTrackForStorage);
+
+    if (stripped.length > 0) {
+      await writeCache(
+        playlistId,
+        { kind: "hit", name: playlist.name, tracks: stripped, truncated },
+        truncated ? SAMPLED_TTL_SECONDS : HIT_TTL_SECONDS
+      );
+    }
+
+    return {
+      name: playlist.name,
+      tracks: stripped,
+      totalTracks: stripped.length,
+      truncated,
+    };
+  } catch (err) {
+    if (err instanceof SpotifyApiError && err.status === 429) {
+      const seconds = await startCooldown(err.retryAfterSeconds);
+      throw cooldownError(seconds);
+    }
+
+    // Only 404 is cached. A 429 is transient by definition and a 5xx is
+    // Spotify's problem, not this playlist's — caching either would make a
+    // blip look like a broken playlist for as long as the entry lived.
+    if (err instanceof SpotifyApiError && err.status === 404) {
+      await writeCache(
+        playlistId,
+        { kind: "missing", message: err.message, status: 404 },
+        NOT_FOUND_TTL_SECONDS
+      );
+    }
+
+    throw err;
+  }
+}
+
+/**
+ * Load a playlist's tracks, going upstream only when it isn't already known.
+ *
+ * Drop-in replacement for calling getPlaylistWithTracks directly — every
+ * caller should use this instead, since a single uncached path is enough to
+ * put the shared quota back at risk.
+ */
+export async function loadPlaylist(playlistUrl: string): Promise<LoadedPlaylist> {
+  const playlistId = parsePlaylistUrl(playlistUrl);
+  if (!playlistId) {
+    throw new SpotifyApiError("Invalid playlist URL", 400);
+  }
+
+  // Checked here as well as inside getPlaylistWithTracks so it stays true
+  // during a cooldown: an editorial playlist is permanently unsupported, and
+  // telling that host "we're rate limited, try again in 60s" would send them
+  // back to a URL that is never going to work.
+  if (isSpotifyEditorial(playlistId)) {
+    throw new SpotifyApiError(
+      "Spotify editorial/algorithm playlists are not supported. Please use a public playlist you created.",
+      404
+    );
+  }
+
+  const cached = await readCache(playlistId);
+  if (cached?.kind === "hit") {
+    await recordHit();
+    return toLoaded(cached);
+  }
+  if (cached?.kind === "missing") {
+    // A cached 404 is a cache hit too — it is a question answered without
+    // touching Spotify, which is the only thing the rate measures.
+    await recordHit();
+    throw new SpotifyApiError(cached.message, cached.status);
+  }
+
+  const existing = inFlight.get(playlistId);
+  if (existing) return existing;
+
+  const pending = fetchAndCache(playlistId, playlistUrl);
+  inFlight.set(playlistId, pending);
+  try {
+    return await pending;
+  } finally {
+    inFlight.delete(playlistId);
+  }
+}
+
+/** Test seam: the in-flight map is module state that outlives a single test. */
+export function __resetInFlightForTests(): void {
+  inFlight.clear();
+}

--- a/lib/room.ts
+++ b/lib/room.ts
@@ -7,7 +7,7 @@
  */
 
 import { randomUUID, timingSafeEqual } from "node:crypto";
-import { getPlaylistWithTracks } from "@/lib/spotify";
+import { loadPlaylist } from "@/lib/playlist-cache";
 import { poolContributions } from "@/lib/mixed-playlist";
 import { getKvStore } from "@/lib/kv";
 import { stripTrackForStorage } from "@/lib/game-session";
@@ -144,6 +144,24 @@ async function requireOpenRoom(code: string) {
 }
 
 /**
+ * The two reasons a submission is refused even though the room is open.
+ * Shared so the pre-fetch check and the authoritative in-loop check cannot
+ * drift apart and start disagreeing about who is allowed in.
+ */
+function assertCanJoin(record: RoomRecord, trimmedName: string): void {
+  if (
+    record.submissions.some(
+      (s) => s.playerName.toLowerCase() === trimmedName.toLowerCase()
+    )
+  ) {
+    throw new RoomError("That name is already taken in this room", 409);
+  }
+  if (record.submissions.length >= ROOM_MAX_SUBMISSIONS) {
+    throw new RoomError("This room is full", 409);
+  }
+}
+
+/**
  * submitToRoom and consumeRoomPool both read-modify-write the whole room
  * record — there's no CAS primitive on lib/kv.ts's get/set. Two requests
  * landing close together (the common case for a QR-code room: a group
@@ -161,14 +179,22 @@ export async function submitToRoom(
 ): Promise<{ trackCount: number }> {
   // Validate the room is currently open before doing the slow network work
   // below, so a request against a dead room fails fast.
-  await requireOpenRoom(code);
+  const { record: openRecord } = await requireOpenRoom(code);
 
   const trimmedName = playerName.trim();
   if (!trimmedName) throw new RoomError("Name is required", 422);
 
+  // Every rejection the write loop below can produce, checked against the
+  // record we already hold. Advisory only — the loop re-checks under its race
+  // guard, which is what actually decides — but it moves the common rejections
+  // (a player retrying under a name someone just took, a 13th phone scanning a
+  // full room) to *before* the playlist fetch. Those used to spend a full
+  // pagination against the shared Spotify quota only to answer with a 409.
+  assertCanJoin(openRecord, trimmedName);
+
   let tracks: Track[];
   try {
-    ({ tracks } = await getPlaylistWithTracks(playlistUrl));
+    ({ tracks } = await loadPlaylist(playlistUrl));
   } catch (err) {
     const message = err instanceof Error ? err.message : "Failed to load playlist";
     throw new RoomError(message, 422);
@@ -183,16 +209,7 @@ export async function submitToRoom(
     const fresh = await store.get<RoomRecord>(roomKey(code));
     if (!fresh) throw new RoomError("Room not found or expired", 404);
     if (fresh.consumed) throw new RoomError("This room has already started", 410);
-    if (
-      fresh.submissions.some(
-        (s) => s.playerName.toLowerCase() === trimmedName.toLowerCase()
-      )
-    ) {
-      throw new RoomError("That name is already taken in this room", 409);
-    }
-    if (fresh.submissions.length >= ROOM_MAX_SUBMISSIONS) {
-      throw new RoomError("This room is full", 409);
-    }
+    assertCanJoin(fresh, trimmedName);
 
     const updated: RoomRecord = {
       ...fresh,

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -5,11 +5,42 @@ const SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token";
 
 /** Carries the HTTP status alongside the message so callers can react to 401 vs 404. */
 export class SpotifyApiError extends Error {
-  constructor(message: string, readonly status: number) {
+  constructor(
+    message: string,
+    readonly status: number,
+    /**
+     * Seconds from Spotify's Retry-After header on a 429. lib/playlist-cache.ts
+     * turns this into a global cooldown, so it has to survive the throw rather
+     * than being flattened into the message.
+     */
+    readonly retryAfterSeconds?: number
+  ) {
     super(message);
     this.name = "SpotifyApiError";
   }
 }
+
+/**
+ * Spotify sends Retry-After (seconds) on a 429. Read defensively: it is absent
+ * on every other status, and a malformed value must not turn a real rate-limit
+ * error into a NaN cooldown that never expires.
+ */
+function parseRetryAfter(response: Response): number | undefined {
+  const raw = response.headers?.get?.("retry-after");
+  if (!raw) return undefined;
+  const seconds = Number(raw);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds : undefined;
+}
+
+/**
+ * A 429 here is `QUOTA_EXCEEDED` against the *app's* client id, not the
+ * caller's IP — every user of the site shares one quota. The old message said
+ * "Make sure the playlist is public", which is not just unhelpful but actively
+ * harmful: it reads as "your URL is wrong", so the host edits it and submits
+ * again, spending more of the quota that is already exhausted.
+ */
+const RATE_LIMITED_MESSAGE =
+  "Spotify is rate limiting us right now (too many playlist loads across the whole site). Please wait a minute and try again — your playlist URL is fine.";
 
 /**
  * Client-credentials tokens live for an hour, but every call used to mint a
@@ -17,9 +48,13 @@ export class SpotifyApiError extends Error {
  *
  * Cached at module scope, which on Vercel means per lambda instance rather
  * than globally. A shared Upstash cache would cut token requests further but
- * was rejected deliberately: /api/playlist currently has zero KV dependency,
- * and routing it through Upstash would mean a KV outage takes down playlist
- * loading entirely. Warm-instance savings are worth more than the remainder.
+ * was rejected deliberately: a token is the one thing with no fallback, so a
+ * KV outage on this path would take down playlist loading entirely.
+ * Warm-instance savings are worth more than the remainder.
+ *
+ * lib/playlist-cache.ts does put playlists in KV, which is not a reversal of
+ * that call — every KV operation there is wrapped so a failure degrades to a
+ * cache miss. This module stays a pure Spotify client with no KV import.
  */
 let cachedToken: { value: string; expiresAt: number } | null = null;
 
@@ -71,8 +106,11 @@ async function getClientAccessToken(): Promise<string> {
     // Leave the cache untouched on failure — an existing (possibly still
     // valid) entry is more useful than clearing it because a refresh blipped.
     throw new SpotifyApiError(
-      `Failed to get access token: ${response.status} ${errorText}`,
-      response.status
+      response.status === 429
+        ? RATE_LIMITED_MESSAGE
+        : `Failed to get access token: ${response.status} ${errorText}`,
+      response.status,
+      parseRetryAfter(response)
     );
   }
 
@@ -154,20 +192,26 @@ export function parsePlaylistUrl(url: string): string | null {
  */
 export async function fetchPlaylist(
   playlistId: string,
-  accessToken: string
+  accessToken: string,
+  signal?: AbortSignal
 ): Promise<SpotifyPlaylist> {
   const response = await fetch(`${SPOTIFY_API_BASE}/playlists/${playlistId}`, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },
+    signal,
   });
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({ error: { message: response.statusText } }));
     console.error("Spotify playlist fetch error:", response.status, errorData);
-    
+
     if (response.status === 404) {
       throw new SpotifyApiError("無法找到此歌單。請確認：1) 歌單是公開的 2) 歌單是你自己建立的（不是 Spotify 編輯歌單）", 404);
+    }
+
+    if (response.status === 429) {
+      throw new SpotifyApiError(RATE_LIMITED_MESSAGE, 429, parseRetryAfter(response));
     }
 
     throw new SpotifyApiError(`Failed to fetch playlist: ${response.status} - ${errorData.error?.message || response.statusText}. Make sure the playlist is public.`, response.status);
@@ -177,46 +221,161 @@ export async function fetchPlaylist(
 }
 
 /**
- * Fetch all tracks from a playlist (handles pagination)
- * Requires user access token for user's own playlists
+ * Spotify allows up to 100 items per page here. This asked for 50, which meant
+ * every playlist cost exactly twice the upstream requests it needed to — the
+ * single cheapest thing to change when the app's shared quota is the bottleneck.
+ */
+const TRACKS_PAGE_LIMIT = 100;
+
+/**
+ * Hard stop on how deep we paginate. The loop used to follow Spotify's `next`
+ * cursor with no bound at all, so one 4,000-track playlist was 40 upstream
+ * requests — for a game that then shuffles and plays at most 50 of them
+ * (SONG_COUNTS in app/page.tsx), or samples 8 per player in Mixed mode.
+ *
+ * 500 covers "All" for any playlist a party would realistically use while
+ * bounding the worst case at 5 requests. Beyond it we take the first 500 and
+ * report `truncated`, rather than silently pretending we read the whole thing.
+ */
+export const MAX_PLAYLIST_TRACKS = 500;
+
+/** How many pages MAX_PLAYLIST_TRACKS works out to. */
+const MAX_TRACK_PAGES = Math.ceil(MAX_PLAYLIST_TRACKS / TRACKS_PAGE_LIMIT);
+
+interface TrackPage {
+  tracks: SpotifyTrack[];
+  /** Length of the whole playlist, not of this page. */
+  total: number;
+  next: string | null;
+}
+
+/** One page of playlist tracks. All the upstream error handling lives here. */
+async function fetchTrackPage(
+  playlistId: string,
+  accessToken: string,
+  offset: number,
+  signal?: AbortSignal
+): Promise<TrackPage> {
+  // Don't specify market when using user token - let Spotify use user's country
+  const url = `${SPOTIFY_API_BASE}/playlists/${playlistId}/tracks?limit=${TRACKS_PAGE_LIMIT}&offset=${offset}`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({ error: { message: response.statusText } }));
+    console.error("Spotify tracks fetch error:", response.status, errorData, "URL:", url);
+
+    if (response.status === 404) {
+      throw new SpotifyApiError("無法找到此歌單。請確認：1) 歌單是公開的 2) 歌單是你自己建立的（不是 Spotify 編輯歌單）", 404);
+    }
+
+    if (response.status === 429) {
+      throw new SpotifyApiError(RATE_LIMITED_MESSAGE, 429, parseRetryAfter(response));
+    }
+
+    throw new SpotifyApiError(`Failed to fetch tracks: ${response.status} - ${errorData.error?.message || response.statusText}. Make sure the playlist is public and accessible.`, response.status);
+  }
+
+  const data = await response.json();
+  const tracks: SpotifyTrack[] = data.items
+    .map((item: { track: SpotifyTrack | null }) => item.track)
+    .filter((track: SpotifyTrack | null): track is SpotifyTrack => track !== null);
+
+  return {
+    tracks,
+    total: typeof data.total === "number" ? data.total : tracks.length,
+    next: data.next || null,
+  };
+}
+
+/** Fisher-Yates. Array#sort with a random comparator is not a uniform shuffle. */
+function shuffle<T>(items: T[]): T[] {
+  const out = [...items];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+/** `count` distinct values drawn from [min, max] without replacement. */
+function samplePageIndices(min: number, max: number, count: number): number[] {
+  const available = [];
+  for (let i = min; i <= max; i++) available.push(i);
+  return shuffle(available).slice(0, count);
+}
+
+/**
+ * Fetch tracks from a playlist, reading at most MAX_PLAYLIST_TRACKS of them.
+ *
+ * Playlists that fit are read in full, in order. Playlists that don't are
+ * *sampled*: the first page tells us the real length, and the rest of the
+ * budget goes on randomly chosen pages spread across the playlist rather than
+ * on pages 2-5. Taking the first 500 of a 4,000-track playlist would mean the
+ * same songs every single game, and whatever the owner happened to add first.
+ *
+ * The sample is by page, not by track — a page is what a request buys, so
+ * sampling any finer would cost more requests, which is the one thing this
+ * whole change exists to avoid. Page 0 is always among the candidates because
+ * reading it is how we learn the length, so the first 100 tracks are slightly
+ * over-represented; everything after them is uniform.
+ *
+ * `signal` matters more than it looks: this runs concurrently with
+ * fetchPlaylist under a Promise.all, and Promise.all rejects on the *first*
+ * failure. Without a signal the loser kept paginating after the HTTP response
+ * had already been sent — burning quota nobody was waiting for, and emitting
+ * its console.error with no request context, which is why "Spotify tracks
+ * fetch error" showed up in /api/preview's logs.
  */
 export async function fetchPlaylistTracks(
   playlistId: string,
-  accessToken: string
-): Promise<SpotifyTrack[]> {
-  const tracks: SpotifyTrack[] = [];
-  // Don't specify market when using user token - let Spotify use user's country
-  let url = `${SPOTIFY_API_BASE}/playlists/${playlistId}/tracks?limit=50`;
+  accessToken: string,
+  signal?: AbortSignal
+): Promise<{ tracks: SpotifyTrack[]; truncated: boolean }> {
+  const firstPage = await fetchTrackPage(playlistId, accessToken, 0, signal);
 
-  while (url) {
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
+  if (firstPage.total <= MAX_PLAYLIST_TRACKS) {
+    const tracks = [...firstPage.tracks];
+    let next = firstPage.next;
+    let offset = TRACKS_PAGE_LIMIT;
 
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({ error: { message: response.statusText } }));
-      console.error("Spotify tracks fetch error:", response.status, errorData, "URL:", url);
-      
-      if (response.status === 404) {
-        throw new SpotifyApiError("無法找到此歌單。請確認：1) 歌單是公開的 2) 歌單是你自己建立的（不是 Spotify 編輯歌單）", 404);
-      }
-
-      throw new SpotifyApiError(`Failed to fetch tracks: ${response.status} - ${errorData.error?.message || response.statusText}. Make sure the playlist is public and accessible.`, response.status);
+    // `total` counts entries, but local files and unavailable tracks come back
+    // as null and get filtered out, so it over-counts what we actually keep.
+    // Keep following `next` (bounded) rather than trusting the arithmetic.
+    while (next && tracks.length < MAX_PLAYLIST_TRACKS) {
+      const page = await fetchTrackPage(playlistId, accessToken, offset, signal);
+      tracks.push(...page.tracks);
+      next = page.next;
+      offset += TRACKS_PAGE_LIMIT;
     }
 
-    const data = await response.json();
-    const validTracks = data.items
-      .map((item: { track: SpotifyTrack | null }) => item.track)
-      .filter((track: SpotifyTrack | null): track is SpotifyTrack => track !== null);
-
-    tracks.push(...validTracks);
-
-    url = data.next || null;
+    return {
+      tracks: tracks.slice(0, MAX_PLAYLIST_TRACKS),
+      truncated: tracks.length > MAX_PLAYLIST_TRACKS,
+    };
   }
 
-  return tracks;
+  const lastPageIndex = Math.ceil(firstPage.total / TRACKS_PAGE_LIMIT) - 1;
+  const sampledPages = samplePageIndices(1, lastPageIndex, MAX_TRACK_PAGES - 1);
+
+  const tracks = [...firstPage.tracks];
+  for (const pageIndex of sampledPages) {
+    const page = await fetchTrackPage(
+      playlistId,
+      accessToken,
+      pageIndex * TRACKS_PAGE_LIMIT,
+      signal
+    );
+    tracks.push(...page.tracks);
+  }
+
+  // Shuffled before slicing so the cap doesn't systematically favour whichever
+  // sampled page happened to be fetched first.
+  return { tracks: shuffle(tracks).slice(0, MAX_PLAYLIST_TRACKS), truncated: true };
 }
 
 /**
@@ -242,7 +401,7 @@ export function convertSpotifyTrack(spotifyTrack: SpotifyTrack): Track {
  */
 export async function getPlaylistWithTracks(
   playlistUrl: string
-): Promise<{ playlist: SpotifyPlaylist; tracks: Track[] }> {
+): Promise<{ playlist: SpotifyPlaylist; tracks: Track[]; truncated: boolean }> {
   const playlistId = parsePlaylistUrl(playlistUrl);
   if (!playlistId) {
     throw new Error("Invalid playlist URL");
@@ -256,20 +415,30 @@ export async function getPlaylistWithTracks(
   // skew, or expiring between the buffer check and Spotify's own clock). That
   // is transparently recoverable, so drop the bad entry and mint a fresh one
   // rather than surfacing an error the user can do nothing about. Only 401
-  // retries — a 404 means the playlist genuinely isn't reachable.
+  // retries — a 404 means the playlist genuinely isn't reachable, and a 429
+  // means the quota is spent, where retrying is what caused the problem.
   for (let attempt = 0; ; attempt++) {
     const token = await getClientAccessToken();
 
+    // Ties the metadata call and the tracks pagination together so the first
+    // failure cancels its sibling. Promise.all settles on that first rejection
+    // and we return, but without this the other half keeps running against
+    // Spotify long after the response has gone out — the exact behaviour that
+    // turns one throttled request into several.
+    const controller = new AbortController();
+
     try {
-      const [playlist, spotifyTracks] = await Promise.all([
-        fetchPlaylist(playlistId, token),
-        fetchPlaylistTracks(playlistId, token),
+      const [playlist, trackPage] = await Promise.all([
+        fetchPlaylist(playlistId, token, controller.signal),
+        fetchPlaylistTracks(playlistId, token, controller.signal),
       ]);
 
-      const tracks = spotifyTracks.map(convertSpotifyTrack);
+      const tracks = trackPage.tracks.map(convertSpotifyTrack);
 
-      return { playlist, tracks };
+      return { playlist, tracks, truncated: trackPage.truncated };
     } catch (err) {
+      controller.abort();
+
       const isAuthFailure = err instanceof SpotifyApiError && err.status === 401;
       if (!isAuthFailure) throw err;
 

--- a/tests/playlist-cache.test.ts
+++ b/tests/playlist-cache.test.ts
@@ -1,0 +1,412 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as spotify from "@/lib/spotify";
+import { loadPlaylist, getCacheStats, __resetInFlightForTests } from "@/lib/playlist-cache";
+import type { Track } from "@/types";
+
+/**
+ * Like tests/preview.test.ts, every assertion here is about upstream call
+ * *count*. A cache that returns the right tracks while still paginating
+ * Spotify on every request fixes nothing — the failure this exists to prevent
+ * is `429 QUOTA_EXCEEDED` against a client id shared by the entire user base,
+ * and the only thing that moves that number is not making the call.
+ */
+
+const kv = vi.hoisted(() => {
+  const mem = new Map<string, { value: unknown; expiresAt: number }>();
+  const writes: Array<{ key: string; value: unknown; ttlSeconds: number }> = [];
+  const flags = { failReads: false, failWrites: false };
+  return { mem, writes, flags };
+});
+
+vi.mock("@/lib/kv", () => ({
+  getKvStore: async () => ({
+    async get(key: string) {
+      if (kv.flags.failReads) throw new Error("kv unavailable");
+      const entry = kv.mem.get(key);
+      if (!entry || Date.now() > entry.expiresAt) return null;
+      return entry.value;
+    },
+    async set(key: string, value: unknown, ttlSeconds: number) {
+      if (kv.flags.failWrites) throw new Error("kv unavailable");
+      kv.writes.push({ key, value, ttlSeconds });
+      kv.mem.set(key, { value, expiresAt: Date.now() + ttlSeconds * 1000 });
+    },
+    async del(key: string) {
+      kv.mem.delete(key);
+    },
+    async incr(key: string, ttlSeconds: number) {
+      const entry = kv.mem.get(key);
+      const now = Date.now();
+      if (!entry || now > entry.expiresAt) {
+        kv.mem.set(key, { value: 1, expiresAt: now + ttlSeconds * 1000 });
+        return 1;
+      }
+      const next = (entry.value as number) + 1;
+      kv.mem.set(key, { value: next, expiresAt: entry.expiresAt });
+      return next;
+    },
+  }),
+}));
+
+// Only the network-facing entry point is mocked. parsePlaylistUrl,
+// isSpotifyEditorial and SpotifyApiError stay real, because the cache's
+// routing decisions are built on them.
+vi.mock("@/lib/spotify", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/spotify")>();
+  return { ...actual, getPlaylistWithTracks: vi.fn() };
+});
+
+const URL_A = "https://open.spotify.com/playlist/aaaaaaaaaaaa";
+const URL_B = "https://open.spotify.com/playlist/bbbbbbbbbbbb";
+
+function makeTrack(id: string): Track {
+  return {
+    id,
+    name: `Song ${id}`,
+    artists: ["Artist"],
+    durationMs: 200000,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    rawJson: { huge: "blob" },
+  };
+}
+
+function upstreamResult(ids: string[], truncated = false) {
+  return {
+    playlist: { id: "p", name: "My Playlist", tracks: { items: [], total: ids.length } },
+    tracks: ids.map(makeTrack),
+    truncated,
+  };
+}
+
+const upstream = () => vi.mocked(spotify.getPlaylistWithTracks);
+const upstreamCalls = () => upstream().mock.calls.length;
+
+beforeEach(() => {
+  kv.mem.clear();
+  kv.writes.length = 0;
+  kv.flags.failReads = false;
+  kv.flags.failWrites = false;
+  __resetInFlightForTests();
+  upstream().mockReset();
+  upstream().mockResolvedValue(upstreamResult(["a", "b"]));
+});
+
+describe("playlist cache", () => {
+  it("returns the playlist and its tracks on a cold load", async () => {
+    const result = await loadPlaylist(URL_A);
+
+    expect(result.name).toBe("My Playlist");
+    expect(result.tracks.map((t) => t.id)).toEqual(["a", "b"]);
+    expect(result.totalTracks).toBe(2);
+    expect(result.truncated).toBe(false);
+    expect(upstreamCalls()).toBe(1);
+  });
+
+  it("serves a repeat load from cache with zero upstream calls", async () => {
+    await loadPlaylist(URL_A);
+    const second = await loadPlaylist(URL_A);
+
+    expect(second.tracks.map((t) => t.id)).toEqual(["a", "b"]);
+    // This is the whole fix: the same playlist used to re-paginate every time.
+    expect(upstreamCalls()).toBe(1);
+  });
+
+  it("keys the cache by playlist id, so a different playlist still loads", async () => {
+    await loadPlaylist(URL_A);
+    upstream().mockResolvedValue(upstreamResult(["c"]));
+    const other = await loadPlaylist(URL_B);
+
+    expect(other.tracks.map((t) => t.id)).toEqual(["c"]);
+    expect(upstreamCalls()).toBe(2);
+  });
+
+  it("hits the same cache entry for the URI form of the same playlist", async () => {
+    await loadPlaylist(URL_A);
+    await loadPlaylist("spotify:playlist:aaaaaaaaaaaa");
+
+    expect(upstreamCalls()).toBe(1);
+  });
+
+  it("strips rawJson before caching, so entries stay small", async () => {
+    const result = await loadPlaylist(URL_A);
+
+    expect(result.tracks[0]).not.toHaveProperty("rawJson");
+    const entry = kv.writes[0].value as { tracks: Track[] };
+    expect(entry.tracks[0]).not.toHaveProperty("rawJson");
+  });
+
+  it("preserves the truncated flag through the cache", async () => {
+    upstream().mockResolvedValue(upstreamResult(["a"], true));
+
+    expect((await loadPlaylist(URL_A)).truncated).toBe(true);
+    expect((await loadPlaylist(URL_A)).truncated).toBe(true);
+    expect(upstreamCalls()).toBe(1);
+  });
+
+  it("does not cache an empty playlist", async () => {
+    upstream().mockResolvedValue(upstreamResult([]));
+
+    await loadPlaylist(URL_A);
+    await loadPlaylist(URL_A);
+
+    // A playlist the host is still filling shouldn't be remembered as empty
+    // for six hours.
+    expect(upstreamCalls()).toBe(2);
+  });
+
+  it("rejects an unparseable URL without calling Spotify", async () => {
+    await expect(loadPlaylist("https://example.com/not-a-playlist")).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(upstreamCalls()).toBe(0);
+  });
+
+  it("rejects an editorial playlist without calling Spotify", async () => {
+    await expect(
+      loadPlaylist("https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M")
+    ).rejects.toThrow(/editorial/i);
+    expect(upstreamCalls()).toBe(0);
+  });
+});
+
+describe("in-flight coalescing", () => {
+  it("collapses concurrent loads of the same playlist into one upstream fetch", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    upstream().mockImplementation(async () => {
+      await gate;
+      return upstreamResult(["a"]);
+    });
+
+    // Mixed mode fires one request per contributor from a single click, and a
+    // QR room gets a burst of submits — duplicate URLs in either used to mean
+    // duplicate pagination, because the cache write lands too late to help
+    // its own siblings.
+    const all = Promise.all([loadPlaylist(URL_A), loadPlaylist(URL_A), loadPlaylist(URL_A)]);
+    release();
+    const results = await all;
+
+    expect(upstreamCalls()).toBe(1);
+    expect(results.every((r) => r.tracks.length === 1)).toBe(true);
+  });
+
+  it("does not coalesce different playlists", async () => {
+    await Promise.all([loadPlaylist(URL_A), loadPlaylist(URL_B)]);
+    expect(upstreamCalls()).toBe(2);
+  });
+
+  it("clears the in-flight entry after a failure, so a later retry is not stuck", async () => {
+    upstream().mockRejectedValueOnce(new spotify.SpotifyApiError("boom", 500));
+    await expect(loadPlaylist(URL_A)).rejects.toThrow("boom");
+
+    upstream().mockResolvedValue(upstreamResult(["a"]));
+    await expect(loadPlaylist(URL_A)).resolves.toMatchObject({ totalTracks: 1 });
+  });
+});
+
+describe("404 negative caching", () => {
+  it("remembers a missing playlist so a retry burst costs one upstream call", async () => {
+    upstream().mockRejectedValue(new spotify.SpotifyApiError("no such playlist", 404));
+
+    await expect(loadPlaylist(URL_A)).rejects.toThrow("no such playlist");
+    await expect(loadPlaylist(URL_A)).rejects.toMatchObject({ status: 404 });
+    await expect(loadPlaylist(URL_A)).rejects.toMatchObject({ status: 404 });
+
+    expect(upstreamCalls()).toBe(1);
+  });
+
+  it("holds a 404 for far less time than a successful load", async () => {
+    upstream().mockRejectedValue(new spotify.SpotifyApiError("gone", 404));
+    await expect(loadPlaylist(URL_A)).rejects.toThrow();
+    const missTtl = kv.writes.at(-1)!.ttlSeconds;
+
+    kv.mem.clear();
+    upstream().mockResolvedValue(upstreamResult(["a"]));
+    await loadPlaylist(URL_A);
+    const hitTtl = kv.writes.at(-1)!.ttlSeconds;
+
+    // A host who fixes their playlist's visibility must not keep being told
+    // it's broken.
+    expect(missTtl).toBeLessThan(hitTtl);
+  });
+
+  it("does not cache a 5xx — that is Spotify's problem, not the playlist's", async () => {
+    upstream().mockRejectedValue(new spotify.SpotifyApiError("upstream down", 503));
+
+    await expect(loadPlaylist(URL_A)).rejects.toThrow();
+    await expect(loadPlaylist(URL_A)).rejects.toThrow();
+
+    expect(upstreamCalls()).toBe(2);
+  });
+});
+
+describe("429 cooldown", () => {
+  it("parks further uncached loads after Spotify reports a 429", async () => {
+    upstream().mockRejectedValueOnce(new spotify.SpotifyApiError("slow down", 429, 45));
+    await expect(loadPlaylist(URL_A)).rejects.toMatchObject({ status: 429 });
+
+    // A different playlist, and the upstream mock is healthy again — but the
+    // quota is per app, so going back out would just spend more of it.
+    upstream().mockResolvedValue(upstreamResult(["c"]));
+    await expect(loadPlaylist(URL_B)).rejects.toMatchObject({ status: 429 });
+
+    expect(upstreamCalls()).toBe(1);
+  });
+
+  it("still serves cached playlists during a cooldown", async () => {
+    await loadPlaylist(URL_A);
+
+    upstream().mockRejectedValueOnce(new spotify.SpotifyApiError("slow down", 429));
+    await expect(loadPlaylist(URL_B)).rejects.toMatchObject({ status: 429 });
+
+    // The party already holding a loaded playlist must not be taken down by
+    // someone else's throttling.
+    await expect(loadPlaylist(URL_A)).resolves.toMatchObject({ totalTracks: 2 });
+  });
+
+  it("clamps a huge Retry-After to a bearable wait", async () => {
+    upstream().mockRejectedValueOnce(
+      new spotify.SpotifyApiError("slow down", 429, 86400)
+    );
+    await expect(loadPlaylist(URL_A)).rejects.toThrow();
+
+    const cooldown = kv.writes.find((w) => w.key === "spotify:cooldown");
+    expect(cooldown!.ttlSeconds).toBeLessThanOrEqual(15 * 60);
+  });
+
+  it("applies a floor when Spotify sends no Retry-After at all", async () => {
+    upstream().mockRejectedValueOnce(new spotify.SpotifyApiError("slow down", 429));
+    await expect(loadPlaylist(URL_A)).rejects.toThrow();
+
+    const cooldown = kv.writes.find((w) => w.key === "spotify:cooldown");
+    expect(cooldown!.ttlSeconds).toBeGreaterThanOrEqual(30);
+  });
+
+  it("tells the user to wait rather than to fix their URL", async () => {
+    upstream().mockRejectedValueOnce(new spotify.SpotifyApiError("429 whatever", 429, 60));
+    const err = await loadPlaylist(URL_A).catch((e) => e);
+
+    expect(err.message).toMatch(/rate limit/i);
+    expect(err.message).not.toMatch(/public/i);
+    expect(err.retryAfterSeconds).toBeGreaterThan(0);
+  });
+});
+
+describe("global upstream budget", () => {
+  beforeEach(() => {
+    process.env.SPOTIFY_MAX_LOADS_PER_MINUTE = "3";
+  });
+
+  afterEach(() => {
+    delete process.env.SPOTIFY_MAX_LOADS_PER_MINUTE;
+  });
+
+  it("refuses new playlists past the per-minute ceiling before Spotify does", async () => {
+    for (let i = 0; i < 3; i++) {
+      upstream().mockResolvedValue(upstreamResult([`t${i}`]));
+      await loadPlaylist(`https://open.spotify.com/playlist/pl${i}aaaaaaaaa`);
+    }
+    expect(upstreamCalls()).toBe(3);
+
+    await expect(
+      loadPlaylist("https://open.spotify.com/playlist/pl9aaaaaaaaa")
+    ).rejects.toMatchObject({ status: 429 });
+
+    // The point is that the 4th never left the building.
+    expect(upstreamCalls()).toBe(3);
+  });
+
+  it("does not spend budget on cached playlists", async () => {
+    await loadPlaylist(URL_A);
+
+    // Ten more reads of an already-known playlist, against a ceiling of 3.
+    for (let i = 0; i < 10; i++) {
+      await expect(loadPlaylist(URL_A)).resolves.toMatchObject({ totalTracks: 2 });
+    }
+    expect(upstreamCalls()).toBe(1);
+  });
+
+  it("tells the user to wait rather than to fix their URL", async () => {
+    for (let i = 0; i < 3; i++) {
+      await loadPlaylist(`https://open.spotify.com/playlist/pl${i}aaaaaaaaa`);
+    }
+
+    const err = await loadPlaylist("https://open.spotify.com/playlist/pl9aaaaaaaaa").catch(
+      (e) => e
+    );
+    expect(err.message).toMatch(/try again/i);
+    expect(err.message).not.toMatch(/public/i);
+  });
+
+  it("fails open when KV is unavailable, rather than blocking every load", async () => {
+    kv.flags.failReads = true;
+    kv.flags.failWrites = true;
+
+    // A budget that can't be read must not become a budget of zero.
+    await expect(loadPlaylist(URL_A)).resolves.toMatchObject({ totalTracks: 2 });
+  });
+});
+
+describe("cache hit-rate stats", () => {
+  it("counts a cold load as a miss and a repeat as a hit", async () => {
+    await loadPlaylist(URL_A);
+    await loadPlaylist(URL_A);
+    await loadPlaylist(URL_A);
+
+    const stats = await getCacheStats();
+    expect(stats.misses).toBe(1);
+    expect(stats.hits).toBe(2);
+    expect(stats.hitRate).toBeCloseTo(2 / 3);
+  });
+
+  it("counts a cached 404 as a hit — it answered without touching Spotify", async () => {
+    upstream().mockRejectedValue(new spotify.SpotifyApiError("gone", 404));
+    await expect(loadPlaylist(URL_A)).rejects.toThrow();
+    await expect(loadPlaylist(URL_A)).rejects.toThrow();
+
+    const stats = await getCacheStats();
+    expect(stats.misses).toBe(1);
+    expect(stats.hits).toBe(1);
+  });
+
+  it("reports a zero rate rather than NaN before anything has loaded", async () => {
+    expect((await getCacheStats()).hitRate).toBe(0);
+  });
+});
+
+describe("sampled playlists", () => {
+  it("caches a truncated playlist for less time than a complete one", async () => {
+    upstream().mockResolvedValue(upstreamResult(["a"], true));
+    await loadPlaylist(URL_A);
+    const sampledTtl = kv.writes.find((w) => w.key.startsWith("playlist:"))!.ttlSeconds;
+
+    kv.mem.clear();
+    kv.writes.length = 0;
+    __resetInFlightForTests();
+    upstream().mockResolvedValue(upstreamResult(["a"], false));
+    await loadPlaylist(URL_A);
+    const fullTtl = kv.writes.find((w) => w.key.startsWith("playlist:"))!.ttlSeconds;
+
+    // A truncated entry is one random draw of 500. Holding it as long as a
+    // complete playlist would mean the same 500 songs all evening, which is
+    // the thing sampling exists to avoid.
+    expect(sampledTtl).toBeLessThan(fullTtl);
+  });
+});
+
+describe("KV degradation", () => {
+  it("still loads when the cache cannot be read", async () => {
+    kv.flags.failReads = true;
+
+    await expect(loadPlaylist(URL_A)).resolves.toMatchObject({ totalTracks: 2 });
+  });
+
+  it("still loads when the cache cannot be written", async () => {
+    kv.flags.failWrites = true;
+
+    await expect(loadPlaylist(URL_A)).resolves.toMatchObject({ totalTracks: 2 });
+  });
+});

--- a/tests/room.test.ts
+++ b/tests/room.test.ts
@@ -1,18 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import * as spotify from "@/lib/spotify";
-import type { SpotifyPlaylist } from "@/lib/spotify";
+import * as playlistCache from "@/lib/playlist-cache";
 import { createRoom, submitToRoom, getRoomStatus, consumeRoomPool } from "@/lib/room";
 import type { Track } from "@/types";
 
-vi.mock("@/lib/spotify", () => ({
-  getPlaylistWithTracks: vi.fn(),
+vi.mock("@/lib/playlist-cache", () => ({
+  loadPlaylist: vi.fn(),
 }));
 
-const FAKE_PLAYLIST: SpotifyPlaylist = {
-  id: "p",
-  name: "P",
-  tracks: { items: [], total: 0 },
-};
+/** Shape lib/playlist-cache.ts returns; room.ts only reads `tracks`. */
+function loaded(tracks: Track[]) {
+  return { name: "P", tracks, totalTracks: tracks.length, truncated: false };
+}
 
 function makeTrack(overrides: Partial<Track> = {}): Track {
   return {
@@ -27,7 +25,7 @@ function makeTrack(overrides: Partial<Track> = {}): Track {
 
 describe("room lifecycle", () => {
   beforeEach(() => {
-    vi.mocked(spotify.getPlaylistWithTracks).mockReset();
+    vi.mocked(playlistCache.loadPlaylist).mockReset();
   });
 
   it("creates a room with a 4-char code, future expiry, and a host token", async () => {
@@ -72,20 +70,14 @@ describe("room lifecycle", () => {
   });
 
   it("submits a playlist and returns its track count", async () => {
-    vi.mocked(spotify.getPlaylistWithTracks).mockResolvedValue({
-      playlist: FAKE_PLAYLIST,
-      tracks: [makeTrack({ id: "a" }), makeTrack({ id: "b" })],
-    });
+    vi.mocked(playlistCache.loadPlaylist).mockResolvedValue(loaded([makeTrack({ id: "a" }), makeTrack({ id: "b" })]));
     const { roomCode } = await createRoom();
     const result = await submitToRoom(roomCode, "Alice", "https://open.spotify.com/playlist/abc");
     expect(result.trackCount).toBe(2);
   });
 
   it("rejects a duplicate name (case-insensitive) in the same room", async () => {
-    vi.mocked(spotify.getPlaylistWithTracks).mockResolvedValue({
-      playlist: FAKE_PLAYLIST,
-      tracks: [makeTrack()],
-    });
+    vi.mocked(playlistCache.loadPlaylist).mockResolvedValue(loaded([makeTrack()]));
     const { roomCode } = await createRoom();
     await submitToRoom(roomCode, "Alice", "url1");
     await expect(submitToRoom(roomCode, "alice", "url2")).rejects.toMatchObject({ status: 409 });
@@ -96,7 +88,7 @@ describe("room lifecycle", () => {
   });
 
   it("propagates playlist parse failures as 422", async () => {
-    vi.mocked(spotify.getPlaylistWithTracks).mockRejectedValue(new Error("bad playlist"));
+    vi.mocked(playlistCache.loadPlaylist).mockRejectedValue(new Error("bad playlist"));
     const { roomCode } = await createRoom();
     await expect(submitToRoom(roomCode, "Alice", "bad-url")).rejects.toMatchObject({
       status: 422,
@@ -104,10 +96,7 @@ describe("room lifecycle", () => {
   });
 
   it("status reports only names and track counts, never track contents", async () => {
-    vi.mocked(spotify.getPlaylistWithTracks).mockResolvedValue({
-      playlist: FAKE_PLAYLIST,
-      tracks: [makeTrack({ id: "a" }), makeTrack({ id: "b" }), makeTrack({ id: "c" })],
-    });
+    vi.mocked(playlistCache.loadPlaylist).mockResolvedValue(loaded([makeTrack({ id: "a" }), makeTrack({ id: "b" }), makeTrack({ id: "c" })]));
     const { roomCode } = await createRoom();
     await submitToRoom(roomCode, "Alice", "url");
     const status = await getRoomStatus(roomCode);
@@ -117,9 +106,9 @@ describe("room lifecycle", () => {
   });
 
   it("pools submissions, marks the room consumed, and blocks further activity", async () => {
-    vi.mocked(spotify.getPlaylistWithTracks)
-      .mockResolvedValueOnce({ playlist: FAKE_PLAYLIST, tracks: [makeTrack({ id: "a", name: "A" })] })
-      .mockResolvedValueOnce({ playlist: FAKE_PLAYLIST, tracks: [makeTrack({ id: "b", name: "B" })] });
+    vi.mocked(playlistCache.loadPlaylist)
+      .mockResolvedValueOnce(loaded([makeTrack({ id: "a", name: "A" })]))
+      .mockResolvedValueOnce(loaded([makeTrack({ id: "b", name: "B" })]));
     const { roomCode, hostToken } = await createRoom();
     await submitToRoom(roomCode, "Alice", "url1");
     await submitToRoom(roomCode, "Bob", "url2");
@@ -138,10 +127,7 @@ describe("room lifecycle", () => {
   });
 
   it("rejects pool consumption with a wrong or missing host token", async () => {
-    vi.mocked(spotify.getPlaylistWithTracks).mockResolvedValue({
-      playlist: FAKE_PLAYLIST,
-      tracks: [makeTrack()],
-    });
+    vi.mocked(playlistCache.loadPlaylist).mockResolvedValue(loaded([makeTrack()]));
     const { roomCode } = await createRoom();
     await submitToRoom(roomCode, "Alice", "url1");
 
@@ -156,22 +142,22 @@ describe("room lifecycle", () => {
     // submitToRoom) while Bob's request runs to completion first — this
     // reproduces the interleaving that used to silently drop whichever
     // submission wrote last against a stale in-memory copy of the record.
-    let resolveAlice!: (v: Awaited<ReturnType<typeof spotify.getPlaylistWithTracks>>) => void;
-    const alicePending = new Promise<Awaited<ReturnType<typeof spotify.getPlaylistWithTracks>>>(
+    let resolveAlice!: (v: Awaited<ReturnType<typeof playlistCache.loadPlaylist>>) => void;
+    const alicePending = new Promise<Awaited<ReturnType<typeof playlistCache.loadPlaylist>>>(
       (resolve) => {
         resolveAlice = resolve;
       }
     );
-    vi.mocked(spotify.getPlaylistWithTracks)
+    vi.mocked(playlistCache.loadPlaylist)
       .mockImplementationOnce(() => alicePending)
-      .mockResolvedValueOnce({ playlist: FAKE_PLAYLIST, tracks: [makeTrack({ id: "b" })] });
+      .mockResolvedValueOnce(loaded([makeTrack({ id: "b" })]));
 
     const submitAlice = submitToRoom(roomCode, "Alice", "url-alice");
     await Promise.resolve();
     await Promise.resolve();
 
     await submitToRoom(roomCode, "Bob", "url-bob");
-    resolveAlice({ playlist: FAKE_PLAYLIST, tracks: [makeTrack({ id: "a" })] });
+    resolveAlice(loaded([makeTrack({ id: "a" })]));
     await submitAlice;
 
     const status = await getRoomStatus(roomCode);
@@ -179,9 +165,9 @@ describe("room lifecycle", () => {
   });
 
   it("only lets one of two concurrent pool-consume calls succeed", async () => {
-    vi.mocked(spotify.getPlaylistWithTracks)
-      .mockResolvedValueOnce({ playlist: FAKE_PLAYLIST, tracks: [makeTrack({ id: "a" })] })
-      .mockResolvedValueOnce({ playlist: FAKE_PLAYLIST, tracks: [makeTrack({ id: "b" })] });
+    vi.mocked(playlistCache.loadPlaylist)
+      .mockResolvedValueOnce(loaded([makeTrack({ id: "a" })]))
+      .mockResolvedValueOnce(loaded([makeTrack({ id: "b" })]));
     const { roomCode, hostToken } = await createRoom();
     await submitToRoom(roomCode, "Alice", "url1");
     await submitToRoom(roomCode, "Bob", "url2");

--- a/tests/spotify.test.ts
+++ b/tests/spotify.test.ts
@@ -15,6 +15,21 @@ interface RouteBehaviour {
   playlistStatus?: number;
   /** Seconds reported by the token endpoint. */
   expiresIn?: number;
+  /**
+   * Size of the fake playlist. The tracks endpoint serves it in pages and
+   * advertises `next` until it's exhausted, so the pagination loop — and the
+   * cap on it — are actually exercised rather than short-circuited by an
+   * empty first page.
+   */
+  totalTracks?: number;
+  /** Retry-After header value returned alongside a non-200 status. */
+  retryAfter?: string;
+  /**
+   * Status for the playlist *metadata* call only, leaving the tracks endpoint
+   * healthy. Needed to test the abort: the two run under one Promise.all, so
+   * failing both at once would stop the pagination loop for the wrong reason.
+   */
+  metadataStatus?: number;
 }
 
 /**
@@ -26,19 +41,45 @@ interface MockResponse {
   ok: boolean;
   status: number;
   statusText: string;
+  headers: { get: (name: string) => string | null };
   json: () => Promise<unknown>;
   text: () => Promise<string>;
+}
+
+function noHeaders(): MockResponse["headers"] {
+  return { get: () => null };
+}
+
+function fakeSpotifyTrack(index: number) {
+  return {
+    id: `track-${index}`,
+    name: `Song ${index}`,
+    artists: [{ name: "Artist" }],
+    duration_ms: 200000,
+    preview_url: null,
+    album: { name: "Album", images: [] },
+  };
 }
 
 /**
  * Routes fetch by URL and counts token mints, which is the thing under test —
  * "did we go back to Spotify for a new token" is not observable any other way.
+ * Also counts track-page requests, since "how many times did we hit Spotify to
+ * read one playlist" is the number the whole cache exists to hold down.
  */
 function installFetchMock(behaviour: RouteBehaviour = {}) {
-  const { playlistStatus = 200, expiresIn = 3600 } = behaviour;
+  const {
+    playlistStatus = 200,
+    expiresIn = 3600,
+    totalTracks = 0,
+    retryAfter,
+    metadataStatus,
+  } = behaviour;
   let tokenRequests = 0;
   let tokenSerial = 0;
+  let trackPageRequests = 0;
   const bearersSeen: string[] = [];
+  const offsetsSeen: number[] = [];
 
   const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit): Promise<MockResponse> => {
     const href = typeof url === "string" ? url : url.toString();
@@ -50,6 +91,7 @@ function installFetchMock(behaviour: RouteBehaviour = {}) {
         ok: true,
         status: 200,
         statusText: "OK",
+        headers: noHeaders(),
         json: async () => ({ access_token: `token-${tokenSerial}`, expires_in: expiresIn }),
         text: async () => "",
       };
@@ -63,18 +105,47 @@ function installFetchMock(behaviour: RouteBehaviour = {}) {
         ok: false,
         status: playlistStatus,
         statusText: "Error",
+        headers: { get: (name) => (name.toLowerCase() === "retry-after" ? retryAfter ?? null : null) },
         json: async () => ({ error: { message: "nope" } }),
         text: async () => "nope",
       };
     }
 
     if (href.includes("/tracks")) {
+      // Model a real fetch: once the caller aborts, the next page rejects
+      // instead of quietly returning data nobody is waiting for.
+      if (init?.signal?.aborted) throw new Error("aborted");
+      trackPageRequests++;
+      const parsed = new URL(href);
+      const limit = Number(parsed.searchParams.get("limit") ?? 100);
+      const offset = Number(parsed.searchParams.get("offset") ?? 0);
+      offsetsSeen.push(offset);
+      const pageEnd = Math.min(offset + limit, totalTracks);
+      const items = Array.from({ length: Math.max(0, pageEnd - offset) }, (_, i) =>
+        ({ track: fakeSpotifyTrack(offset + i) })
+      );
+      const next =
+        pageEnd < totalTracks
+          ? `https://api.spotify.com/v1/playlists/abc123/tracks?limit=${limit}&offset=${pageEnd}`
+          : null;
       return {
         ok: true,
         status: 200,
         statusText: "OK",
-        json: async () => ({ items: [], next: null }),
+        headers: noHeaders(),
+        json: async () => ({ items, next, total: totalTracks }),
         text: async () => "",
+      };
+    }
+
+    if (metadataStatus !== undefined && metadataStatus !== 200) {
+      return {
+        ok: false,
+        status: metadataStatus,
+        statusText: "Error",
+        headers: noHeaders(),
+        json: async () => ({ error: { message: "metadata failed" } }),
+        text: async () => "metadata failed",
       };
     }
 
@@ -82,7 +153,8 @@ function installFetchMock(behaviour: RouteBehaviour = {}) {
       ok: true,
       status: 200,
       statusText: "OK",
-      json: async () => ({ id: "abc123", name: "Test Playlist", tracks: { items: [], total: 0 } }),
+      headers: noHeaders(),
+      json: async () => ({ id: "abc123", name: "Test Playlist", tracks: { items: [], total: totalTracks } }),
       text: async () => "",
     };
   });
@@ -91,6 +163,8 @@ function installFetchMock(behaviour: RouteBehaviour = {}) {
   return {
     tokenRequests: () => tokenRequests,
     bearersSeen: () => bearersSeen,
+    trackPageRequests: () => trackPageRequests,
+    offsetsSeen: () => offsetsSeen,
   };
 }
 
@@ -214,6 +288,7 @@ describe("Spotify token invalidation on 401", () => {
           ok: false,
           status: 404,
           statusText: "Not Found",
+          headers: noHeaders(),
           json: async () => ({ error: { message: "no" } }),
           text: async () => "no",
         };
@@ -233,5 +308,173 @@ describe("SpotifyApiError", () => {
     expect(err).toBeInstanceOf(Error);
     expect(err.status).toBe(401);
     expect(err.message).toBe("boom");
+  });
+});
+
+/**
+ * Upstream request *count* per playlist load is the number that decides whether
+ * the app's shared Spotify quota survives a busy evening, and nothing used to
+ * assert it. These lock it down.
+ */
+describe("playlist pagination cost", () => {
+  beforeEach(() => {
+    process.env.SPOTIFY_CLIENT_ID = "id";
+    process.env.SPOTIFY_CLIENT_SECRET = "secret";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reads 100 tracks per page, not 50", async () => {
+    const probe = installFetchMock({ totalTracks: 100 });
+    const { getPlaylistWithTracks } = await freshSpotify();
+
+    const { tracks } = await getPlaylistWithTracks(PLAYLIST_URL);
+
+    expect(tracks).toHaveLength(100);
+    // At limit=50 this same playlist would have cost two pages.
+    expect(probe.trackPageRequests()).toBe(1);
+  });
+
+  it("stops at MAX_PLAYLIST_TRACKS instead of following `next` forever", async () => {
+    const probe = installFetchMock({ totalTracks: 5000 });
+    const { getPlaylistWithTracks, MAX_PLAYLIST_TRACKS } = await freshSpotify();
+
+    const { tracks, truncated } = await getPlaylistWithTracks(PLAYLIST_URL);
+
+    expect(tracks).toHaveLength(MAX_PLAYLIST_TRACKS);
+    expect(truncated).toBe(true);
+    // Uncapped, a 5,000-track playlist was 50 requests against a quota shared
+    // by every user of the site.
+    expect(probe.trackPageRequests()).toBe(MAX_PLAYLIST_TRACKS / 100);
+  });
+
+  it("samples an oversized playlist across its whole length, not just the front", async () => {
+    const probe = installFetchMock({ totalTracks: 5000 });
+    const { getPlaylistWithTracks } = await freshSpotify();
+
+    await getPlaylistWithTracks(PLAYLIST_URL);
+
+    // Taking the first 500 would read offsets 0,100,200,300,400 every time —
+    // the same songs every game, and whatever the owner happened to add first.
+    const offsets = probe.offsetsSeen();
+    expect(offsets).toContain(0); // page 0 is how we learn the length
+    expect(Math.max(...offsets)).toBeGreaterThan(400);
+    expect(new Set(offsets).size).toBe(offsets.length); // no page read twice
+  });
+
+  it("draws a different sample on a later load of the same big playlist", async () => {
+    const { getPlaylistWithTracks } = await freshSpotify();
+
+    // Ten draws of 4 pages from ~49 candidates. Identical results every time
+    // would mean the sampling is not actually random.
+    const draws = new Set<string>();
+    for (let i = 0; i < 10; i++) {
+      const probe = installFetchMock({ totalTracks: 5000 });
+      await getPlaylistWithTracks(PLAYLIST_URL);
+      draws.add(probe.offsetsSeen().slice().sort((a, b) => a - b).join(","));
+    }
+
+    expect(draws.size).toBeGreaterThan(1);
+  });
+
+  it("reads a playlist that fits in full and in order", async () => {
+    const probe = installFetchMock({ totalTracks: 250 });
+    const { getPlaylistWithTracks } = await freshSpotify();
+
+    const { tracks, truncated } = await getPlaylistWithTracks(PLAYLIST_URL);
+
+    // Under the cap nothing is sampled or shuffled — the host's ordering is
+    // preserved, and the game page does its own shuffling downstream.
+    expect(truncated).toBe(false);
+    expect(tracks).toHaveLength(250);
+    expect(tracks[0].id).toBe("track-0");
+    expect(tracks[249].id).toBe("track-249");
+    expect(probe.offsetsSeen()).toEqual([0, 100, 200]);
+  });
+
+  it("reports truncated=false for a playlist that fits", async () => {
+    installFetchMock({ totalTracks: 120 });
+    const { getPlaylistWithTracks } = await freshSpotify();
+
+    const { tracks, truncated } = await getPlaylistWithTracks(PLAYLIST_URL);
+
+    expect(tracks).toHaveLength(120);
+    expect(truncated).toBe(false);
+  });
+
+  it("does not keep paginating after the metadata call fails", async () => {
+    // The pagination loop and the metadata call run under one Promise.all, so
+    // the rejection returns while the loop is still mid-flight. The tracks
+    // endpoint here is perfectly healthy — only the metadata call fails, which
+    // is exactly the production shape when Spotify throttles one of the two.
+    //
+    // Without the abort the loop runs on until MAX_PLAYLIST_TRACKS stops it
+    // (5 pages here), long after the HTTP response has gone out: quota spent
+    // on a request nobody is waiting for, and a console.error with no request
+    // context — which is why "Spotify tracks fetch error" surfaced in
+    // /api/preview's logs. Aborting cuts it to whatever was already in flight.
+    const probe = installFetchMock({ totalTracks: 5000, metadataStatus: 500 });
+    const { getPlaylistWithTracks } = await freshSpotify();
+
+    await expect(getPlaylistWithTracks(PLAYLIST_URL)).rejects.toThrow();
+
+    // Settle long enough that an unaborted loop would have walked well past
+    // the handful of pages already in flight when the rejection landed.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(probe.trackPageRequests()).toBeLessThan(5);
+  });
+});
+
+describe("Spotify 429 handling", () => {
+  beforeEach(() => {
+    process.env.SPOTIFY_CLIENT_ID = "id";
+    process.env.SPOTIFY_CLIENT_SECRET = "secret";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("surfaces the Retry-After seconds rather than flattening them into the message", async () => {
+    installFetchMock({ playlistStatus: 429, retryAfter: "42" });
+    const { getPlaylistWithTracks, SpotifyApiError } = await freshSpotify();
+
+    const err = await getPlaylistWithTracks(PLAYLIST_URL).catch((e) => e);
+
+    expect(err).toBeInstanceOf(SpotifyApiError);
+    expect(err.status).toBe(429);
+    expect(err.retryAfterSeconds).toBe(42);
+  });
+
+  it("never blames the user's playlist for a quota error", async () => {
+    installFetchMock({ playlistStatus: 429 });
+    const { getPlaylistWithTracks } = await freshSpotify();
+
+    const err = await getPlaylistWithTracks(PLAYLIST_URL).catch((e) => e);
+
+    // The old message told throttled hosts to check their URL was public,
+    // which sent them straight back into retrying against a spent quota.
+    expect(err.message).not.toMatch(/public/i);
+    expect(err.message).toMatch(/rate limit/i);
+  });
+
+  it("does not retry a 429 — retrying is what exhausted the quota", async () => {
+    const probe = installFetchMock({ playlistStatus: 429 });
+    const { getPlaylistWithTracks } = await freshSpotify();
+
+    await expect(getPlaylistWithTracks(PLAYLIST_URL)).rejects.toThrow();
+
+    expect(probe.tokenRequests()).toBe(1);
+  });
+
+  it("ignores a malformed Retry-After instead of producing a NaN cooldown", async () => {
+    installFetchMock({ playlistStatus: 429, retryAfter: "soon" });
+    const { getPlaylistWithTracks } = await freshSpotify();
+
+    const err = await getPlaylistWithTracks(PLAYLIST_URL).catch((e) => e);
+
+    expect(err.retryAfterSeconds).toBeUndefined();
   });
 });


### PR DESCRIPTION
## The bug

Production was returning `429 QUOTA_EXCEEDED` on `/api/playlist`. Two different playlists 429'd within the same second in the logs, which is the tell: **Spotify throttles on the client id**, so one budget covers the entire user base. Every limiter in `lib/rate-limit.ts` is keyed by IP, which bounds one abusive client and does nothing about aggregate load.

On top of that, nothing cached a playlist. `getPlaylistWithTracks` went to the network on every single call, so the same URL re-paginated in full on every host retry, every room submit, and for every player in a room who pasted the same link.

Five compounding causes:

| | Cost |
|---|---|
| No playlist cache anywhere | Full pagination on every load |
| `limit=50` (Spotify's max is 100) | **Exactly 2×** the requests needed |
| Unbounded `while (data.next)` | A 4,000-track playlist = 40 requests, for a game that plays ≤50 songs |
| `Promise.all` with no abort | Response returns, losing half keeps paginating |
| Upstream 429 flattened to HTTP 400 | UI told throttled hosts to "check the playlist is public" → they retried into a spent quota |

That fourth one also explains the confusing logs: `Spotify tracks fetch error` was appearing under `/api/preview` requests. `/api/preview` never calls Spotify. The pagination loop was outliving the request that started it and its `console.error` landed on whatever invocation was live.

## The fix

**`lib/playlist-cache.ts`** (new) — four layers, cheapest first:

```
loadPlaylist ─→ KV cache ─────── hit ──→ return (zero upstream calls)
                    │ miss
                    ├─ in-flight map ── hit ──→ await the existing fetch
                    │ miss
                    ├─ global budget ── spent ─→ throw 429 (never leaves the building)
                    │ ok
                    ├─ cooldown gate ── open ──→ throw 429 immediately
                    │ closed
                    └─ Spotify ─→ store ─→ return
```

- **Cache** — keyed by playlist id, 6h. A repeat costs zero upstream calls.
- **In-flight coalescing** — one Mixed-mode Start fires a request per contributor and a QR room gets a burst of simultaneous submits. Duplicate URLs in either meant duplicate pagination, because the cache write lands too late to help its own siblings.
- **Global budget** (`SPOTIFY_MAX_LOADS_PER_MINUTE`, default 40) — KV `incr` shared across instances, refusing before Spotify does. **Fails open** on a KV error: losing the safety net must mean "back to how it was", not "nobody can play".
- **429 cooldown** — parks all *uncached* loads for `Retry-After` (clamped 30s–15min), in KV so every instance sees it. Without this a throttled window is self-sustaining: every host errors, every host retries, the retries keep the quota pinned. Cached playlists keep serving, so a party mid-game is unaffected by someone else's throttling.

Plus: `limit=100`, `MAX_PLAYLIST_TRACKS=500`, an `AbortController` killing the orphaned pagination, and `/api/playlist` returning 429/404 as themselves with a `Retry-After` header and a message that says the URL is fine.

## Oversized playlists are sampled, not truncated

A playlist past the cap is no longer read front-to-back. Page 0 reports the real length, and the remaining budget goes on randomly chosen pages spread across the playlist — otherwise a 4,000-track playlist plays the same 500 songs every game, and whatever the owner happened to add first.

Sampling is by *page*, not by track: a page is what a request buys, and sampling finer would cost more requests, which is the one thing this change exists to avoid. Page 0 is always a candidate since reading it is how the length is discovered, so the first 100 tracks are slightly over-represented and everything after them is uniform. Sampled entries cache 1h rather than 6h — the TTL is also how long everyone is stuck with one draw.

Playlists that fit are still read whole and in order.

## What this is *not*

Rotating client ids or egress IPs. IP rotation does nothing against a client-id quota, and running multiple apps to evade rate limits violates the Spotify developer terms — risking the app that's actually in production, to work around something a cache fixes.

## Impact

A 200-track playlist: ~6 upstream requests per load before, 3 on the first load and **0 for the next 6 hours** after.

## Verification

- 221 tests pass (16 files), lint clean, production build succeeds.
- New `tests/playlist-cache.test.ts` (33 tests) — every assertion is on upstream call *count*, following `tests/preview.test.ts`. Covers coalescing, negative caching, cooldown, budget, KV degradation, stats.
- `tests/spotify.test.ts` gains page-count, cap, sampling-spread, 429 and abort coverage. The abort test was verified to fail with the fix reverted.
- `tests/room.test.ts` retargeted at the cache module.

## Follow-ups (in CHANGELOG "Known gaps")

- The default budget of 40 is a guess — the right value depends on the app's quota tier, which the code can't discover. Watch the `[playlist-cache] miss … rate=…` log for a week and tune.
- `truncated` is returned but not surfaced in the UI; a host with a huge playlist gets no indication they're playing a sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
