### PR TITLE
docs: rewrite the README, add an MIT LICENSE, rename the package, fix llms.txt

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Wayn Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -251,3 +251,7 @@ The root suite covers the pure logic (pooling, taste card, share-target parsing,
 - **Previews** — a small number of tracks have no 30s clip on either iTunes or Deezer and will show a "no audio" state.
 - **Scoring** — the host is the judge. No automated answer checking.
 - **Found a bug?** — use the "Report a problem" link in the footer.
+
+## License
+
+[MIT](./LICENSE) — fork it, remix it, host your own.

--- a/README.md
+++ b/README.md
@@ -1,47 +1,79 @@
 # GuessSong
 
-A local party music guessing game powered by Spotify playlists.
+A local party music guessing game powered by Spotify playlists. Live at **[guessong.app](https://www.guessong.app)**.
+
+No login, no accounts. The host pastes a public Spotify playlist URL (or picks a built-in one), everyone guesses out loud, and the host awards points.
+
+Current version: **1.1.0** — see [CHANGELOG.md](./CHANGELOG.md).
 
 ## How It Works
 
-1. **Setup** — Paste any public Spotify playlist URL (or pick a built-in trial playlist), add player names, choose a clip length (5–30s) and song count, and hit Start
-2. **Play** — A short audio clip plays; everyone guesses the song out loud
-3. **Score** — The host picks who got it right (+3 pts for song, +1 pt for album)
+1. **Setup** — Paste a public Spotify playlist URL (or pick a built-in trial playlist), add player names, choose a clip length and song count, hit Start
+2. **Play** — A short audio clip plays; everyone guesses the song
+3. **Score** — The host taps whoever got it right
 4. **Finish** — Final scoreboard with a shareable results image
 
-No login required. Works entirely in the browser.
+Clip lengths are `5 / 10 / 15 / 20 / 30` seconds; song counts are `10 / 20 / 30 / 50 / all`.
 
-### Mixed Playlist Mode
+### Scoring
 
-Instead of one playlist, merge everyone's playlists into a shared pool:
+The host is the judge — there's no automated answer checking.
 
-- **Room mode** — the host shows a QR code, players scan it and submit their own playlist URL from their phone, the host pulls in the pooled tracks once everyone's in
-- **Phone mode** — pass one phone around and add each player's playlist directly
+| Award | Points | Where |
+|---|---|---|
+| Correct song | +3 | Party & Buzzer modes |
+| Correct album | +1 | Party & Buzzer modes |
+| Correct "whose playlist is this?" | +2 | Mixed Playlist Mode only |
+| Correct guess | +1 | Trial mode (solo) |
 
-Pooled tracks are deduped across submissions and sampled so every contributor is fairly represented. A round-scoring history feeds a shareable "group taste card" at the end (most obscure picks, most mainstream picks, most shared tracks).
+One award of each type per round.
+
+## Game Modes
+
+Two orthogonal choices: **how you play** and **where the songs come from**.
+
+### How you play
+
+| Mode | What it is |
+|---|---|
+| **Party** (default) | Host types the player names, plays clips, and manually awards points. |
+| **Trial** | Zero-setup demo — tap one of the three bundled playlists and play solo, +1 per round. Never calls Spotify. |
+| **Buzzer** | Everyone scans one QR code and gets a full-screen buzzer on their own phone. A Cloudflare Durable Object decides who pressed first, so the host can stop refereeing and actually play. Only offered when `NEXT_PUBLIC_BUZZER_WS_URL` is set. |
+
+### Where the songs come from
+
+| Source | What it is |
+|---|---|
+| **Own playlist** | The host pastes one public Spotify playlist URL. |
+| **Built-in** | Three bundled, preview-verified playlists (華語金曲, Western Classics, 2010s Pop Hits — 16 tracks each). No Spotify credentials needed. |
+| **Mixed Playlist Mode** | Merge everyone's playlists into one pool. Either a **QR room** (players scan and submit their own playlist URL from their phone) or **phone mode** (pass one phone around). Tracks are deduped with provenance and fair-sampled per contributor, and a round-scoring history feeds a shareable "group taste card" at the end — most obscure picks, most mainstream picks, most shared tracks. |
+
+Buzzer Mode and Mixed Playlist Mode share a single room code and QR: the host claims the buzzer room first, then opens the playlist mailbox under the same code.
 
 ## Features
 
-- Spotify playlist import (Client Credentials, no user auth)
-- Built-in, preview-verified trial playlists for a no-setup demo game
-- Mixed Playlist Mode — QR-code room or single-phone collection, with fair per-contributor sampling
-- 30s audio previews via iTunes Search API (Deezer fallback)
-- Blurred album art hint system
-- Real-time progress bar + countdown during playback
-- Replay clip from guessing phase
-- Export final scores (and, in Mixed Playlist Mode, a group taste card) as a PNG
-- Installable as a PWA, with Android Web Share Target support for sharing a Spotify playlist link straight into the app
-- Mobile-friendly layout
+- Spotify playlist import via Client Credentials — no user auth, players never see a Spotify sign-in
+- Three game modes and three playlist sources (above)
+- 30s audio previews resolved from the **iTunes Search API**, falling back to **Deezer**
+- Blurred album art hint system, live progress bar + countdown, replay from the guessing phase
+- Export the final scoreboard (and the Mixed-mode taste card) as a PNG
+- Fully **bilingual** — English and Traditional Chinese landing pages (`/`, `/zh`), plus every user-facing error string in both languages, picked by device locale
+- In-app "What's new" release notes overlay
+- Installable as a PWA, with Android Web Share Target support — share a Spotify playlist link straight into the app
+- GA4 analytics behind a typed event union (opt-in via env var)
+- Mobile-first layout
 
 ## Stack
 
-- [Next.js 15](https://nextjs.org/) App Router
-- TypeScript + Tailwind CSS
-- [shadcn/ui](https://ui.shadcn.com/) components
-- Spotify Web API (Client Credentials)
-- iTunes Search API for audio previews
-- [Upstash Redis](https://upstash.com/) for the Mixed Playlist Mode room store (falls back to in-memory locally)
-- [Vitest](https://vitest.dev/) for unit tests
+- **[Next.js 15](https://nextjs.org/)** App Router, React 18, TypeScript
+- **Tailwind CSS** + [shadcn/ui](https://ui.shadcn.com/) primitives (the setup and game pages use inline styles instead)
+- **Spotify Web API** (Client Credentials) for playlists
+- **iTunes Search API** → **Deezer** for audio previews
+- **[Upstash Redis](https://upstash.com/)** for rooms, rate limiting, and the playlist/preview caches (falls back to an in-process `Map` locally)
+- **[Cloudflare Workers](https://workers.cloudflare.com/) + Durable Objects** for live buzzer rooms (`worker/`)
+- **[Vitest](https://vitest.dev/)** for both suites; `zod` for request validation, `qrcode` for room QR codes
+
+This is a **two-deployment project**: the Next.js app on Vercel, the buzzer Worker on Cloudflare. Everything except Buzzer Mode works with just the first.
 
 ## Getting Started
 
@@ -53,32 +85,24 @@ cd GuessSong
 npm install
 ```
 
-### 2. Set up environment variables
-
-Copy `.env.example` to `.env.local` and fill in the values:
+### 2. Environment variables
 
 ```bash
 cp .env.example .env.local
 ```
 
-```env
-SPOTIFY_CLIENT_ID=your_spotify_client_id
-SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
-
-# Optional — defaults to https://www.guessong.app
-NEXT_PUBLIC_BASE_URL=
-
-# Optional — enables GA4 when set
-NEXT_PUBLIC_GA_MEASUREMENT_ID=
-
-# Optional — only needed for production deploys, see note below
-UPSTASH_REDIS_REST_URL=your_upstash_redis_rest_url
-UPSTASH_REDIS_REST_TOKEN=your_upstash_redis_rest_token
-```
-
-`SPOTIFY_CLIENT_ID`/`SECRET` are app-level Client Credentials, not user login — there's no redirect URI and players never see a Spotify sign-in screen. They're required whenever the app fetches a playlist you paste in (single-playlist mode, or Mixed Playlist Mode's room/phone submissions), since `/api/playlist` calls Spotify's Web API and needs them to authenticate. If you just want to try the 3 built-in trial playlists, you can skip these — those are bundled locally and never call Spotify. Get credentials at [developer.spotify.com](https://developer.spotify.com/dashboard) — create an app and copy the Client ID and Secret.
-
-`UPSTASH_REDIS_REST_URL`/`TOKEN` back the QR-code room store used by Mixed Playlist Mode (`lib/kv.ts`) and its rate limiting (`lib/rate-limit.ts`). Leave them unset for local dev — the app falls back to an in-memory store that works fine on a single `next dev` process. **On a serverless/multi-instance deploy (e.g. Vercel) you must set these**, otherwise a room created on one instance can be invisible to a request that lands on another. Get a free database at [upstash.com](https://upstash.com).
+| Variable | Required? | Notes |
+|---|---|---|
+| `SPOTIFY_CLIENT_ID` | For pasted playlists | App-level Client Credentials, not user login — no redirect URI. Get them at [developer.spotify.com](https://developer.spotify.com/dashboard). Skip if you only want the built-in trial playlists. |
+| `SPOTIFY_CLIENT_SECRET` | ⤴ | |
+| `UPSTASH_REDIS_REST_URL` | Production | Backs rooms, rate limits, and both caches (`lib/kv.ts`). Unset locally → in-process `Map`, which is fine for one `next dev` process but **not** for multi-instance serverless. Free tier at [upstash.com](https://upstash.com). |
+| `UPSTASH_REDIS_REST_TOKEN` | ⤴ | |
+| `NEXT_PUBLIC_BUZZER_WS_URL` | Buzzer Mode only | `ws://127.0.0.1:8787` locally, `wss://guesssong-buzzer.<subdomain>.workers.dev` in production. Unset → the Buzzer Mode toggle is hidden. |
+| `NEXT_PUBLIC_BASE_URL` | Optional | Defaults to `https://www.guessong.app`. |
+| `NEXT_PUBLIC_GA_MEASUREMENT_ID` | Optional | Injects GA4 when set. Events no-op outside production regardless. |
+| `SPOTIFY_MAX_LOADS_PER_MINUTE` | Optional | Global ceiling on uncached Spotify playlist loads. Default `40`. |
+| `PREVIEW_MAX_LOOKUPS_PER_MINUTE` | Optional | Global ceiling on iTunes/Deezer lookups. Default `120`. |
+| `DEV_ORIGINS` | Optional, dev only | Comma-separated LAN hostnames (no scheme, no port) added to `allowedDevOrigins`. Needed to test from a phone. |
 
 ### 3. Run the dev server
 
@@ -86,23 +110,144 @@ UPSTASH_REDIS_REST_TOKEN=your_upstash_redis_rest_token
 npm run dev
 ```
 
-Open [http://127.0.0.1:8000](http://127.0.0.1:8000).
+Open **[http://127.0.0.1:8000](http://127.0.0.1:8000)**.
 
-> **Note:** Use `127.0.0.1:8000` specifically — the Spotify app is configured for this origin.
+> Use `127.0.0.1:8000` specifically — the Spotify app is configured for this origin.
+
+### 4. Buzzer Mode locally (optional)
+
+Buzzer Mode needs the Cloudflare Worker running alongside Next.js:
+
+```bash
+cd worker
+cp .dev.vars.example .dev.vars   # then add your LAN IP to ALLOWED_ORIGINS
+npm install
+npm run dev                       # wrangler dev on :8787
+```
+
+Then set `NEXT_PUBLIC_BUZZER_WS_URL=ws://127.0.0.1:8787` in `.env.local`.
+
+**Testing with real phones is where this trips people up.** Phones on your Wi-Fi hit the dev server by LAN IP, not `127.0.0.1`, and that LAN origin has to be allowed in *two* places:
+
+```bash
+ipconfig getifaddr en0            # macOS Wi-Fi — e.g. 10.107.0.98
+```
+
+- `.env.local` → `DEV_ORIGINS=10.107.0.98` (hostname only — Next.js refuses cross-origin `/_next/*` otherwise)
+- `worker/.dev.vars` → add `http://10.107.0.98:8000` to `ALLOWED_ORIGINS` (full origin — the browser sends this on the WebSocket upgrade)
 
 ## Scripts
 
+**Root (Next.js app)**
+
 | Command | Description |
 |---|---|
-| `npm run dev` | Start dev server on port 8000 |
+| `npm run dev` | Dev server on port 8000 |
 | `npm run build` | Production build |
 | `npm run start` | Start production server |
-| `npm run lint` | Run ESLint |
-| `npm test` | Run the Vitest suite (`tests/`) |
+| `npm run lint` | ESLint |
+| `npm test` | Vitest suite in `tests/` — does **not** include the Worker tests |
+
+**`worker/` (Cloudflare buzzer Worker)**
+
+| Command | Description |
+|---|---|
+| `npm run dev` | `wrangler dev --ip 0.0.0.0` on port 8787 |
+| `npm run deploy` | `wrangler deploy` |
+| `npm run test` | Durable Object tests, run inside workerd via `@cloudflare/vitest-pool-workers` |
+| `npm run typecheck` | `tsc --noEmit` |
+| `npm run types` | Regenerate `worker-configuration.d.ts` |
+
+**Maintenance**
+
+```bash
+node scripts/fetch-builtin-playlists.mjs   # re-curate lib/builtin-playlists-data.json
+```
+
+Verifies every bundled track still has a working 30s iTunes preview. Needs the Spotify credentials.
+
+## Project Layout
+
+```
+app/
+  page.tsx                   Setup — playlist, players, clip length, mode selection
+  game/page.tsx              The game — phase machine, playback, scoring, result images
+  about/                     "How to play" page
+  zh/                        Traditional-Chinese landing page (written natively, not translated)
+  j/[code]/                  Mixed Playlist Mode join page
+  buzz/[code]/               Buzzer Mode player page (holds the live WebSocket)
+  share/                     Web Share Target handler + /share/unsupported explainer
+  icons/[size]/              PWA icons generated at the edge
+  api/                       See the table below
+  icon.tsx, opengraph-image.tsx, robots.ts, sitemap.ts
+components/                  Buzzer button + host panel, room panel, mixed collector,
+                             install banner, changelog modal, ui/ (shadcn primitives)
+lib/                         All shared logic — see "Architecture" below
+worker/                      Cloudflare Worker + BuzzerRoom Durable Object
+tests/                       17 Vitest files, 273 cases
+types/                       Track, room, and preview wire types
+```
+
+## API Routes
+
+Every route is IP rate limited (`lib/rate-limit.ts`) with a fixed window; limits below are per IP.
+
+| Route | Method | Purpose | Limit |
+|---|---|---|---|
+| `/api/playlist` | POST | `{url}` → playlist name + tracks, via Spotify Client Credentials. Editorial playlists (IDs starting `37i9`) are rejected — they 404 for new apps. | 30 / 10 min |
+| `/api/preview` | GET | `?track=&artist=&id=` → `{previewUrl, status}` where status is `found` / `absent` / `unavailable`. `&refresh=1` re-resolves a URL that stopped playing. | 300 / 10 min (refresh: 30) |
+| `/api/preview/batch` | POST | `{tracks:[{id,name,artist}]}` (max 60) → previews for a whole game in one request. | 20 / 10 min |
+| `/api/room` | POST | Optional `{code}` → `{roomCode, hostToken, expiresAt}`. Creates the Mixed Playlist mailbox. | 10 / 10 min |
+| `/api/room/[code]/submit` | POST | `{playerName, playlistUrl}` → `{ok, trackCount}`. | 20 / 10 min |
+| `/api/room/[code]/status` | GET | Who has submitted so far (host polls every 4s). | 200 / 10 min |
+| `/api/room/[code]/pool` | GET | `?sampledPerPlayer=N` + `x-host-token` header → the sampled, deduped pool. One-shot consume. | 20 / 10 min |
+| `/share` | GET | Web Share Target — extracts a playlist from shared text and redirects to `/?playlist=…`. | — |
+| `/icons/[size]` | GET | Generated PWA icons (`192`, `512`, `maskable`). | — |
+
+**Worker** (separate Cloudflare origin): `POST /rooms` → `{code, hostToken, expiresAt}`, `GET /rooms/:code/ws` → WebSocket upgrade.
+
+## Architecture Notes
+
+### Audio previews
+
+Spotify deprecated `preview_url` for most tracks in Nov 2024, so the game resolves clips itself. On mount the game page prefetches everything with one `POST /api/preview/batch`; anything unresolved falls back to `GET /api/preview` lazily when the host presses Play. Both search iTunes first, then Deezer.
+
+Preview results are three-way, not two-way: `found`, `absent` (nothing has a clip — cached a week), and `unavailable` (we were throttled or the request never got through — cached 90 seconds). Collapsing those two nulls is a real bug that shipped once: one throttled minute marked a slice of the catalogue silent for a week.
+
+### Caching and admission control
+
+Spotify throttles per **client ID**, so every visitor shares one budget — per-IP rate limits bound one abusive client but do nothing about aggregate load. iTunes and Deezer throttle per IP, and a serverless deploy's egress IPs are shared, so the whole user base looks like one very noisy client. Both `lib/playlist-cache.ts` and `lib/preview-cache.ts` therefore run the same three layers, all fail-open, all in KV so every instance sees them:
+
+1. **Cache** — a repeat playlist or track costs zero upstream calls
+2. **Global budget** — a shared counter that refuses new work before upstream does
+3. **Cooldown** — when upstream returns 429, uncached loads are parked for `Retry-After`; cached content keeps serving, so a party mid-game is unaffected
+
+`lib/playlist-cache.ts` also coalesces concurrent loads of the same playlist into one fetch, which matters because a QR room produces a burst of simultaneous submits from one click.
+
+### Buzzer rooms
+
+Vercel pins WebSocket connections to a single function instance with no guarantee a second connection lands on the same one — there's nothing to broadcast a room to. So live rooms run on Cloudflare instead. The host `POST`s to the Worker's `/rooms`, which generates a 4-character code from an ambiguity-free alphabet and claims a Durable Object by that name; the DO *is* the registry, so a non-null return is the collision check. Players connect to `/rooms/:code/ws`, and ordering is decided by the DO's single-threaded execution — no locks, no CAS. Verdicts stay human: the room decides *who* was first, a person decides *whether* they were right. Max 12 players, 3h idle timeout.
+
+### Error messages
+
+`lib/error-messages.ts` is the only place a user-visible error string exists — one code union and one `{en, zh}` table, so a missing translation is a compile error. The server sends `{error, code}` and the client picks the language from the device locale. Localising server-side would be wrong: one room is read by several devices, and cached 404s would freeze one language into the cache for everyone.
+
+### Release notes
+
+Two hand-written changelogs, and a release updates both: [`CHANGELOG.md`](./CHANGELOG.md) is the maintainer's technical record, `lib/changelog.ts` is the plain-language bilingual copy players read in the footer overlay. `tests/changelog.test.ts` pins `LATEST_VERSION` to `package.json`'s version, so bumping one without the other fails the suite.
+
+## Testing
+
+```bash
+npm test              # 17 files, 273 cases — vitest, jsdom
+cd worker && npm test # Durable Object tests inside workerd
+```
+
+The root suite covers the pure logic (pooling, taste card, share-target parsing, game-session round-trips) and the parts most likely to regress expensively: `tests/playlist-cache.test.ts` asserts upstream **call counts** for cache hits, coalescing, cooldowns and budgets, and `tests/preview.test.ts` drives the real route handlers to pin found/absent/unavailable classification. There's no CI workflow in this repo — run both suites before shipping.
 
 ## Gameplay Notes
 
-- **Audio previews** — Spotify no longer provides preview URLs for most tracks (deprecated Nov 2024). The app falls back to the iTunes Search API to find a matching 30s preview. A small number of tracks may have no preview available.
-- **Playlists** — Use public playlists you created. Spotify editorial playlists (Discover Weekly, etc.) are not supported since those IDs return 404 for new apps.
-- **Scoring** — The host is the judge. No automated answer checking — players guess verbally and the host awards points.
-- **Found a bug?** — Use the "Report a problem" link in the footer to email the maintainer directly.
+- **Playlists** — use public playlists you created. Spotify editorial playlists (Discover Weekly, Today's Top Hits, …) are not supported: those IDs return 404 for new apps.
+- **Previews** — a small number of tracks have no 30s clip on either iTunes or Deezer and will show a "no audio" state.
+- **Scoring** — the host is the judge. No automated answer checking.
+- **Found a bug?** — use the "Report a problem" link in the footer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "guesssong",
       "version": "1.1.0",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "spotify-guess-web",
-  "version": "0.2.0",
+  "name": "guesssong",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "spotify-guess-web",
-      "version": "0.2.0",
+      "name": "guesssong",
+      "version": "1.1.0",
       "dependencies": {
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "guesssong",
   "version": "1.1.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "dev": "next dev -p 8000",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "spotify-guess-web",
+  "name": "guesssong",
   "version": "1.1.0",
   "private": true,
   "scripts": {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,18 +1,22 @@
 # GuessSong
 
-> A free music guessing game for parties. Works with any Spotify playlist. No login required. Local multiplayer.
+> A free music guessing game for parties. Works with any Spotify playlist. No login required. Play on one device, or let everyone join from their own phone.
 
 ## What it does
 
-GuessSong plays a short audio clip from a Spotify playlist and players compete to guess the song title. The host controls pacing; players type guesses in real time. Points are awarded after each round. Works on any device with a browser.
+GuessSong plays a short audio clip from a Spotify playlist and players compete to name the song. Guessing is verbal — players call out the answer and the host, who controls pacing, taps whoever got it right. Points are awarded after each round. Works on any device with a browser.
 
 ## Key facts
 
 - Free to use, no account needed
-- Paste any public Spotify playlist URL to start
-- Supports 2–10+ players on the same device or room
-- Clip duration is configurable (5s, 10s, 15s, 30s)
-- Built with Next.js, runs entirely in the browser (no server state)
+- Paste any public Spotify playlist URL, or pick one of the built-in playlists to start with no setup
+- Clip duration is configurable (5s, 10s, 15s, 20s, 30s), as is the number of songs
+- Scoring: 3 points for the song title, 1 for the album
+- Mixed Playlist Mode merges everyone's playlists into one deduplicated pool — players submit theirs by scanning a QR code, and there's a bonus point for guessing whose playlist a track came from
+- Buzzer Mode gives every player a buzzer on their own phone, so the first press wins the round and the host can play too
+- Available in English and Traditional Chinese
+- Installable as a PWA
+- Built with Next.js; live buzzer rooms run on Cloudflare Durable Objects
 
 ## URL
 


### PR DESCRIPTION
Three commits, all documentation and metadata. No source changes, no behaviour change.

## 1. README rewrite

It predated v1.0.0 and v1.1.0, so it described a smaller app than the one in the repo. Two concrete consequences: someone cloning it could not have enabled Buzzer Mode from it, and would not have known this is a **two-deployment project** (Next.js on Vercel, the buzzer Worker on Cloudflare).

Everything was verified against the source rather than inferred — route methods and rate limits read from each `route.ts`, scoring constants from `app/game/page.tsx`, env vars from `grep process.env`, test counts from an actual `npm test` run.

**Added, all previously absent:**

- **Buzzer Mode**: the mode itself, `worker/`, Durable Objects, and `NEXT_PUBLIC_BUZZER_WS_URL` — which `.env.example` documented but the README did not, so the two disagreed. Includes the LAN-IP setup, since testing on real phones needs the origin allowed in *both* `DEV_ORIGINS` and `worker/.dev.vars`, and that is the most likely place a contributor gets stuck.
- **A full API route table** with per-route rate limits, including `GET /share` and `GET /icons/[size]` (neither is in CLAUDE.md either).
- The `/about` and `/zh` pages, bilingual error messages, the changelog overlay, and GA4 analytics.
- The **caching and admission-control layer** that is the substance of v1.1.0, and the three-way `found`/`absent`/`unavailable` preview status.
- The `worker/` script table and `scripts/fetch-builtin-playlists.mjs`.

**Corrected:**

- Scoring listed only +3/+1. Mixed mode also awards **+2** for guessing whose playlist a track came from, and trial mode is a solo **+1**.
- The three game modes (`party`/`trial`/`buzzer`) and three playlist sources (`own`/`builtin`/`mixed`) were never named.
- Four env vars were missing: `NEXT_PUBLIC_BUZZER_WS_URL`, `SPOTIFY_MAX_LOADS_PER_MINUTE`, `PREVIEW_MAX_LOOKUPS_PER_MINUTE`, `DEV_ORIGINS`.
- The stack omitted Cloudflare Workers, `zod` and `qrcode`, and described Upstash as the room store when it now also backs both caches and the rate limiter.

## 2. MIT LICENSE

The site claimed to be open source in **nine places** across `/`, `/about` and `/zh` — including a card reading *"Fork it, remix it, host your own"* — while the repo carried no LICENSE. Legally none of that was true: without a license, all rights are reserved and nobody could actually reuse the code.

MIT, verified byte-for-byte against the canonical template. Also declared in `package.json` and linked from the README. Copyright line reads `Wayn Liu` — say the word if you want it as `Waynting` or a different legal name.

## 3. Package rename

`package.json` said `spotify-guess-web` while the product, the domain (`guessong.app`), the repo (`Waynting/GuessSong`) and the Worker package (`guesssong-buzzer`) all say GuessSong. Now `guesssong`, matching the Worker's prefix.

Nothing imports the name — a repo-wide grep found it only in `package.json` and `package-lock.json`, so this is metadata only. The Vercel deployment hostnames in `worker/wrangler.jsonc`'s `ALLOWED_ORIGINS` are a different string (`spotify-song-guess-web-*.vercel.app`) and are deliberately untouched, since those are live origins.

Regenerating the lockfile also picked up a pre-existing drift: it recorded version `0.2.0` against `package.json`'s `1.1.0`. No dependency churn.

## 4. llms.txt corrections

`public/llms.txt` exists to tell models what the product is, and was describing a game that doesn't exist:

- *"players type guesses in real time"* — guessing is **verbal**, and the host taps whoever got it right. That is the single most load-bearing fact about how GuessSong works.
- *"runs entirely in the browser (no server state)"* — untrue since the KV room store, and doubly untrue now that buzzer rooms are Durable Objects.
- Clip durations listed as 5/10/15/30, missing 20.
- Predated both Mixed Playlist Mode and Buzzer Mode, and did not mention the Traditional Chinese site.

## Verification

`npm test` passes at every commit: 17 files, 273 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)