### PR TITLE
feat: give every player-facing page a way back to hosting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,167 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-08-09
+
+Buzzer Mode has been putting a phone in every hand for weeks, and none of those
+phones were ever told what they were holding. `app/buzz/[code]/page.tsx` was 264
+lines containing zero `<a>` tags and not one occurrence of the string
+"GuessSong"; `app/j/[code]/page.tsx` ended at a confirmation card with nowhere
+to go; `lib/result-image.ts` printed "Played with GuessSong" on the one artifact
+that leaves the party, with no address on it. The expensive half of a viral loop
+— rooms, live sockets, share cards — already shipped. This release is the cheap
+half nobody had written.
+
+### Added
+
+- **A way back to the product from every player-facing surface.** Five of them,
+  each named once in `lib/loop-links.ts` and derived from there everywhere else.
+  The name is needed in three places at once — the link's `href`, the analytics
+  param, and the server-side validator — and hand-syncing them fails *silently*:
+  a renamed href against a stale validator still redirects, the counter just
+  stops incrementing, and that arm reads as "nobody clicked it". You would then
+  correctly conclude the CTA was useless and delete one that was working. Same
+  single-union trick `lib/buzzer-protocol.ts` uses across the Worker boundary.
+  - `buzz_footer` on all three of the buzzer page's return paths, including the
+    pre-join form — the calmest screen on that phone, and the only moment there
+    that is not competing with a song.
+  - `buzz_cta`, a full-width button on the live buzzer screen, shown only
+    between rounds and never before the first has resolved. Gated on
+    `snapshot.roundIndex >= 1 && phase === "idle"`, **not** on a `locked → idle`
+    transition: `handleResolve` in `worker/src/buzzer-room.ts` reaches `idle`
+    from both `open` and `locked`, so a round nobody buzzed at is
+    indistinguishable from one that was answered. `roundIndex` advances only on
+    `host:next`, which is exactly "a round finished", and reading it off the
+    snapshot means it survives a reconnect where the snapshot is adopted whole.
+    Rendered always and hidden when inactive, so appearing between rounds cannot
+    shove the buzz button down the screen under someone's thumb.
+  - `join_submitted` on the Mixed Playlist confirmation screen, which was a dead
+    end and is the one moment on that page where the player has finished the
+    task and is still looking.
+  - `game_over`, a QR on the host's Game Over screen. The highest-attention
+    surface the product has and the only one it never used: the music has
+    stopped, every person in the room is looking at a television, and they all
+    still have the phone they spent the last half hour buzzing with. The trial
+    overlay has shipped "Start a Party Game →" since launch; the party path, the
+    one with five other people in it, had nothing.
+  - `share`, a QR drawn into the result card itself.
+- **`POST /api/pulse`**, for the two facts the browser knows and no existing
+  request carries: that a loop surface was rendered, and that a hosted game
+  started with the device's game index. Sent with `navigator.sendBeacon`,
+  because both fire immediately before a navigation and an in-flight `fetch` is
+  cancelled as the document tears down — the measurement would be lost exactly
+  in the cases worth measuring, and lost silently. Body validated field by field
+  in `lib/pulse.ts`: it is unauthenticated by necessity (the people it measures
+  have no accounts), so the body is as trustworthy as a query string, and one of
+  its values becomes part of a KV key.
+- **`host_game_index`**, a per-device count of hosted games in `localStorage`
+  (`lib/host-session.ts`). `>= 2` is the number this whole line of work is
+  waiting on — proof that someone came back — and it is deliberately reported as
+  a **floor**: iOS evicts script-writable storage after seven days without a
+  visit, which is precisely the gap between two parties, private windows start
+  empty, and a laptop passed around a room is several hosts wearing one
+  identity. Raw integer in GA4, not a bucket: CLAUDE.md's bucketing rule is
+  about *failure* params, where the value comes from an upstream string; every
+  count param already there (`round_index`, `player_count`, `rounds_played`) is
+  raw, and bucketing at collection freezes the boundaries before the
+  distribution is known.
+- **`arrived_from` on `game_started`**, credited to the last loop touch within
+  60 days rather than to the visit that carried the `?ref=`. The conversion is
+  not same-session — somebody taps a CTA on a friend's sofa and hosts their own
+  party a fortnight later — so attributing only within the pageview would record
+  almost every real conversion as organic and report a working loop as dead.
+- **Server-side counters** in `lib/loop-stats.ts`, held 30 days rather than the
+  7 `lib/playlist-cache.ts` uses. A weekly digest whose window ends a couple of
+  days back would expire the oldest day of every report right before reading it,
+  and an expired key is indistinguishable from one never written. Also carries a
+  **liveness marker**, bumped unconditionally alongside every other counter,
+  because `mget` returns null for a key that was never created and that is what
+  a genuine zero looks like too — without it, "the CTA does nothing", the single
+  most important negative result available here, would render as "no data yet"
+  forever.
+- **`dayBucket()` in `lib/kv.ts`**, replacing the copies that had accumulated in
+  `lib/playlist-cache.ts` and `lib/preview-cache.ts`. The writer and the reader
+  of a day-bucketed counter always live in different modules, so the exact
+  string is the contract between them; a divergence throws nothing and simply
+  addresses a different key. UTC, so a lambda and a laptop agree. Pinned by a
+  test asserting the literal.
+
+### Changed
+
+- **The loop link is a real navigation to `/r/[surface]`, not a click handler.**
+  The click being measured is the click that leaves the page, so a background
+  report fired at that moment is the report most likely to be cancelled. Routing
+  through the server makes the navigation itself the measurement — there is
+  nothing left to cancel. Plain `<a>` rather than `next/link`, because
+  prefetching a counting endpoint would inflate it with hits nobody made, and
+  `/r` is disallowed in `app/robots.ts` for the same reason.
+  - **The visitor always reaches the setup page.** Unknown segment, spent rate
+    limit, KV unavailable: every branch still redirects, and only the count is
+    allowed to be lost. The person clicking is precisely the person the feature
+    exists to reach; refusing them to protect an integer would be an own goal.
+    Same fail-open contract as `lib/playlist-cache.ts`'s global budget.
+  - The limiter is sized for a household rather than a person (120/hour), since
+    it is keyed by IP and a party is a dozen phones behind one Wi-Fi address —
+    `app/api/room/[code]/status` is the standing lesson on what a per-device
+    budget does to a whole room. Throttled clicks are counted separately so the
+    undercount appears in the digest instead of quietly depressing the rate.
+  - `Cache-Control: no-store`, or an intermediary caches the 302 and every later
+    click from that network is served without reaching the counter: the redirect
+    would keep working while the measurement silently stopped.
+- **The result card footer is a QR, not a line of text.** It used to read
+  "Played with GuessSong" — a brand with no address — so anyone who saw it in a
+  group chat had to already know the name, which is the audience it does not
+  need to reach. Printing the URL as text is barely better; nobody retypes a URL
+  off a screenshot. `drawCardFooter` is now async and takes the code, and
+  `CARD_FOOTER_HEIGHT` is exported so the two callers that size the canvas
+  cannot drift from what the footer draws.
+  - **The URL is deliberately not also added to the `navigator.share` payload.**
+    iOS drops `url` when a file is attached, and several Android targets drop
+    the *file* when a `url` is present. Risking the image, which is the entire
+    payload, to add a link one platform throws away is a bad trade.
+- `?ref=` is read from `window.location.search` in an effect, **not**
+  `useSearchParams`. `app/page.tsx` is a client component that is still
+  statically prerendered, carries the FAQ structured data, and takes
+  essentially all of the site's traffic; an unsuspended `useSearchParams` either
+  fails the Next 15 build or opts the page out of prerendering, and there is no
+  Suspense boundary anywhere in this app. Verified against `next build`: `/`
+  remains `○ (Static)`.
+- `?ref=` is validated through `isLoopSurface` before it can reach a GA4 param.
+  `/?ref=` is a public URL, and CLAUDE.md's analytics rule against user input in
+  params is the same hazard by a shorter path. Anything unrecognised is
+  `organic`.
+- Impressions are counted once per surface per tab. `room_join_opened` fires per
+  page load — a phone that drops Wi-Fi and reloads counts twice, as this file
+  already noted in 1.0.0 — which makes it a floor rather than a denominator.
+
+### Known gaps
+
+- **`arrived_from: "organic"` is a catch-all.** Every lost attribution lands
+  there: a PWA launched from the home screen, a stripped query string, a URL
+  retyped without its path. Since organic is already effectively all of the
+  traffic, the loop's share of starts is a floor and a low number cannot be read
+  as "the CTA does not work" without ruling out "we could not see it".
+- **The `share` arm is the weakest link and stays that way.** It now depends on
+  someone scanning a QR out of a forwarded image rather than typing an address,
+  which is a large improvement over nothing but still the only surface whose hit
+  does not originate on a page of ours.
+- **No digest yet.** The counters are being written and nothing reads them. That
+  is the next change, and until it lands this release has the same defect as
+  everything before it: the numbers exist and require a human to go and fetch
+  them.
+- `host_game_index` is capped at 10 in KV to bound the key space. Fine for the
+  question being asked; it would need revisiting before anyone studies the tail.
+- The buzzer wire protocol still has no end-of-game signal (`BuzzerPhase` is
+  `idle | open | locked`, `ClientMessage` has no `host:end`), so the player's
+  phone cannot react to the game finishing. `buzz_cta` uses "a round has
+  resolved" as the nearest available proxy. If its conversion comes in clearly
+  below `join_submitted`, that gap is the signal that the protocol change is
+  worth making.
+- Route handlers still have no unit tests anywhere in this repo. The two added
+  here are shells over `lib/loop-redirect.ts` and `lib/pulse.ts`, which are
+  tested, but the 302 status, the `Location` header and the `Cache-Control` are
+  verified only by reading them.
+
 ## [1.2.0] - 2026-08-09
 
 ### Fixed

--- a/app/api/pulse/route.ts
+++ b/app/api/pulse/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getClientIp, rateLimit } from "@/lib/rate-limit";
+import { parsePulse } from "@/lib/pulse";
+import { recordGameStart, recordLoopImpression } from "@/lib/loop-stats";
+
+/**
+ * Fire-and-forget counters from the browser. See `lib/pulse.ts` for what the
+ * two events are and why they cannot ride on an existing request.
+ *
+ * Sent with `navigator.sendBeacon`, so this handler must stay cheap and must
+ * never make the caller care about the answer.
+ */
+
+/**
+ * Sized for a household, not a person: the limiter is keyed by IP and a party
+ * is a dozen phones behind one Wi-Fi address, each reporting an impression and
+ * possibly a game start. `app/api/room/[code]/status` is the standing lesson
+ * that a per-device budget throttles a whole room.
+ */
+const PULSE_LIMIT = 240;
+const PULSE_WINDOW_SECONDS = 60 * 60;
+
+/** Beacons are tiny; anything larger is not one of ours. */
+const MAX_BODY_BYTES = 512;
+
+export async function POST(req: NextRequest) {
+  // Over budget: drop the event and say nothing. A 429 would be worse than
+  // useless — `sendBeacon` cannot see it, and any client that could would
+  // retry, spending more of the budget that was just found to be spent.
+  try {
+    const ip = getClientIp(req);
+    const { allowed } = await rateLimit(
+      `pulse:${ip}`,
+      PULSE_LIMIT,
+      PULSE_WINDOW_SECONDS
+    );
+    if (!allowed) return new NextResponse(null, { status: 204 });
+  } catch {
+    // Fail open: an unavailable limiter must not cost a measurement.
+  }
+
+  let body: unknown;
+  try {
+    const text = await req.text();
+    if (text.length > MAX_BODY_BYTES) {
+      return new NextResponse(null, { status: 400 });
+    }
+    body = JSON.parse(text);
+  } catch {
+    return new NextResponse(null, { status: 400 });
+  }
+
+  const event = parsePulse(body);
+  if (!event) return new NextResponse(null, { status: 400 });
+
+  // Both recorders are fail-soft, so nothing below can throw.
+  if (event.kind === "loop_impression") {
+    await recordLoopImpression(event.surface);
+  } else {
+    await recordGameStart(event.hostGameIndex);
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/app/buzz/[code]/page.tsx
+++ b/app/buzz/[code]/page.tsx
@@ -29,6 +29,7 @@ import {
   BUZZER_ERROR_CODES,
 } from "@/lib/error-messages";
 import { useErrorLocale } from "@/lib/use-error-locale";
+import { LoopCtaButton, LoopFooter } from "@/components/loop-cta";
 
 const NAME_STORAGE_KEY = "guesssong_player_name";
 
@@ -203,6 +204,10 @@ export default function BuzzPlayerPage() {
             {submitting ? "Submitting..." : wantsPlaylist ? "Submit & Join" : "Join Room"}
           </Button>
           {joinError && <p className="text-sm text-destructive">{joinError}</p>}
+          {/* The calmest screen on this phone: the player has just scanned a
+              code, the room has not started, and they are reading. It is the
+              only moment here that is not competing with a song. */}
+          <LoopFooter surface="buzz_footer" />
         </div>
       </main>
     );
@@ -233,6 +238,9 @@ export default function BuzzPlayerPage() {
           >
             Try a different name
           </Button>
+          {/* A dead end by definition — the room is gone or the name is taken.
+              Somewhere to go is worth more here than on any working screen. */}
+          <LoopFooter surface="buzz_footer" />
         </div>
       </main>
     );
@@ -256,9 +264,34 @@ export default function BuzzPlayerPage() {
         onBuzz={buzz}
       />
 
-      <p className="px-1 pb-1 text-center text-xs text-muted-foreground">
+      <p className="px-1 text-center text-xs text-muted-foreground">
         Hold your phone ready. Buzz the moment the clip starts, then shout the answer.
       </p>
+
+      {/*
+        Between rounds only, and never before the first round has resolved —
+        a player who has not yet buzzed at anything has no idea what this app
+        does and is the wrong person to ask.
+
+        `roundIndex` is the right signal and `phase` transitions are not:
+        `handleResolve` in the Worker reaches `idle` from both `open` and
+        `locked`, so a round nobody buzzed at looks identical to one that was
+        answered. `roundIndex` advances only on `host:next`
+        (worker/src/buzzer-room.ts), which is exactly "a round finished".
+        Reading it off the snapshot rather than a ref also means it survives a
+        reconnect, where the whole snapshot is adopted wholesale.
+
+        Rendered always and hidden when inactive so it can never reflow the
+        buzz button underneath someone's thumb.
+      */}
+      <div className="px-1 pb-1">
+        <LoopCtaButton
+          surface="buzz_cta"
+          active={snapshot?.phase === "idle" && (snapshot?.roundIndex ?? 0) >= 1}
+        >
+          Host the next one →
+        </LoopCtaButton>
+      </div>
     </main>
   );
 }

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -17,15 +17,18 @@ import {
 import { fetchPreview, fetchPreviewBatch } from "@/lib/preview-client";
 import { isPreviewSettled, type PreviewBatchTrack } from "@/types/preview";
 import { BuzzerHostPanel, type BuzzerControls } from "@/components/buzzer-host-panel";
+import { LoopQr } from "@/components/loop-qr";
 import type { RoundHistoryEntry } from "@/lib/round-history";
 import { buildTasteCard } from "@/lib/taste-card";
 import {
+  CARD_FOOTER_HEIGHT,
   createResultCanvas,
   drawCardBackground,
   drawCardHeader,
   drawCardFooter,
   shareOrDownloadCanvas,
 } from "@/lib/result-image";
+import { loopQrDataUrl } from "@/lib/loop-qr";
 
 type Phase = "waiting" | "playing" | "guessing" | "revealed" | "finished";
 
@@ -568,8 +571,9 @@ export default function GamePage() {
     const W = 640;
     const rowH = 64;
     const headerH = 200;
-    const footerH = 80;
+    const footerH = CARD_FOOTER_HEIGHT;
     const H = headerH + sortedPlayers.length * rowH + footerH;
+    const qr = await loopQrDataUrl();
     const { canvas, ctx } = createResultCanvas(W, H);
 
     drawCardBackground(ctx, W, H);
@@ -622,7 +626,7 @@ export default function GamePage() {
     });
 
     const footerY = headerH + sortedPlayers.length * rowH + 20;
-    drawCardFooter(ctx, W, footerY);
+    await drawCardFooter(ctx, W, footerY, qr);
     const outcome = await shareOrDownloadCanvas(
       canvas,
       `guesssong-results-${Date.now()}.png`,
@@ -646,7 +650,8 @@ export default function GamePage() {
       sharedTracks.length > 0 ? 40 + sharedTracks.length * sharedRowH + 20 : 0;
     const awardCount = (tasteCard.mostObscure ? 1 : 0) + (tasteCard.mostMainstream ? 1 : 0);
     const awardsSectionH = 40 + awardCount * 70 + 20;
-    const footerH = 80;
+    const footerH = CARD_FOOTER_HEIGHT;
+    const qr = await loopQrDataUrl();
     const H = headerH + sharedSectionH + awardsSectionH + footerH;
     const { canvas, ctx } = createResultCanvas(W, H);
 
@@ -723,7 +728,7 @@ export default function GamePage() {
       y += 70;
     }
 
-    drawCardFooter(ctx, W, y + 20);
+    await drawCardFooter(ctx, W, y + 20, qr);
     const outcome = await shareOrDownloadCanvas(
       canvas,
       `guesssong-taste-card-${Date.now()}.png`,
@@ -1807,6 +1812,12 @@ export default function GamePage() {
                   </button>
                 )}
               </div>
+
+              {/* The room is looking at this screen with their phones already
+                  in hand. The trial overlay above has shipped a way onward for
+                  a single player since launch; the party path — the one with
+                  five other people in it — has never had one. */}
+              <LoopQr />
             </div>
           )}
         </main>

--- a/app/j/[code]/page.tsx
+++ b/app/j/[code]/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { LoopCtaButton, LoopFooter } from "@/components/loop-cta";
 
 type SubmitStatus = "idle" | "loading" | "done" | "error";
 
@@ -90,11 +91,18 @@ export default function JoinRoomPage() {
               Received {trackCount} track{trackCount === 1 ? "" : "s"} from your playlist.
             </CardDescription>
           </CardHeader>
-          <CardContent>
+          <CardContent className="flex flex-col gap-4">
             <p className="text-sm text-muted-foreground">
               You can close this page now — the host will start the game once everyone&apos;s in.
               No one else can see your playlist.
             </p>
+            {/* This screen used to end here. It is the one moment on this page
+                where the player has finished the task, has nothing left to do,
+                and is still looking — which makes it the best placement in the
+                whole flow and, until now, a dead end. */}
+            <LoopCtaButton surface="join_submitted">
+              Host your own game →
+            </LoopCtaButton>
           </CardContent>
         </Card>
       </main>
@@ -136,6 +144,7 @@ export default function JoinRoomPage() {
             {status === "loading" ? "Submitting..." : "Submit Playlist"}
           </Button>
           {error && <p className="text-sm text-destructive">{error}</p>}
+          <LoopFooter surface="join_footer" />
         </CardContent>
       </Card>
     </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,9 @@ import { useRouter } from "next/navigation";
 import type { Track } from "@/types";
 import { DEFAULT_SAMPLED_PER_PLAYER, type RoomSubmissionSummary, type RoomPoolResponse } from "@/types/room";
 import { trackEvent } from "@/lib/analytics";
+import { arrivedFrom } from "@/lib/loop-links";
+import { bumpHostGameCount, recallLoopRef, rememberLoopRef } from "@/lib/host-session";
+import { reportGameStart } from "@/lib/loop-client";
 import { REPORT_PROBLEM_MAILTO } from "@/lib/contact";
 import {
   AppError,
@@ -234,6 +237,7 @@ export default function SetupPage() {
         song_count: data.tracks.length,
         playlist_source: "mixed",
         game_mode: room ? "buzzer" : "party",
+        ...recordHostedStart(),
       });
       trackEvent("room_started", {
         contributor_count: data.players.length,
@@ -252,10 +256,46 @@ export default function SetupPage() {
 
   useEffect(() => {
     setMounted(true);
+    // Read straight off `window.location`, not `useSearchParams`. This page is
+    // a client component that is still statically prerendered — it carries the
+    // FAQ structured data and takes essentially all of the site's traffic — and
+    // an unsuspended `useSearchParams` would either fail the build or opt the
+    // whole page out of prerendering. There is no Suspense boundary anywhere in
+    // this app, and this is not the page to introduce one on.
+    const query = new URLSearchParams(window.location.search);
+
     // Prefill from the share target redirect (/share → /?playlist=...).
-    const shared = new URLSearchParams(window.location.search).get("playlist");
+    const shared = query.get("playlist");
     if (shared) setPlaylistUrl(shared);
+
+    // Attribution from /r/[surface]. Stored rather than used immediately: the
+    // person who just followed a call to action at someone else's party is not
+    // about to host one tonight, so the game this credits is weeks away.
+    const ref = query.get("ref");
+    if (ref) rememberLoopRef(ref);
   }, []);
+
+  /**
+   * Everything a hosted start owes the funnel, in one place.
+   *
+   * Called by the three paths that begin a real party — own playlist, mixed
+   * pool, and the room variant — and deliberately not by `handleQuickStart`,
+   * which is one person trying the app on a built-in playlist. Counting that
+   * as hosting would inflate the single number that answers whether anyone
+   * comes back.
+   *
+   * Has side effects: it advances the device's game counter and beacons the
+   * new index to `/api/pulse`, which is the only path by which that number
+   * reaches the weekly digest. GA4 gets the same value as a param below.
+   */
+  function recordHostedStart() {
+    const hostGameIndex = bumpHostGameCount();
+    reportGameStart(hostGameIndex);
+    return {
+      host_game_index: hostGameIndex,
+      arrived_from: arrivedFrom(recallLoopRef()),
+    };
+  }
 
   const isValidSpotifyUrl = playlistUrl.includes("spotify.com/playlist") || playlistUrl.includes("spotify:playlist:");
   const isEditorial = playlistUrl.includes("37i9");
@@ -330,6 +370,7 @@ export default function SetupPage() {
         song_count: limited.length,
         playlist_source: "own",
         game_mode: room ? "buzzer" : "party",
+        ...recordHostedStart(),
       });
       router.push("/game");
     } catch (e: unknown) {
@@ -429,6 +470,7 @@ export default function SetupPage() {
         song_count: pooled.length,
         playlist_source: "mixed",
         game_mode: room ? "buzzer" : "party",
+        ...recordHostedStart(),
       });
       trackEvent("mixed_pool_built", {
         contributor_count: mixedContributions.length,

--- a/app/r/[surface]/route.ts
+++ b/app/r/[surface]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getClientIp, rateLimit } from "@/lib/rate-limit";
+import { handleLoopHit } from "@/lib/loop-redirect";
+
+/**
+ * Every loop link goes through here: the footers and calls to action on the
+ * player-facing pages, and the QR printed on the result card. The server
+ * counts the hit and forwards to the setup page, so the click is measured by
+ * the navigation itself rather than by a background request the browser is
+ * about to cancel.
+ *
+ * The decision lives in `lib/loop-redirect.ts`. This file is deliberately a
+ * shell — it resolves the segment, asks the limiter, and builds a response.
+ *
+ * Not in the sitemap, and disallowed in `app/robots.ts`: it is plumbing, it
+ * returns no content, and a crawler walking it would both waste crawl budget
+ * and inflate the counter.
+ */
+
+/**
+ * Generous on purpose. The limiter is keyed by IP and a party is a dozen
+ * phones sharing one Wi-Fi egress address, so the honest unit here is "a
+ * household for an evening", not "a person". `app/api/room/[code]/status`
+ * already taught this lesson the expensive way: a per-IP bucket sized for one
+ * device throttles the whole room. 120 an hour is far past anything a real
+ * party produces and still bounds a script.
+ */
+const LOOP_LIMIT = 120;
+const LOOP_WINDOW_SECONDS = 60 * 60;
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ surface: string }> }
+) {
+  const { surface } = await params;
+
+  // Fail *open*: if the limiter itself is unavailable the click still counts.
+  // Losing KV must mean "back to how it was", not "stop measuring" — and
+  // certainly not "stop redirecting".
+  let allowed = true;
+  try {
+    const ip = getClientIp(req);
+    ({ allowed } = await rateLimit(
+      `loop:${ip}`,
+      LOOP_LIMIT,
+      LOOP_WINDOW_SECONDS
+    ));
+  } catch {
+    allowed = true;
+  }
+
+  const outcome = await handleLoopHit(surface, allowed);
+
+  const res = NextResponse.redirect(new URL(outcome.destination, req.url), 302);
+  // Without this an intermediary can cache the 302 and every later click from
+  // that network is served without ever reaching the counter — the redirect
+  // would keep working while the measurement quietly stopped, which is the
+  // exact failure this route was built to avoid.
+  res.headers.set("Cache-Control", "no-store, max-age=0");
+  return res;
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -9,7 +9,13 @@ export default function robots(): MetadataRoute.Robots {
       allow: "/",
       // /buzz and /j are ephemeral room codes — nothing to index, and crawling
       // them just burns budget on pages that 404 once the room's TTL expires.
-      disallow: ["/game", "/api/", "/share", "/buzz", "/j"],
+      //
+      // /r is the loop redirect. It has no content to index, and every fetch of
+      // it increments a counter — so a crawler, or the link unfurler in
+      // whichever chat app a result card lands in, would report clicks nobody
+      // made. Robots is a request rather than a guarantee, which is part of why
+      // the counter is only ever read as a floor.
+      disallow: ["/game", "/api/", "/share", "/buzz", "/j", "/r"],
     },
     sitemap: `${BASE_URL}/sitemap.xml`,
   };

--- a/components/loop-cta.tsx
+++ b/components/loop-cta.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+/**
+ * The way out of a player-facing page and back into hosting your own game.
+ *
+ * Both join pages ended without one for months: `app/buzz/[code]/page.tsx` was
+ * 264 lines that never contained the string "GuessSong", and `app/j/[code]`
+ * finished at a confirmation card with nowhere to go. Every party put four or
+ * five phones on those pages and told none of them what the thing was called.
+ *
+ * ## Why the link is a real navigation
+ *
+ * `href` goes to `/r/[surface]`, which counts the hit and redirects. It has to
+ * be a genuine link, not a click handler that reports and then routes: the
+ * browser cancels in-flight requests as a page tears down, so a background
+ * report fired on the click that leaves the page is exactly the report most
+ * likely to be lost. Making the navigation itself the measurement leaves
+ * nothing to cancel. That is also why `<a>` rather than `next/link` — this is a
+ * server round trip on purpose, and prefetching a counting endpoint would
+ * inflate it with hits nobody made.
+ */
+
+import { useEffect } from "react";
+import { loopHref, type LoopSurface } from "@/lib/loop-links";
+import { reportLoopClick, reportLoopImpression } from "@/lib/loop-client";
+
+/**
+ * The behaviour, without any opinion about how it looks.
+ *
+ * Exists because `app/game/page.tsx` styles everything with inline styles and
+ * `<style>` blocks while the join pages use Tailwind, so a single styled
+ * component cannot serve both. The part worth sharing is the part that can
+ * silently break — the surface name, the impression, the click — and that is
+ * all in here.
+ */
+export function useLoopSurface(
+  surface: LoopSurface,
+  /**
+   * False while the surface is rendered but not actually visible — the buzzer
+   * page keeps its call to action mounted and hidden between rounds so that
+   * showing it cannot shove the buzz button down the screen at the exact
+   * moment someone is about to hit it. An impression for a hidden element
+   * would inflate the denominator and depress every rate built on it.
+   */
+  active = true
+): { href: string; onClick: () => void } {
+  useEffect(() => {
+    if (active) reportLoopImpression(surface);
+  }, [surface, active]);
+
+  return {
+    href: loopHref(surface),
+    onClick: () => reportLoopClick(surface),
+  };
+}
+
+/**
+ * The quiet one. A line of text at the bottom of a page saying what this is.
+ *
+ * Its job is mostly not to be a call to action: it is there so that a player
+ * who wondered "what am I even looking at" has an answer, and so the brand
+ * appears at all on the pages most people see.
+ */
+export function LoopFooter({ surface }: { surface: LoopSurface }) {
+  const { href, onClick } = useLoopSurface(surface);
+  return (
+    <p className="pt-2 text-center text-xs text-muted-foreground">
+      <a
+        href={href}
+        onClick={onClick}
+        className="underline-offset-4 hover:underline"
+      >
+        Played with <span className="font-semibold">GuessSong</span> — host your own
+      </a>
+    </p>
+  );
+}
+
+/**
+ * The loud one. Shown at the moments a player has just finished doing
+ * something and is looking at a screen with nothing left on it.
+ */
+export function LoopCtaButton({
+  surface,
+  children,
+  /**
+   * When false the button keeps its space and stops existing for the user.
+   *
+   * Reserving the height rather than unmounting is the point: on the buzzer
+   * page this sits under a button the player is about to slam, and appearing
+   * between rounds would move that button a centimetre at the worst possible
+   * moment. Hidden, it reports no impression and cannot be tabbed to.
+   */
+  active = true,
+}: {
+  surface: LoopSurface;
+  children: React.ReactNode;
+  active?: boolean;
+}) {
+  const { href, onClick } = useLoopSurface(surface, active);
+  return (
+    <a
+      href={href}
+      onClick={onClick}
+      aria-hidden={!active}
+      tabIndex={active ? undefined : -1}
+      className={`flex h-12 w-full items-center justify-center rounded-md bg-[#1DB954] px-4 text-base font-semibold text-black transition-opacity ${
+        active ? "opacity-100 hover:opacity-90" : "pointer-events-none opacity-0"
+      }`}
+    >
+      {children}
+    </a>
+  );
+}

--- a/components/loop-qr.tsx
+++ b/components/loop-qr.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+/**
+ * A scannable way off the host's screen, for the room to use.
+ *
+ * The Game Over screen is the highest-attention surface this product has and
+ * the only one it never used: the music has stopped, the host is not touching
+ * anything, and every person in the room is looking at a television with their
+ * phone already in their hand — because they spent the last half hour buzzing
+ * with it. Until now that screen showed scores and two buttons the host does
+ * not need help finding.
+ *
+ * A printed address would be the wrong answer here for the same reason it is
+ * the wrong answer on the result card: nobody types a URL off a screen. A QR
+ * is the only thing five people can act on at once from across a room.
+ *
+ * `qrcode` is already a production dependency — `components/buzzer-host-panel`
+ * and `components/room-panel` both use it for the join code — so this costs a
+ * component and no bundle.
+ */
+
+import { useEffect, useState } from "react";
+import type { LoopSurface } from "@/lib/loop-links";
+import { loopQrDataUrl } from "@/lib/loop-qr";
+import { reportLoopImpression } from "@/lib/loop-client";
+
+export function LoopQr({
+  surface = "game_over",
+  size = 92,
+}: {
+  surface?: LoopSurface;
+  size?: number;
+}) {
+  const [dataUrl, setDataUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    // Always the production URL, never `window.location.origin` — the inverse
+    // of the rule for a room QR (`lib/buzzer-client.ts:78`). A room code has to
+    // point at the deploy the room lives on; this one is scanned by people who
+    // may open it another day, when a preview URL would be dead.
+    void loopQrDataUrl(surface, size * 2).then((url) => {
+      // A failed render is not worth an error state on a celebration screen;
+      // the caption below still names the product.
+      if (!cancelled) setDataUrl(url);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [surface, size]);
+
+  // Counted as an impression once per session even when the image fails: the
+  // room was shown the surface either way, and quietly dropping those would
+  // make the scan rate look better than it is.
+  useEffect(() => {
+    reportLoopImpression(surface);
+  }, [surface]);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "12px",
+        marginTop: "14px",
+        flexShrink: 0,
+      }}
+    >
+      {dataUrl && (
+        /* eslint-disable-next-line @next/next/no-img-element -- a data: URL
+           generated at runtime; next/image would add a loader for nothing. */
+        <img
+          src={dataUrl}
+          alt=""
+          width={size}
+          height={size}
+          style={{ borderRadius: "6px", display: "block" }}
+        />
+      )}
+      <div style={{ textAlign: "left" }}>
+        <div
+          style={{
+            fontFamily: "'Bebas Neue', sans-serif",
+            fontSize: "20px",
+            letterSpacing: "0.06em",
+            color: "#1DB954",
+            lineHeight: 1.1,
+          }}
+        >
+          GuessSong
+        </div>
+        <div style={{ fontSize: "12px", color: "#666", marginTop: "2px" }}>
+          Scan to host your own party
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -11,6 +11,7 @@ import type { ShareOutcome } from "@/lib/result-image";
 // Type-only, so the analytics <-> game-session cycle is erased at compile time
 // and never becomes a runtime import cycle.
 import type { GameMode } from "@/lib/game-session";
+import type { ArrivedFrom, LoopSurface } from "@/lib/loop-links";
 
 export type PlaylistSource = "own" | "builtin" | "mixed";
 export type ShareType = "track" | "album" | "artist" | "unknown";
@@ -74,6 +75,33 @@ export type AnalyticsEvent =
          * one meaningless line.
          */
         game_mode?: GameMode;
+        /**
+         * Which loop surface this host came in through, or `organic`.
+         *
+         * Last loop touch within `LOOP_REF_TTL_MS`, not same-pageview: the
+         * conversion happens at a *later* party, so crediting only the visit
+         * that carried the `?ref=` would record almost every real conversion
+         * as organic and report a working loop as dead.
+         *
+         * Always produced by `arrivedFrom()`, never read straight off the URL
+         * — `/?ref=` is public and this is a GA4 param.
+         */
+        arrived_from?: ArrivedFrom;
+        /**
+         * How many games this device has hosted, this one included. 1 for a
+         * first-time host.
+         *
+         * A raw integer, not a bucket: CLAUDE.md's bucketing rule is about
+         * *failure* params, where the value comes from an upstream string and
+         * the hazard is cardinality and user input. Every count param already
+         * here (`round_index`, `player_count`, `rounds_played`) is raw, and
+         * bucketing at collection time would freeze the boundaries before the
+         * distribution is known. The KV counter behind the digest caps its own
+         * key space separately, where the cardinality actually matters.
+         *
+         * Absent on solo trials, which are one person and not a party.
+         */
+        host_game_index?: number;
       };
     }
   | {
@@ -268,6 +296,38 @@ export type AnalyticsEvent =
        *  release can be checked against how many people actually read it. */
       name: "changelog_opened";
       params: { version: string };
+    }
+  | {
+      /**
+       * A loop surface was rendered to someone. The denominator.
+       *
+       * Without it a click count cannot be read at all: twelve out of fifteen
+       * is a working call to action and twelve out of nine thousand is a dead
+       * one, and the two call for opposite responses. Deliberately not reusing
+       * `room_join_opened`, which fires per page load rather than per person
+       * (a phone that drops Wi-Fi and reloads counts twice) and so is a floor
+       * rather than a denominator.
+       */
+      name: "loop_surface_shown";
+      params: { surface: LoopSurface };
+    }
+  | {
+      /**
+       * Someone followed a loop link back to the setup page.
+       *
+       * The GA4 copy of a number the server also counts on `/r/[surface]`.
+       * Both exist on purpose and they will disagree: an ad blocker kills this
+       * one and not the redirect, a spent rate-limit window drops the redirect's
+       * count and not this one. **KV is authoritative for the digest**; this
+       * half is here for cohorting and for the questions nobody has thought of
+       * yet — and the gap between the two is itself a reading of how much of
+       * this audience blocks analytics.
+       *
+       * Fired with the navigation, so it must be sent in a way that survives
+       * the page tearing down. See `lib/pulse-client.ts`.
+       */
+      name: "player_to_host_click";
+      params: { surface: LoopSurface };
     };
 
 export type AnalyticsEventName = AnalyticsEvent["name"];

--- a/lib/changelog.ts
+++ b/lib/changelog.ts
@@ -49,6 +49,34 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "1.3.0",
+    date: "2026-08-09",
+    headline:
+      "If you played on someone else's phone, you can now find your way back — the game finally tells you what it is called.",
+    headlineZh:
+      "在別人的房間玩過之後，現在找得到回來的路了 —— 這個遊戲總算會告訴你它叫什麼名字。",
+    changes: [
+      {
+        kind: "new",
+        text: "The Game Over screen now shows a QR code. Everyone in the room already has their phone out from buzzing, so anyone who wants to run the next party can just point it at the screen.",
+        textZh:
+          "遊戲結束的畫面現在會顯示一個 QR code。大家搶答完手機本來就還在手上，誰想主辦下一場，對著螢幕掃一下就好。",
+      },
+      {
+        kind: "new",
+        text: "Saved result cards carry a QR code too. Until now a card you sent to a group chat said the name of the game and nothing else, so anyone it reached had to already know where to find us.",
+        textZh:
+          "存下來的成績卡也帶著 QR code 了。以前傳到群組裡的卡片只寫了遊戲名字，收到的人得本來就知道去哪裡找我們才行。",
+      },
+      {
+        kind: "better",
+        text: "The buzzer and playlist pages on your phone now say what this is and link back to it. They used to be a dead end: you buzzed, the game ended, and the page never mentioned the name at all.",
+        textZh:
+          "手機上的搶答頁和交歌單頁，現在會說明這是什麼並附上連結。以前那是死路：你按完搶答鈕、遊戲結束，那個頁面從頭到尾沒提過名字。",
+      },
+    ],
+  },
+  {
     version: "1.2.0",
     date: "2026-08-09",
     headline:

--- a/lib/host-session.ts
+++ b/lib/host-session.ts
@@ -1,0 +1,135 @@
+/**
+ * The two things a device remembers between parties: how many games it has
+ * hosted, and which loop surface brought it here.
+ *
+ * Both live in `localStorage` and both are per-device, never per-person. There
+ * are no accounts and there will not be — the whole product works because a
+ * host pastes a link and starts, and anything that asks for a login is a worse
+ * product. So this is the cheapest identity that answers "did anyone come
+ * back", and it is deliberately not a user id: nothing here is sent anywhere
+ * that could join it to a person.
+ *
+ * ## Read every number here as a floor
+ *
+ * iOS evicts script-writable storage after seven days without a visit, which
+ * is precisely the gap between two parties. Private windows start empty. A
+ * laptop passed around a room is several hosts wearing one identity. So a low
+ * repeat-host figure is not evidence that nobody came back — it is the sum of
+ * "did not come back" and "came back and we could not tell". Only the upward
+ * direction of this number means anything.
+ */
+
+const GAMES_KEY = "guesssong_host_games";
+const REF_KEY = "guesssong_loop_ref";
+
+/**
+ * How long a loop click keeps crediting a later game.
+ *
+ * The conversion this measures is not same-session. Someone taps "host the
+ * next one" on a friend's sofa, and then hosts their own party a fortnight
+ * later — attributing only within the pageview would record that as organic
+ * and report the loop as dead. Sixty days is past any realistic gap while
+ * still being short enough that a credit does not outlive its own cause.
+ */
+export const LOOP_REF_TTL_MS = 60 * 24 * 60 * 60 * 1000;
+
+/**
+ * Every read and write goes through here.
+ *
+ * `app/page.tsx` is statically prerendered, so this module is evaluated during
+ * the build where `window` does not exist — same guard, same reason, as
+ * `getPersistentPlayerId` in `lib/use-buzzer-socket.ts`. Storage also throws
+ * rather than returning null in a locked-down browser (Safari with cookies
+ * blocked, some embedded webviews), and a party host is not going to debug
+ * that, so every path swallows and degrades.
+ */
+function withStorage<T>(fn: (storage: Storage) => T, fallback: T): T {
+  if (typeof window === "undefined") return fallback;
+  try {
+    return fn(window.localStorage);
+  } catch {
+    return fallback;
+  }
+}
+
+/** Games this device has hosted so far. 0 before the first one. */
+export function getHostGameCount(): number {
+  return withStorage((storage) => {
+    const raw = storage.getItem(GAMES_KEY);
+    // Digits only, deliberately stricter than `parseInt`, which is lenient in
+    // ways that matter here: it reads "12abc" as 12 and "1e309" as 1, so a
+    // corrupted value would come back looking like a plausible count instead
+    // of like corruption. A hand-edited or half-written entry reads as a fresh
+    // device, which is the safe direction — it undercounts repeat hosting
+    // rather than inventing it.
+    if (!raw || !/^\d+$/.test(raw)) return 0;
+    const parsed = Number(raw);
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 0;
+  }, 0);
+}
+
+/**
+ * Records that a hosted game is starting and returns its 1-based index.
+ *
+ * No idempotency token, on purpose. The two ways this could double-count are
+ * both already closed: the Start button is disabled for the whole async
+ * playlist load (`app/page.tsx`, `disabled={loading || roomStarting}`), and
+ * reloading `/game` cannot re-fire it because every `game_started` call site
+ * lives on the setup page and runs immediately before the navigation. The one
+ * path that *does* reach here twice — "Play again", which routes back through
+ * setup — is a genuine second game and must count as one.
+ *
+ * Solo trials on a built-in playlist do not call this. They are one person
+ * with no party, so counting them as hosting would inflate the only number
+ * that answers whether anyone comes back.
+ */
+export function bumpHostGameCount(): number {
+  return withStorage((storage) => {
+    const next = getHostGameCount() + 1;
+    storage.setItem(GAMES_KEY, String(next));
+    return next;
+  }, 1);
+}
+
+interface StoredRef {
+  surface: string;
+  at: number;
+}
+
+/** Remembers the loop surface a visitor arrived from, for a later game. */
+export function rememberLoopRef(surface: string, now = Date.now()): void {
+  withStorage((storage) => {
+    const entry: StoredRef = { surface, at: now };
+    storage.setItem(REF_KEY, JSON.stringify(entry));
+  }, undefined);
+}
+
+/**
+ * The remembered surface, or null once it has aged out.
+ *
+ * Last touch rather than first: a visitor who came in through the loop, then
+ * returned by search, then came through the loop again is credited to the most
+ * recent loop click. Organic visits in between do not clear it — they are how
+ * people normally return, and treating them as a reset would erase the loop's
+ * contribution from exactly the users it worked on.
+ */
+export function recallLoopRef(now = Date.now()): string | null {
+  return withStorage((storage) => {
+    const raw = storage.getItem(REF_KEY);
+    if (!raw) return null;
+    try {
+      const entry = JSON.parse(raw) as Partial<StoredRef>;
+      if (typeof entry?.surface !== "string") return null;
+      if (typeof entry?.at !== "number" || !Number.isFinite(entry.at)) {
+        return null;
+      }
+      if (now - entry.at > LOOP_REF_TTL_MS) return null;
+      // A clock that jumped backwards would otherwise keep a stale credit
+      // alive indefinitely.
+      if (entry.at > now + 24 * 60 * 60 * 1000) return null;
+      return entry.surface;
+    } catch {
+      return null;
+    }
+  }, null);
+}

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -34,6 +34,28 @@ export interface KvStore {
   incr(key: string, ttlSeconds: number, by?: number): Promise<number>;
 }
 
+/**
+ * The day segment shared by every day-bucketed counter key in the app.
+ *
+ * It lives here, next to the store, because the writer and the reader are
+ * always in different modules — `lib/loop-redirect.ts` increments a bucket that
+ * `lib/digest.ts` reads back a week later — and the two have to produce a
+ * byte-identical string or they address different keys. That failure is silent:
+ * nothing errors, the counter simply reads zero forever. Three copies of
+ * `new Date().toISOString().slice(0, 10)` were already drifting distance apart
+ * before this existed.
+ *
+ * **UTC, deliberately.** A local-time bucket would move under a server whose
+ * region changes and would disagree between a lambda and a laptop, so a day is
+ * whatever UTC says it is. The visible cost is that a rate read shortly after
+ * 00:00 UTC is measuring almost nothing, which is documented rather than fixed.
+ *
+ * `at` exists so tests can pin the boundary; production never passes it.
+ */
+export function dayBucket(at: Date = new Date()): string {
+  return at.toISOString().slice(0, 10);
+}
+
 type MemoryEntry = { value: unknown; expiresAt: number };
 
 declare global {

--- a/lib/loop-client.ts
+++ b/lib/loop-client.ts
@@ -1,0 +1,82 @@
+/**
+ * What a loop surface does when it is shown and when it is followed.
+ *
+ * Two destinations, because they answer different questions and fail in
+ * different ways:
+ *
+ *   - **GA4** — cohorting, sessions, the questions nobody has asked yet. Dies
+ *     to an ad blocker.
+ *   - **KV, via `/api/pulse` and `/r/[surface]`** — the numbers the weekly
+ *     digest pushes to a human without anyone opening a dashboard. Dies to a
+ *     spent rate-limit window.
+ *
+ * Neither is a superset. KV is authoritative for the digest; the gap between
+ * the two is itself a reading of how much of this audience blocks analytics.
+ *
+ * Keeping both calls behind one function is the point: two call sites per
+ * surface would drift, and the drift is silent — one number keeps moving, the
+ * other quietly stops.
+ */
+
+import { trackEvent } from "@/lib/analytics";
+import type { LoopSurface } from "@/lib/loop-links";
+import { sendPulse } from "@/lib/pulse-client";
+
+const SEEN_PREFIX = "guesssong_loop_seen:";
+
+/**
+ * Once per surface per tab.
+ *
+ * `room_join_opened` fires on every page load and CHANGELOG.md:34 already
+ * records what that costs: a phone that drops Wi-Fi and reloads counts twice,
+ * so the denominator inflates and every rate built on it reads low. A player
+ * who reloads the buzzer page mid-party has not been shown the call to action
+ * a second time in any sense that matters.
+ *
+ * Session-scoped rather than device-scoped on purpose: the next party is a new
+ * session and genuinely is a new impression.
+ */
+function firstTimeThisSession(surface: LoopSurface): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const key = `${SEEN_PREFIX}${surface}`;
+    if (window.sessionStorage.getItem(key)) return false;
+    window.sessionStorage.setItem(key, "1");
+    return true;
+  } catch {
+    // Storage blocked: count it. Over-counting an impression understates the
+    // click rate, which is the safe direction — it cannot manufacture a
+    // success that did not happen.
+    return true;
+  }
+}
+
+/** Call when a loop surface becomes visible. Safe to call on every render. */
+export function reportLoopImpression(surface: LoopSurface): void {
+  if (!firstTimeThisSession(surface)) return;
+  trackEvent("loop_surface_shown", { surface });
+  sendPulse({ kind: "loop_impression", surface });
+}
+
+/**
+ * Call from the click handler on a loop link.
+ *
+ * Only GA4 here. The KV side is counted by `/r/[surface]` when the browser
+ * follows the link, which is why the link is a real navigation and not a
+ * background request: the navigation cannot be cancelled the way an in-flight
+ * `fetch` can, and this is the one number the whole feature is judged on.
+ */
+export function reportLoopClick(surface: LoopSurface): void {
+  trackEvent("player_to_host_click", { surface });
+}
+
+/**
+ * Call as a hosted game starts, with the device's 1-based game index.
+ *
+ * Sent as a beacon because the caller navigates to `/game` immediately after.
+ * GA4 gets the same number as a param on `game_started`; this is the copy the
+ * digest can read.
+ */
+export function reportGameStart(hostGameIndex: number): void {
+  sendPulse({ kind: "game_started", hostGameIndex });
+}

--- a/lib/loop-links.ts
+++ b/lib/loop-links.ts
@@ -1,0 +1,126 @@
+/**
+ * The loop: every place the product can tell a player it exists.
+ *
+ * Buzzer Mode already puts a phone in every hand — `app/buzz/[code]/page.tsx`
+ * was 264 lines that never once contained the string "GuessSong", and
+ * `app/j/[code]/page.tsx` ended at a dead confirmation screen. The expensive
+ * half of a viral loop (rooms, phones, share cards) has been shipping for
+ * weeks with no call to action anywhere in it. These are the surfaces that
+ * close it.
+ *
+ * ## Why the surface name lives in exactly one place
+ *
+ * Each surface's name is needed in three places at once: the link's `href`,
+ * the analytics param, and the server-side validator on `/r/[surface]`. Written
+ * out by hand that is one string per surface per site, kept in sync by
+ * discipline — and the failure mode is silent. A renamed href with a stale
+ * validator does not throw; the redirect still works, the counter simply stops
+ * incrementing and that arm reads as "nobody clicked it". You would then
+ * correctly conclude the CTA was useless and delete a CTA that was working.
+ *
+ * So the union is declared once here and every consumer derives from it, the
+ * same trick `lib/buzzer-protocol.ts` uses to keep the Worker and the client
+ * speaking one language. This module stays dependency-free for the same reason
+ * that one does: it is imported from a client component, a route handler, and
+ * the digest, and nothing here may drag `lib/kv.ts` into a browser bundle.
+ */
+
+/**
+ * Ordered so the list reads down the funnel: the two passive footers, the two
+ * moments a player has just finished doing something, then the card that
+ * leaves the party entirely.
+ */
+export const LOOP_SURFACES = [
+  /** Persistent footer on the buzzer player page. Always live. */
+  "buzz_footer",
+  /**
+   * Full-width call to action on the buzzer player page, shown only between
+   * rounds. See `app/buzz/[code]/page.tsx` for why it cannot be shown at the
+   * end of the game: the wire protocol has no end-of-game signal.
+   */
+  "buzz_cta",
+  /** Persistent footer on the Mixed Playlist submit page. */
+  "join_footer",
+  /** The confirmation screen after a player submits their playlist. */
+  "join_submitted",
+  /**
+   * The QR on the Game Over screen, scanned off the host's television by the
+   * people who just spent half an hour buzzing at it.
+   *
+   * Kept separate from `share` even though both are QR codes, because they are
+   * scanned by different people under different conditions — this one by a room
+   * that has just played, that one by whoever a photo got forwarded to — and
+   * merging them would average a warm audience with a cold one into a number
+   * that describes neither.
+   */
+  "game_over",
+  /**
+   * The result card. Reached by scanning the QR printed into the image, so
+   * unlike the others this hit does not come from a page of ours at all — it
+   * arrives from whatever app the picture was forwarded into, possibly days
+   * later.
+   */
+  "share",
+] as const;
+
+export type LoopSurface = (typeof LOOP_SURFACES)[number];
+
+/**
+ * Where a visitor came from, as recorded on `game_started`.
+ *
+ * `organic` is everything that is not one of ours, which at 100% search
+ * traffic is nearly all of it — but it is also the bucket that absorbs every
+ * *lost* attribution: a PWA launched from the home screen, a stripped query
+ * string, a URL retyped without its path. So the loop's share of starts is a
+ * floor, never a measurement, and a low number can mean "the CTA does not
+ * work" or "we could not see it". Do not read it as the former alone.
+ */
+export type ArrivedFrom = LoopSurface | "organic";
+
+const SURFACE_SET: ReadonlySet<string> = new Set(LOOP_SURFACES);
+
+/** Narrows an untrusted string — a URL segment, a query param — to a surface. */
+export function isLoopSurface(value: unknown): value is LoopSurface {
+  return typeof value === "string" && SURFACE_SET.has(value);
+}
+
+/**
+ * The link to put in an `href`. Always relative, so it works on a preview
+ * deploy and on localhost without anyone configuring an origin.
+ *
+ * Deliberately not a full URL even though the QR code needs one: making the
+ * absolute form a separate, explicit call (`loopUrl`) keeps the accident of
+ * pointing an on-page link at production out of the common path.
+ */
+export function loopHref(surface: LoopSurface): string {
+  return `/r/${surface}`;
+}
+
+/**
+ * The absolute form, for the one carrier that leaves this device.
+ *
+ * This is the inverse of the rule in `lib/buzzer-client.ts:78`: a room QR uses
+ * `window.location.origin` because the people scanning it are in the same room
+ * on the same build, and sending them to production would point them at a room
+ * that does not exist there. A *result card* is the opposite — it gets
+ * forwarded into a group chat and scanned days later by someone who has never
+ * heard of this app, so it must always point at production, never at a preview
+ * URL that will be gone by then.
+ */
+export function loopUrl(surface: LoopSurface): string {
+  const base = process.env.NEXT_PUBLIC_BASE_URL ?? "https://www.guessong.app";
+  return `${base.replace(/\/$/, "")}${loopHref(surface)}`;
+}
+
+/**
+ * Reads the `?ref=` the redirect route appended, for the analytics param.
+ *
+ * Validated rather than passed through, because `/?ref=` is a public URL and
+ * anyone can put anything in it. CLAUDE.md's analytics rule is explicit that
+ * user input must never reach a GA4 param — the concern there was pasted
+ * playlist URLs arriving via error messages, and a hand-edited query string is
+ * the same hazard with a shorter path. Anything unrecognised is `organic`.
+ */
+export function arrivedFrom(ref: string | null | undefined): ArrivedFrom {
+  return isLoopSurface(ref) ? ref : "organic";
+}

--- a/lib/loop-qr.ts
+++ b/lib/loop-qr.ts
@@ -1,0 +1,36 @@
+/**
+ * A QR back to the site, as a data URL.
+ *
+ * Its own module rather than a helper on `lib/loop-client.ts` because that one
+ * is imported by the setup page, and `qrcode` has no business in the bundle of
+ * the page that takes essentially all of this site's search traffic. Only the
+ * two places that actually draw a code pull this in.
+ */
+
+import QRCode from "qrcode";
+import { loopUrl, type LoopSurface } from "@/lib/loop-links";
+
+/**
+ * Returns null rather than throwing.
+ *
+ * Both callers are in the middle of giving someone something they asked for —
+ * a picture of their scores, a celebration screen — and neither should fail
+ * over a decoration. The caller falls back to printing the address as text.
+ */
+export async function loopQrDataUrl(
+  surface: LoopSurface = "share",
+  pixels = 240
+): Promise<string | null> {
+  try {
+    return await QRCode.toDataURL(loopUrl(surface), {
+      margin: 1,
+      width: pixels,
+      // Dark modules on white. The cards are near-black, so a transparent or
+      // inverted code would be unreadable to half the scanners that see it —
+      // the quiet zone has to be light for the pattern to be found at all.
+      color: { dark: "#000000", light: "#ffffff" },
+    });
+  } catch {
+    return null;
+  }
+}

--- a/lib/loop-redirect.ts
+++ b/lib/loop-redirect.ts
@@ -1,0 +1,82 @@
+/**
+ * The decision behind `/r/[surface]`, kept out of the route so it can be tested.
+ *
+ * The route itself is a shell: read the segment, ask the limiter, call this,
+ * build a 302. Everything that can be wrong is here.
+ *
+ * ## Why a redirect and not a background event
+ *
+ * The click being measured is the click that navigates away. A `fetch` fired at
+ * that moment is routinely cancelled by the browser as the page tears down, so
+ * the single most important number in the loop — did anyone actually follow the
+ * call to action — would arrive undercounted by an unknown amount and read as
+ * "nobody clicked". Routing the link through the server makes the navigation
+ * itself the measurement. There is nothing left to cancel.
+ *
+ * ## The rule every branch obeys
+ *
+ * **The visitor always reaches the setup page.** Unknown segment, spent rate
+ * limit, KV on fire: all of them still redirect. Only the count is allowed to
+ * be lost. This is the same fail-open contract `lib/playlist-cache.ts` uses for
+ * its global budget, and the reason is sharper here — the person clicking is
+ * precisely the person this whole feature exists to reach, and refusing them to
+ * protect an integer would be an own goal.
+ */
+
+import { isLoopSurface, type LoopSurface } from "@/lib/loop-links";
+import { recordLoopClick, recordLoopThrottled } from "@/lib/loop-stats";
+
+/** Where an unrecognised segment lands. Still the setup page, just unattributed. */
+export const LOOP_FALLBACK_DESTINATION = "/";
+
+export interface LoopHitOutcome {
+  /** The recognised surface, or null when the segment was not one of ours. */
+  surface: LoopSurface | null;
+  /** Always a path. Always somewhere useful. */
+  destination: string;
+  /** Whether a click was added to the counters. */
+  counted: boolean;
+  /** True when a real click was dropped because the window was spent. */
+  throttled: boolean;
+}
+
+/**
+ * @param rawSurface the `[surface]` path segment, entirely untrusted
+ * @param allowed    the limiter's verdict, resolved by the caller so this stays
+ *                   free of `NextRequest`. Pass `true` when the limiter itself
+ *                   failed — an unavailable limiter must not cost a count.
+ */
+export async function handleLoopHit(
+  rawSurface: string,
+  allowed: boolean
+): Promise<LoopHitOutcome> {
+  if (!isLoopSurface(rawSurface)) {
+    // Not ours: a typo, a crawler, a hand-edited URL. Send them to the setup
+    // page anyway — a 404 would be a worse answer to "I typed your address" —
+    // but do not invent a surface for it, and do not spend a KV write on it.
+    // Unbounded junk segments are exactly what would fill the key space.
+    return {
+      surface: null,
+      destination: LOOP_FALLBACK_DESTINATION,
+      counted: false,
+      throttled: false,
+    };
+  }
+
+  // Attribution rides on the query string so the setup page can read it after
+  // the redirect. The surface is already narrowed, so nothing untrusted is
+  // being reflected back into the URL.
+  const destination = `${LOOP_FALLBACK_DESTINATION}?ref=${rawSurface}`;
+
+  if (!allowed) {
+    // A party is a dozen phones behind one NAT and the limiter is keyed by IP,
+    // so being here is ordinary rather than hostile. Record that a click was
+    // dropped, so the digest can say how far the number is understated instead
+    // of quietly reporting a low one.
+    await recordLoopThrottled();
+    return { surface: rawSurface, destination, counted: false, throttled: true };
+  }
+
+  await recordLoopClick(rawSurface);
+  return { surface: rawSurface, destination, counted: true, throttled: false };
+}

--- a/lib/loop-stats.ts
+++ b/lib/loop-stats.ts
@@ -1,0 +1,153 @@
+/**
+ * Server-side counters for the loop, in KV.
+ *
+ * ## Why these are not simply GA4 events
+ *
+ * They are also GA4 events. This is the second copy, and it exists because the
+ * numbers have to arrive somewhere without anyone going to fetch them. Four
+ * separate attempts to read the GA4 dashboard have not happened, so any plan
+ * whose payoff is "and then open Analytics" has a measured completion rate of
+ * zero and must be designed around rather than repeated. These counters feed a
+ * digest that is pushed. GA4 keeps the cohorting and the exploration; this is
+ * the half that gets read.
+ *
+ * The two will disagree, and that is expected: an ad blocker kills the GA4
+ * event and not the redirect, while a spent rate-limit window drops the KV
+ * increment and not the GA4 event. **KV is authoritative for the digest.**
+ *
+ * ## Every function here is fail-soft
+ *
+ * Same contract as `lib/playlist-cache.ts` and `lib/preview-cache.ts`: losing
+ * the safety net has to mean "back to how it was", never "the feature broke".
+ * A counter that can fail a redirect is a counter that costs you the user it
+ * was trying to measure.
+ */
+
+import { dayBucket, getKvStore } from "@/lib/kv";
+import type { LoopSurface } from "@/lib/loop-links";
+
+/**
+ * 30 days, not the 7 that `lib/playlist-cache.ts` uses for its own stats.
+ *
+ * The digest reports a week at a time and its window ends a couple of days
+ * back, so a 7-day TTL would expire the oldest day or two of every single
+ * report right before it was read — and, worse, an expired key is
+ * indistinguishable from one that was never written, so the loss would render
+ * as "no data yet" rather than as a gap. 30 days also leaves room to miss a
+ * few weeks of digests and still be able to look back.
+ */
+export const LOOP_STATS_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+/**
+ * Above this, `host_game_index` stops getting its own key.
+ *
+ * The index comes from a client counter, so without a ceiling the key space is
+ * unbounded and one loop in a console fills KV with `host_index:99999` keys.
+ * Ten is far past the point where the question ("does anyone host twice?") has
+ * been answered.
+ */
+export const HOST_INDEX_CEILING = 10;
+
+function key(day: string, metric: string): string {
+  return `loop:stats:${day}:${metric}`;
+}
+
+/**
+ * Every key the digest reads for one day.
+ *
+ * Exported so the reader and the writers derive their keys from one place —
+ * the failure mode of two hand-written key formats is that the digest reads a
+ * key nobody writes, reports zero, and never errors.
+ */
+export function loopStatsKeys(
+  day: string,
+  surfaces: readonly LoopSurface[]
+): {
+  live: string;
+  throttled: string;
+  games: string;
+  repeatHost: string;
+  impressions: Record<string, string>;
+  clicks: Record<string, string>;
+  hostIndex: string[];
+} {
+  const impressions: Record<string, string> = {};
+  const clicks: Record<string, string> = {};
+  for (const surface of surfaces) {
+    impressions[surface] = key(day, `impression:${surface}`);
+    clicks[surface] = key(day, `click:${surface}`);
+  }
+  const hostIndex: string[] = [];
+  for (let n = 1; n <= HOST_INDEX_CEILING; n += 1) {
+    hostIndex.push(key(day, `host_index:${n}`));
+  }
+  return {
+    live: key(day, "live"),
+    throttled: key(day, "throttled"),
+    games: key(day, "games"),
+    repeatHost: key(day, "repeat_host"),
+    impressions,
+    clicks,
+    hostIndex,
+  };
+}
+
+/**
+ * Bumped alongside every other counter, and never conditionally.
+ *
+ * Without it a day with no clicks and a day the counters never ran look
+ * identical: `mget` returns null for a key that was never created, which is
+ * exactly what a genuine zero also looks like. Printing both as "no data yet"
+ * would hide the single most important negative result this whole exercise can
+ * produce — that the CTA does nothing. With a liveness marker, null-and-live is
+ * a real zero and null-and-dead is a plumbing problem.
+ */
+async function bump(metric: string, by = 1): Promise<void> {
+  try {
+    const store = await getKvStore();
+    const day = dayBucket();
+    await store.incr(key(day, metric), LOOP_STATS_TTL_SECONDS, by);
+    await store.incr(key(day, "live"), LOOP_STATS_TTL_SECONDS);
+  } catch {
+    // Instrumentation must never be able to fail a request.
+  }
+}
+
+/** A loop surface was rendered to someone. The denominator. */
+export function recordLoopImpression(surface: LoopSurface): Promise<void> {
+  return bump(`impression:${surface}`);
+}
+
+/** Someone followed a loop link. The numerator. */
+export function recordLoopClick(surface: LoopSurface): Promise<void> {
+  return bump(`click:${surface}`);
+}
+
+/**
+ * A click that was not counted because the window was spent.
+ *
+ * Recorded so the undercount is visible in the digest instead of silently
+ * depressing the click rate. A party is a dozen phones behind one NAT and the
+ * limiter is keyed by IP, so this is a normal occurrence, not an attack.
+ */
+export function recordLoopThrottled(): Promise<void> {
+  return bump("throttled");
+}
+
+/**
+ * A hosted game started, and which number it was for this device.
+ *
+ * `hostGameIndex` is 1 for a first-time host. Anything at or above 2 is the
+ * number the whole plan is waiting on: proof that someone came back. It is a
+ * floor and not a measurement — iOS evicts localStorage after seven days
+ * without interaction, which is exactly the gap between two parties, so a host
+ * on a monthly rhythm reads as first-time forever.
+ */
+export async function recordGameStart(hostGameIndex: number): Promise<void> {
+  const index = Number.isFinite(hostGameIndex)
+    ? Math.max(1, Math.min(Math.trunc(hostGameIndex), HOST_INDEX_CEILING))
+    : 1;
+  await bump("games");
+  await bump(`host_index:${index}`);
+  if (index >= 2) await bump("repeat_host");
+}

--- a/lib/playlist-cache.ts
+++ b/lib/playlist-cache.ts
@@ -28,7 +28,7 @@
  * "broken" — same contract as app/api/preview/route.ts, which this follows.
  */
 
-import { getKvStore } from "@/lib/kv";
+import { dayBucket, getKvStore } from "@/lib/kv";
 import {
   getPlaylistWithTracks,
   isSpotifyEditorial,
@@ -232,8 +232,7 @@ async function claimGlobalBudget(): Promise<boolean> {
  * as things get healthier, and a sudden run of lines is itself the signal.
  */
 function statsKey(kind: "hit" | "miss" | "negative"): string {
-  const day = new Date().toISOString().slice(0, 10);
-  return `playlist:stats:${day}:${kind}`;
+  return `playlist:stats:${dayBucket()}:${kind}`;
 }
 
 const STATS_TTL_SECONDS = 7 * 24 * 60 * 60;

--- a/lib/preview-cache.ts
+++ b/lib/preview-cache.ts
@@ -71,7 +71,7 @@
  * next time they're written.
  */
 
-import { getKvStore, type KvStore } from "@/lib/kv";
+import { dayBucket, getKvStore, type KvStore } from "@/lib/kv";
 import type { PreviewResult, PreviewStatus } from "@/types/preview";
 
 export type { PreviewResult, PreviewStatus };
@@ -216,8 +216,7 @@ function cooldownKey(source: PreviewSource): string {
 }
 
 function statsKey(kind: "hit" | "miss" | "unavailable"): string {
-  const day = new Date().toISOString().slice(0, 10);
-  return `preview:stats:${day}:${kind}`;
+  return `preview:stats:${dayBucket()}:${kind}`;
 }
 
 /* ------------------------------------------------------------------ */

--- a/lib/pulse-client.ts
+++ b/lib/pulse-client.ts
@@ -1,0 +1,61 @@
+/**
+ * The browser half of `POST /api/pulse`.
+ *
+ * ## Why `sendBeacon` and not `fetch`
+ *
+ * Both events this sends happen immediately before the page goes away. A game
+ * start is followed by `router.push("/game")`; an impression on the buzzer
+ * page can be followed by the player tapping the call to action a second
+ * later. A `fetch` in flight when a document tears down is cancelled, so the
+ * measurement would be lost exactly in the cases worth measuring, and lost
+ * silently — the number would simply read low and be mistaken for the thing it
+ * was trying to detect.
+ *
+ * `navigator.sendBeacon` exists for this: the request is handed to the browser
+ * and survives the unload. It gives no response and no error, which is fine —
+ * nothing here is worth blocking a user for.
+ */
+
+import type { PulseEvent } from "@/lib/pulse";
+
+const ENDPOINT = "/api/pulse";
+
+/**
+ * Best effort, always. Never throws, never awaits anything the caller needs.
+ *
+ * Returns whether the browser accepted the beacon for delivery, which is not
+ * the same as it arriving — only useful for tests and for the fallback below.
+ */
+export function sendPulse(event: PulseEvent): boolean {
+  if (typeof navigator === "undefined") return false;
+
+  const body = JSON.stringify(event);
+
+  try {
+    if (typeof navigator.sendBeacon === "function") {
+      // `text/plain` on purpose. A Blob typed `application/json` makes the
+      // beacon a CORS-preflighted request in some browsers, and a preflight
+      // cannot complete during unload — the exact moment this is being used.
+      // Same origin, and the route reads the raw text, so the type is cosmetic.
+      const blob = new Blob([body], { type: "text/plain;charset=UTF-8" });
+      if (navigator.sendBeacon(ENDPOINT, blob)) return true;
+    }
+  } catch {
+    // Some privacy modes make sendBeacon throw rather than return false.
+  }
+
+  // Fallback for browsers without sendBeacon, and for the case where it
+  // refuses (the beacon queue is full). `keepalive` asks fetch for the same
+  // survive-the-unload behaviour; it is weaker but better than nothing.
+  try {
+    void fetch(ENDPOINT, {
+      method: "POST",
+      body,
+      keepalive: true,
+      headers: { "Content-Type": "text/plain;charset=UTF-8" },
+    }).catch(() => {});
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/lib/pulse.ts
+++ b/lib/pulse.ts
@@ -1,0 +1,62 @@
+/**
+ * The two facts the browser knows and the server does not.
+ *
+ * `/r/[surface]` already counts clicks server-side, because a click is a
+ * navigation and a navigation reaches the server on its own. These two do not
+ * navigate anywhere:
+ *
+ *   - **impressions** — a loop surface was rendered. The denominator. Without
+ *     it "buzz_cta: 12" cannot be read as anything: twelve out of fifteen is a
+ *     working call to action, twelve out of nine thousand is a dead one, and
+ *     the two demand opposite responses.
+ *   - **game starts** — with the host's game index, which is the number the
+ *     whole exercise is waiting on. It lives in `localStorage` and no existing
+ *     request carries it. Piggybacking it on `POST /api/playlist` looked
+ *     cheaper until Mixed mode, which fires one of those per contributor from
+ *     a single Start and would multiply every such game by its guest count.
+ *
+ * So: one narrow endpoint, two event shapes, a closed set of values, and
+ * nothing that a caller can turn into a key. The parsing lives here rather
+ * than in the route so the rejection paths are testable — they are the ones
+ * that matter, since the body arrives from the open internet.
+ */
+
+import { isLoopSurface, type LoopSurface } from "@/lib/loop-links";
+import { HOST_INDEX_CEILING } from "@/lib/loop-stats";
+
+export type PulseEvent =
+  | { kind: "loop_impression"; surface: LoopSurface }
+  | { kind: "game_started"; hostGameIndex: number };
+
+/**
+ * Narrows an untrusted request body, or returns null.
+ *
+ * Every field is checked rather than cast. This endpoint is unauthenticated by
+ * necessity — the people it measures have no accounts — so the body is exactly
+ * as trustworthy as a query string, and one of these values becomes part of a
+ * KV key. An unbounded string reaching that key is how a counter namespace
+ * turns into a bill.
+ */
+export function parsePulse(body: unknown): PulseEvent | null {
+  if (typeof body !== "object" || body === null) return null;
+  const raw = body as Record<string, unknown>;
+
+  if (raw.kind === "loop_impression") {
+    return isLoopSurface(raw.surface)
+      ? { kind: "loop_impression", surface: raw.surface }
+      : null;
+  }
+
+  if (raw.kind === "game_started") {
+    const index = raw.hostGameIndex;
+    if (typeof index !== "number" || !Number.isFinite(index)) return null;
+    // Clamped here as well as in lib/loop-stats.ts. The store clamps because
+    // it owns the key space; this clamps because a body claiming 1e308 should
+    // never have been accepted in the first place, and rejecting it outright
+    // would drop a real game over a corrupted counter.
+    const clamped = Math.max(1, Math.min(Math.trunc(index), HOST_INDEX_CEILING));
+    return { kind: "game_started", hostGameIndex: clamped };
+  }
+
+  return null;
+}

--- a/lib/result-image.ts
+++ b/lib/result-image.ts
@@ -72,16 +72,87 @@ export function drawCardHeader(ctx: CanvasRenderingContext2D, opts: HeaderOption
   return 155;
 }
 
-/** Draws the footer divider + credit line at the given y. */
-export function drawCardFooter(ctx: CanvasRenderingContext2D, width: number, y: number) {
+/**
+ * How much vertical room `drawCardFooter` needs.
+ *
+ * Exported so the two callers that size their canvas cannot drift from what
+ * the footer actually draws — a footer taller than its band gets silently
+ * clipped, and the thing that would get clipped is the QR.
+ */
+export const CARD_FOOTER_HEIGHT = 112;
+
+const QR_SIZE = 60;
+
+/** Loads a data URL into something `drawImage` accepts. */
+async function loadImage(src: string): Promise<HTMLImageElement> {
+  const img = new Image();
+  img.src = src;
+  if (typeof img.decode === "function") {
+    await img.decode();
+    return img;
+  }
+  await new Promise<void>((resolve, reject) => {
+    img.onload = () => resolve();
+    img.onerror = () => reject(new Error("qr image failed to load"));
+  });
+  return img;
+}
+
+/**
+ * Draws the footer: a divider, a QR back to the site, and the credit.
+ *
+ * ## Why a QR and not the address in text
+ *
+ * This card is the only artifact the product makes that leaves the party. It
+ * used to read "Played with GuessSong" — a brand with no address — so anyone
+ * who saw it in a group chat had to already know the name to act on it, which
+ * is exactly the audience it does not need to reach. Printing the URL as text
+ * is barely better: nobody retypes a URL off a screenshot.
+ *
+ * The URL is deliberately *not* also put in the `navigator.share` payload. iOS
+ * drops `url` when a file is attached, and several Android targets drop the
+ * *file* when a `url` is present — risking the image, which is the entire
+ * payload, to add a link one platform throws away is a bad trade. The pixels
+ * are the carrier.
+ *
+ * Async because generating the QR is. Fails soft: a QR that will not render
+ * leaves the credit line in place rather than failing the save, since the
+ * player asked for a picture of their scores and is owed one either way.
+ */
+export async function drawCardFooter(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  y: number,
+  qrDataUrl?: string | null
+) {
   ctx.strokeStyle = "#222";
   ctx.beginPath();
   ctx.moveTo(40, y);
   ctx.lineTo(width - 40, y);
   ctx.stroke();
-  ctx.font = "12px sans-serif";
-  ctx.fillStyle = "#444";
-  ctx.fillText("Played with GuessSong", 40, y + 30);
+
+  let textX = 40;
+  if (qrDataUrl) {
+    try {
+      const img = await loadImage(qrDataUrl);
+      ctx.drawImage(img, 40, y + 14, QR_SIZE, QR_SIZE);
+      textX = 40 + QR_SIZE + 16;
+    } catch {
+      // Keep the credit at the left margin; the card still saves.
+    }
+  }
+
+  ctx.font = "bold 20px sans-serif";
+  ctx.fillStyle = "#1DB954";
+  ctx.fillText("GuessSong", textX, y + 42);
+
+  ctx.font = "13px sans-serif";
+  ctx.fillStyle = "#666";
+  ctx.fillText(
+    qrDataUrl ? "Scan to play your own" : "guessong.app",
+    textX,
+    y + 64
+  );
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guesssong",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/tests/host-session.test.ts
+++ b/tests/host-session.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  LOOP_REF_TTL_MS,
+  bumpHostGameCount,
+  getHostGameCount,
+  recallLoopRef,
+  rememberLoopRef,
+} from "@/lib/host-session";
+
+const NOW = new Date("2026-08-09T12:00:00.000Z").getTime();
+const DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * jsdom gives us `window` but NOT `window.localStorage` — verified against
+ * this project's jsdom 29 / vitest 4 setup. Without a stub, every call in
+ * `lib/host-session.ts` takes its "storage unavailable" branch and the whole
+ * suite passes while testing nothing. So the stub is load-bearing: it is what
+ * makes these assertions mean anything.
+ */
+function installStorage(): Storage {
+  const map = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (key) => map.get(key) ?? null,
+    key: (index) => [...map.keys()][index] ?? null,
+    removeItem: (key) => void map.delete(key),
+    setItem: (key, value) => void map.set(key, String(value)),
+  };
+  Object.defineProperty(window, "localStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+  return storage;
+}
+
+beforeEach(() => {
+  installStorage();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("the test environment itself", () => {
+  it("really has storage, so the assertions below are not vacuous", () => {
+    // jsdom does not supply localStorage here. If the stub above ever stops
+    // being installed, every other test in this file would still pass while
+    // exercising only the unavailable-storage fallback. This is the canary.
+    expect(typeof window.localStorage?.setItem).toBe("function");
+    window.localStorage.setItem("canary", "1");
+    expect(window.localStorage.getItem("canary")).toBe("1");
+  });
+});
+
+describe("host game count", () => {
+  it("starts at zero and counts up from one", () => {
+    expect(getHostGameCount()).toBe(0);
+    expect(bumpHostGameCount()).toBe(1);
+    expect(bumpHostGameCount()).toBe(2);
+    expect(getHostGameCount()).toBe(2);
+  });
+
+  it("survives a reload, which is the whole point", () => {
+    bumpHostGameCount();
+    bumpHostGameCount();
+    // Nothing in-memory is carried over; the value comes back from storage.
+    expect(getHostGameCount()).toBe(2);
+  });
+
+  it("reads a corrupted value as a fresh device rather than poisoning the count", () => {
+    // "1e309" and "12abc" are the reason this does not use parseInt: it would
+    // read them as 1 and 12, which look like counts rather than like damage.
+    for (const junk of [
+      "",
+      " ",
+      "abc",
+      "NaN",
+      "-3",
+      "0",
+      "1e309",
+      "12abc",
+      " 5",
+      "5 ",
+      "{}",
+      "9".repeat(400),
+    ]) {
+      window.localStorage.setItem("guesssong_host_games", junk);
+      expect(getHostGameCount()).toBe(0);
+      expect(bumpHostGameCount()).toBe(1);
+      window.localStorage.clear();
+    }
+  });
+
+  it("never throws when storage is unavailable, and reports a first game", () => {
+    // Safari with cookies blocked throws on access rather than returning null.
+    // A party host is not going to debug that; the game must still start.
+    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    expect(() => bumpHostGameCount()).not.toThrow();
+    expect(bumpHostGameCount()).toBe(1);
+  });
+
+  it("reports zero rather than throwing when reads are blocked", () => {
+    vi.spyOn(window.localStorage, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+    expect(getHostGameCount()).toBe(0);
+  });
+});
+
+describe("remembered loop attribution", () => {
+  it("returns nothing before anything has been remembered", () => {
+    expect(recallLoopRef(NOW)).toBeNull();
+  });
+
+  it("credits a game hosted weeks after the click", () => {
+    // The conversion this measures is not same-session: someone taps the CTA
+    // at a friend's party and hosts their own a fortnight later.
+    rememberLoopRef("buzz_cta", NOW);
+    expect(recallLoopRef(NOW + 14 * DAY)).toBe("buzz_cta");
+  });
+
+  it("ages out once the credit has outlived its cause", () => {
+    rememberLoopRef("buzz_cta", NOW);
+    expect(recallLoopRef(NOW + LOOP_REF_TTL_MS - 1)).toBe("buzz_cta");
+    expect(recallLoopRef(NOW + LOOP_REF_TTL_MS + 1)).toBeNull();
+  });
+
+  it("keeps the most recent loop touch", () => {
+    rememberLoopRef("join_footer", NOW);
+    rememberLoopRef("share", NOW + DAY);
+    expect(recallLoopRef(NOW + 2 * DAY)).toBe("share");
+  });
+
+  it("ignores a stored entry whose clock is impossibly far ahead", () => {
+    // A device whose clock jumped backwards would otherwise keep a stale
+    // credit alive forever.
+    rememberLoopRef("share", NOW + 30 * DAY);
+    expect(recallLoopRef(NOW)).toBeNull();
+  });
+
+  it("survives a hand-edited or truncated entry", () => {
+    for (const junk of [
+      "not json",
+      "null",
+      "[]",
+      '{"surface":123,"at":0}',
+      '{"surface":"share"}',
+      '{"at":0}',
+      '{"surface":"share","at":"soon"}',
+    ]) {
+      window.localStorage.setItem("guesssong_loop_ref", junk);
+      expect(recallLoopRef(NOW)).toBeNull();
+    }
+  });
+
+  it("does not validate the surface here — the analytics boundary does that", () => {
+    // Storage is dumb on purpose; `arrivedFrom` in lib/loop-links.ts is the one
+    // place that decides what may reach a GA4 param, so there is exactly one
+    // gate to audit rather than two that can disagree.
+    rememberLoopRef("something_else", NOW);
+    expect(recallLoopRef(NOW)).toBe("something_else");
+  });
+});

--- a/tests/kv.test.ts
+++ b/tests/kv.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { getKvStore } from "@/lib/kv";
+import { dayBucket, getKvStore } from "@/lib/kv";
 
 const redisMock = vi.hoisted(() => ({
   get: vi.fn(),
@@ -191,5 +191,37 @@ describe("getKvStore (Upstash backend)", () => {
 
     expect(await store.mget([])).toEqual([]);
     expect(redisMock.mget).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The writer and the reader of a day-bucketed counter always live in different
+ * modules, so the exact output string is the contract between them. A change
+ * here does not break a build or throw — it silently addresses a different key
+ * and every counter reads zero from then on. Hence pinning the literal.
+ */
+describe("dayBucket", () => {
+  it("is the UTC calendar date, exactly YYYY-MM-DD", () => {
+    expect(dayBucket(new Date("2026-08-09T12:34:56.789Z"))).toBe("2026-08-09");
+  });
+
+  it("splits on the UTC midnight boundary, not a local one", () => {
+    expect(dayBucket(new Date("2026-08-09T23:59:59.999Z"))).toBe("2026-08-09");
+    expect(dayBucket(new Date("2026-08-10T00:00:00.000Z"))).toBe("2026-08-10");
+  });
+
+  it("ignores the host timezone, so a lambda and a laptop agree", () => {
+    // 2026-08-09T22:00Z is already the 10th in UTC+10 and still the 9th in UTC.
+    // Whichever zone the process happens to run in, the bucket is the UTC one.
+    const instant = new Date("2026-08-09T22:00:00.000Z");
+    expect(dayBucket(instant)).toBe("2026-08-09");
+    expect(dayBucket(instant)).toBe(instant.toISOString().slice(0, 10));
+  });
+
+  it("defaults to now, so callers do not each reach for a clock", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2027-01-02T03:04:05.000Z"));
+    expect(dayBucket()).toBe("2027-01-02");
+    vi.useRealTimers();
   });
 });

--- a/tests/loop-links.test.ts
+++ b/tests/loop-links.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  LOOP_SURFACES,
+  arrivedFrom,
+  isLoopSurface,
+  loopHref,
+  loopUrl,
+  type LoopSurface,
+} from "@/lib/loop-links";
+
+describe("LOOP_SURFACES", () => {
+  it("has no duplicates — a repeated name would merge two arms into one counter", () => {
+    expect(new Set(LOOP_SURFACES).size).toBe(LOOP_SURFACES.length);
+  });
+
+  it("uses only URL-path-safe names, since each becomes a path segment", () => {
+    for (const surface of LOOP_SURFACES) {
+      expect(surface).toMatch(/^[a-z][a-z0-9_]*$/);
+      expect(encodeURIComponent(surface)).toBe(surface);
+    }
+  });
+});
+
+describe("isLoopSurface", () => {
+  it("accepts every declared surface", () => {
+    for (const surface of LOOP_SURFACES) {
+      expect(isLoopSurface(surface)).toBe(true);
+    }
+  });
+
+  it("rejects the shapes an untrusted URL segment actually arrives in", () => {
+    // `/r/[surface]` is public, so these are inputs the route will really see.
+    for (const bad of [
+      "",
+      " ",
+      "buzz",
+      "BUZZ_FOOTER",
+      "buzz_footer ",
+      "../../etc/passwd",
+      "buzz_footer/../share",
+      "__proto__",
+      "constructor",
+      "toString",
+      "x".repeat(4096),
+    ]) {
+      expect(isLoopSurface(bad)).toBe(false);
+    }
+  });
+
+  it("rejects non-strings without throwing", () => {
+    for (const bad of [null, undefined, 0, 1, {}, [], true, Symbol("s")]) {
+      expect(isLoopSurface(bad)).toBe(false);
+    }
+  });
+
+  it("is not fooled by inherited Object properties", () => {
+    // A plain-object lookup table would answer true for these. The Set does not.
+    expect(isLoopSurface("hasOwnProperty")).toBe(false);
+    expect(isLoopSurface("valueOf")).toBe(false);
+  });
+});
+
+describe("loopHref", () => {
+  it("is relative, so previews and localhost keep working", () => {
+    for (const surface of LOOP_SURFACES) {
+      expect(loopHref(surface)).toBe(`/r/${surface}`);
+    }
+  });
+
+  it("round-trips through the route's own validator", () => {
+    // The href and the server-side check must agree on the segment, which is
+    // the whole reason both derive from LOOP_SURFACES.
+    for (const surface of LOOP_SURFACES) {
+      const segment = loopHref(surface).split("/").pop();
+      expect(isLoopSurface(segment)).toBe(true);
+    }
+  });
+});
+
+describe("loopUrl", () => {
+  const original = process.env.NEXT_PUBLIC_BASE_URL;
+  afterEach(() => {
+    if (original === undefined) delete process.env.NEXT_PUBLIC_BASE_URL;
+    else process.env.NEXT_PUBLIC_BASE_URL = original;
+  });
+
+  it("defaults to production, because the card outlives the deploy that made it", () => {
+    delete process.env.NEXT_PUBLIC_BASE_URL;
+    expect(loopUrl("share")).toBe("https://www.guessong.app/r/share");
+  });
+
+  it("honours a configured base", () => {
+    process.env.NEXT_PUBLIC_BASE_URL = "https://staging.example.com";
+    expect(loopUrl("share")).toBe("https://staging.example.com/r/share");
+  });
+
+  it("does not double the slash when the base carries a trailing one", () => {
+    process.env.NEXT_PUBLIC_BASE_URL = "https://www.guessong.app/";
+    expect(loopUrl("share")).toBe("https://www.guessong.app/r/share");
+  });
+
+  it("produces something a QR scanner can hand to a browser", () => {
+    delete process.env.NEXT_PUBLIC_BASE_URL;
+    const parsed = new URL(loopUrl("share"));
+    expect(parsed.protocol).toBe("https:");
+    expect(parsed.pathname).toBe("/r/share");
+  });
+});
+
+describe("arrivedFrom", () => {
+  it("passes through a surface we issued", () => {
+    for (const surface of LOOP_SURFACES) {
+      expect(arrivedFrom(surface)).toBe(surface);
+    }
+  });
+
+  it("falls back to organic for a missing ref", () => {
+    expect(arrivedFrom(null)).toBe("organic");
+    expect(arrivedFrom(undefined)).toBe("organic");
+    expect(arrivedFrom("")).toBe("organic");
+  });
+
+  it("never lets a hand-edited query string reach the analytics param", () => {
+    // CLAUDE.md: user input must not become a GA4 param value. `/?ref=` is a
+    // public URL, so this is the enforcement point, not a formality.
+    const hostile = [
+      "<script>alert(1)</script>",
+      "buzz_footer'; DROP TABLE",
+      "a".repeat(10_000),
+      "share ",
+      "SHARE",
+    ];
+    for (const value of hostile) {
+      expect(arrivedFrom(value)).toBe("organic");
+    }
+  });
+
+  it("returns a value inside the declared union, whatever it is given", () => {
+    const allowed: string[] = [...LOOP_SURFACES, "organic"];
+    for (const value of ["buzz_cta", "nonsense", null, ""]) {
+      expect(allowed).toContain(arrivedFrom(value as LoopSurface | null));
+    }
+  });
+});

--- a/tests/loop-redirect.test.ts
+++ b/tests/loop-redirect.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { LOOP_SURFACES } from "@/lib/loop-links";
+
+const recorded = vi.hoisted(() => ({
+  clicks: [] as string[],
+  throttled: 0,
+}));
+
+vi.mock("@/lib/loop-stats", () => ({
+  recordLoopClick: async (surface: string) => {
+    recorded.clicks.push(surface);
+  },
+  recordLoopThrottled: async () => {
+    recorded.throttled += 1;
+  },
+}));
+
+const { handleLoopHit, LOOP_FALLBACK_DESTINATION } = await import(
+  "@/lib/loop-redirect"
+);
+
+beforeEach(() => {
+  recorded.clicks = [];
+  recorded.throttled = 0;
+});
+
+describe("handleLoopHit — the happy path", () => {
+  it("counts the click and carries attribution to the setup page", async () => {
+    const outcome = await handleLoopHit("buzz_cta", true);
+    expect(outcome).toEqual({
+      surface: "buzz_cta",
+      destination: "/?ref=buzz_cta",
+      counted: true,
+      throttled: false,
+    });
+    expect(recorded.clicks).toEqual(["buzz_cta"]);
+  });
+
+  it("handles every declared surface, so no arm is silently unreachable", async () => {
+    for (const surface of LOOP_SURFACES) {
+      const outcome = await handleLoopHit(surface, true);
+      expect(outcome.surface).toBe(surface);
+      expect(outcome.counted).toBe(true);
+      expect(outcome.destination).toBe(`/?ref=${surface}`);
+    }
+    expect(recorded.clicks).toEqual([...LOOP_SURFACES]);
+  });
+});
+
+describe("handleLoopHit — the visitor always lands somewhere useful", () => {
+  it("redirects an unknown segment instead of 404ing the person", async () => {
+    const outcome = await handleLoopHit("nonsense", true);
+    expect(outcome.destination).toBe(LOOP_FALLBACK_DESTINATION);
+    expect(outcome.surface).toBeNull();
+  });
+
+  it("spends no KV write on junk, which is what would fill the key space", async () => {
+    for (const junk of [
+      "",
+      " ",
+      "../../etc/passwd",
+      "buzz_footer/../share",
+      "__proto__",
+      "BUZZ_CTA",
+      "x".repeat(4096),
+    ]) {
+      const outcome = await handleLoopHit(junk, true);
+      expect(outcome.counted).toBe(false);
+      expect(outcome.destination).toBe(LOOP_FALLBACK_DESTINATION);
+    }
+    expect(recorded.clicks).toEqual([]);
+    expect(recorded.throttled).toBe(0);
+  });
+
+  it("never reflects an unrecognised segment back into the URL", async () => {
+    const outcome = await handleLoopHit("<script>alert(1)</script>", true);
+    expect(outcome.destination).toBe("/");
+    expect(outcome.destination).not.toContain("script");
+  });
+
+  it("still redirects when the window is spent — a party shares one IP", async () => {
+    const outcome = await handleLoopHit("buzz_footer", false);
+    expect(outcome.destination).toBe("/?ref=buzz_footer");
+    expect(outcome.surface).toBe("buzz_footer");
+  });
+});
+
+describe("handleLoopHit — the undercount is recorded, not hidden", () => {
+  it("counts a throttled click as throttled rather than as nothing", async () => {
+    const outcome = await handleLoopHit("share", false);
+    expect(outcome).toEqual({
+      surface: "share",
+      destination: "/?ref=share",
+      counted: false,
+      throttled: true,
+    });
+    expect(recorded.throttled).toBe(1);
+    expect(recorded.clicks).toEqual([]);
+  });
+
+  it("does not double-count a throttled click as both", async () => {
+    await handleLoopHit("join_footer", false);
+    expect(recorded.clicks).toEqual([]);
+    expect(recorded.throttled).toBe(1);
+  });
+
+  it("does not record a throttle for a segment that was never ours", async () => {
+    // Otherwise a crawler walking bad URLs would inflate the "we are
+    // undercounting" signal and make a healthy week look throttled.
+    await handleLoopHit("nonsense", false);
+    expect(recorded.throttled).toBe(0);
+    expect(recorded.clicks).toEqual([]);
+  });
+});

--- a/tests/loop-stats.test.ts
+++ b/tests/loop-stats.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { LOOP_SURFACES } from "@/lib/loop-links";
+
+const kv = vi.hoisted(() => ({
+  incrs: [] as Array<{ key: string; ttl: number; by?: number }>,
+  failWrites: false,
+}));
+
+vi.mock("@/lib/kv", () => ({
+  dayBucket: () => "2026-08-09",
+  getKvStore: async () => ({
+    async incr(key: string, ttl: number, by?: number) {
+      if (kv.failWrites) throw new Error("kv unavailable");
+      kv.incrs.push({ key, ttl, by });
+      return 1;
+    },
+  }),
+}));
+
+const {
+  HOST_INDEX_CEILING,
+  LOOP_STATS_TTL_SECONDS,
+  loopStatsKeys,
+  recordGameStart,
+  recordLoopClick,
+  recordLoopImpression,
+  recordLoopThrottled,
+} = await import("@/lib/loop-stats");
+
+beforeEach(() => {
+  kv.incrs = [];
+  kv.failWrites = false;
+});
+
+const keysWritten = () => kv.incrs.map((i) => i.key);
+
+describe("the key format is the contract between writer and reader", () => {
+  it("writes exactly the keys loopStatsKeys says it will read", async () => {
+    // If these two ever disagree the digest reads a key nobody writes,
+    // reports zero, and never errors. This is the test that catches it.
+    const expected = loopStatsKeys("2026-08-09", LOOP_SURFACES);
+
+    await recordLoopImpression("buzz_cta");
+    expect(keysWritten()).toContain(expected.impressions.buzz_cta);
+
+    kv.incrs = [];
+    await recordLoopClick("buzz_cta");
+    expect(keysWritten()).toContain(expected.clicks.buzz_cta);
+
+    kv.incrs = [];
+    await recordLoopThrottled();
+    expect(keysWritten()).toContain(expected.throttled);
+
+    kv.incrs = [];
+    await recordGameStart(3);
+    expect(keysWritten()).toContain(expected.games);
+    expect(keysWritten()).toContain(expected.hostIndex[2]); // host_index:3
+  });
+
+  it("covers every surface on both sides", () => {
+    const keys = loopStatsKeys("2026-08-09", LOOP_SURFACES);
+    for (const surface of LOOP_SURFACES) {
+      expect(keys.impressions[surface]).toBe(
+        `loop:stats:2026-08-09:impression:${surface}`
+      );
+      expect(keys.clicks[surface]).toBe(`loop:stats:2026-08-09:click:${surface}`);
+    }
+    expect(keys.hostIndex).toHaveLength(HOST_INDEX_CEILING);
+  });
+});
+
+describe("the liveness marker", () => {
+  it("is bumped by every recorded event, so a real zero is not 'no data'", async () => {
+    const live = loopStatsKeys("2026-08-09", LOOP_SURFACES).live;
+    for (const record of [
+      () => recordLoopImpression("join_footer"),
+      () => recordLoopClick("join_footer"),
+      () => recordLoopThrottled(),
+    ]) {
+      kv.incrs = [];
+      await record();
+      expect(keysWritten()).toContain(live);
+    }
+  });
+});
+
+describe("host game index", () => {
+  it("counts a repeat host only from the second game on", async () => {
+    const repeat = loopStatsKeys("2026-08-09", LOOP_SURFACES).repeatHost;
+
+    await recordGameStart(1);
+    expect(keysWritten()).not.toContain(repeat);
+
+    kv.incrs = [];
+    await recordGameStart(2);
+    expect(keysWritten()).toContain(repeat);
+  });
+
+  it("caps the key space, so a scripted counter cannot fill KV", async () => {
+    await recordGameStart(9_999);
+    expect(keysWritten()).toContain(
+      `loop:stats:2026-08-09:host_index:${HOST_INDEX_CEILING}`
+    );
+  });
+
+  it("clamps nonsense from a corrupted client counter to a first game", async () => {
+    for (const bad of [0, -5, Number.NaN, Number.POSITIVE_INFINITY, 1.7]) {
+      kv.incrs = [];
+      await recordGameStart(bad);
+      expect(keysWritten()).toContain("loop:stats:2026-08-09:host_index:1");
+    }
+  });
+});
+
+describe("fail-soft", () => {
+  it("swallows a KV outage rather than failing the caller's request", async () => {
+    kv.failWrites = true;
+    await expect(recordLoopClick("share")).resolves.toBeUndefined();
+    await expect(recordGameStart(2)).resolves.toBeUndefined();
+    await expect(recordLoopThrottled()).resolves.toBeUndefined();
+  });
+});
+
+describe("TTL", () => {
+  it("outlives the digest window, which ends days back and reads a week", async () => {
+    // A 7-day TTL would expire the oldest day of every report right before it
+    // was read, and an expired key is indistinguishable from an unwritten one.
+    await recordLoopClick("share");
+    expect(LOOP_STATS_TTL_SECONDS).toBeGreaterThanOrEqual(14 * 24 * 60 * 60);
+    for (const write of kv.incrs) {
+      expect(write.ttl).toBe(LOOP_STATS_TTL_SECONDS);
+    }
+  });
+});

--- a/tests/playlist-cache.test.ts
+++ b/tests/playlist-cache.test.ts
@@ -20,6 +20,10 @@ const kv = vi.hoisted(() => {
 });
 
 vi.mock("@/lib/kv", () => ({
+  // `dayBucket` is a pure function over a clock, not a store, so the fake
+  // reproduces it rather than stubbing it — a mocked bucket would let the key
+  // format drift here without any test noticing.
+  dayBucket: (at: Date = new Date()) => at.toISOString().slice(0, 10),
   getKvStore: async () => ({
     async get(key: string) {
       if (kv.flags.failReads) throw new Error("kv unavailable");

--- a/tests/pulse.test.ts
+++ b/tests/pulse.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { parsePulse } from "@/lib/pulse";
+import { HOST_INDEX_CEILING } from "@/lib/loop-stats";
+import { LOOP_SURFACES } from "@/lib/loop-links";
+
+describe("parsePulse — impressions", () => {
+  it("accepts every declared surface", () => {
+    for (const surface of LOOP_SURFACES) {
+      expect(parsePulse({ kind: "loop_impression", surface })).toEqual({
+        kind: "loop_impression",
+        surface,
+      });
+    }
+  });
+
+  it("rejects a surface we did not declare, which would become a KV key", () => {
+    for (const surface of ["", "nonsense", "BUZZ_CTA", "a".repeat(500), 7, null]) {
+      expect(parsePulse({ kind: "loop_impression", surface })).toBeNull();
+    }
+  });
+});
+
+describe("parsePulse — game starts", () => {
+  it("accepts a plain index", () => {
+    expect(parsePulse({ kind: "game_started", hostGameIndex: 3 })).toEqual({
+      kind: "game_started",
+      hostGameIndex: 3,
+    });
+  });
+
+  it("clamps rather than rejects a corrupted counter, so a real game still counts", () => {
+    const cases: Array<[number, number]> = [
+      [0, 1],
+      [-42, 1],
+      [1.9, 1],
+      [HOST_INDEX_CEILING + 1, HOST_INDEX_CEILING],
+      [1e12, HOST_INDEX_CEILING],
+    ];
+    for (const [input, expected] of cases) {
+      expect(parsePulse({ kind: "game_started", hostGameIndex: input })).toEqual({
+        kind: "game_started",
+        hostGameIndex: expected,
+      });
+    }
+  });
+
+  it("rejects a non-finite or non-numeric index", () => {
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, "3", null, undefined, {}]) {
+      expect(parsePulse({ kind: "game_started", hostGameIndex: bad })).toBeNull();
+    }
+  });
+});
+
+describe("parsePulse — everything else", () => {
+  it("rejects bodies that are not objects", () => {
+    for (const bad of [null, undefined, 0, "", "kind", [], true]) {
+      expect(parsePulse(bad)).toBeNull();
+    }
+  });
+
+  it("rejects an unknown kind rather than guessing", () => {
+    expect(parsePulse({ kind: "something_new", surface: "share" })).toBeNull();
+    expect(parsePulse({ surface: "share" })).toBeNull();
+  });
+
+  it("ignores extra fields instead of passing them through", () => {
+    const parsed = parsePulse({
+      kind: "loop_impression",
+      surface: "share",
+      evil: "<script>",
+      hostGameIndex: 99,
+    });
+    expect(parsed).toEqual({ kind: "loop_impression", surface: "share" });
+  });
+
+  it("is not fooled by a prototype-polluting body", () => {
+    const parsed = parsePulse(JSON.parse('{"__proto__":{"kind":"game_started"}}'));
+    expect(parsed).toBeNull();
+  });
+});


### PR DESCRIPTION
Buzzer Mode has put a phone in every hand for weeks and never told any of them what they were holding.

- `app/buzz/[code]/page.tsx` — 264 lines, zero `<a>` tags, and not one occurrence of the string "GuessSong"
- `app/j/[code]/page.tsx` — ended at a confirmation card with nowhere to go
- `lib/result-image.ts:84` — printed "Played with GuessSong" on the one artifact that leaves the party, with no address on it

The expensive half of a viral loop (rooms, live sockets, canvas share cards) already shipped. This is the half nobody wrote.

## The five surfaces

| Surface | Where | Note |
|---|---|---|
| `buzz_footer` | all three of the buzzer page's return paths | including the pre-join form — the only screen on that phone not competing with a song |
| `buzz_cta` | the live buzzer screen, between rounds | kept mounted and hidden, so it cannot reflow the buzz button under a thumb |
| `join_submitted` | the Mixed Playlist confirmation screen | previously a dead end |
| `game_over` | a QR on the host's Game Over screen | the room is looking at a TV holding the phones they just buzzed with; the trial overlay has had a way onward since launch and the party path had none |
| `share` | a QR drawn into the result card | |

Each is named once in `lib/loop-links.ts` and derived everywhere else. The name is needed in the `href`, the analytics param and the server-side validator at the same time, and hand-syncing them fails **silently**: a stale validator still redirects, the counter just stops, and that arm reads as "nobody clicked it" — you would then correctly conclude the CTA was useless and delete one that was working. Same single-union trick `lib/buzzer-protocol.ts` uses across the Worker boundary.

## Decisions worth reviewing

**The link is a real navigation to `/r/[surface]`, not a click handler.** The click being measured is the click that leaves the page, so a background report fired at that moment is the one most likely to be cancelled. Routing through the server makes the navigation itself the measurement. Plain `<a>` rather than `next/link` (prefetching a counting endpoint would inflate it), `Cache-Control: no-store` (a cached 302 serves later clicks without reaching the counter), and `/r` disallowed in `app/robots.ts`.

**The visitor always reaches the setup page.** Unknown segment, spent rate limit, KV unavailable — every branch still redirects, and only the count may be lost. The person clicking is precisely the person this feature exists to reach. The limiter is sized for a household rather than a person (120/hour) because it is keyed by IP and a party is a dozen phones behind one Wi-Fi address; `app/api/room/[code]/status` is the standing lesson there. Throttled clicks are counted separately so the undercount shows up rather than quietly depressing the rate.

**`buzz_cta` is gated on `snapshot.roundIndex >= 1 && phase === "idle"`, not on a `locked → idle` transition.** `handleResolve` in `worker/src/buzzer-room.ts` reaches `idle` from both `open` and `locked`, so a round nobody buzzed at is indistinguishable from one that was answered. `roundIndex` advances only on `host:next`, and reading it off the snapshot means it survives a reconnect.

**The card's URL is deliberately NOT added to the `navigator.share` payload.** iOS drops `url` when a file is attached, and several Android targets drop the *file* when a `url` is present. Risking the image, which is the entire payload, to add a link one platform throws away is a bad trade. The pixels are the carrier.

**`?ref=` is read from `window.location.search`, not `useSearchParams`.** `/` is a client component that is still statically prerendered, carries the FAQ structured data, and takes essentially all of this site's traffic. Verified against `next build`: `/` is still `○ (Static)`. It is also validated through `isLoopSurface` before it can reach a GA4 param — `/?ref=` is a public URL.

## Read these numbers as floors

`host_game_index >= 2` is the number this line of work is waiting on, and it is systematically undercounted: iOS evicts script-writable `localStorage` after seven days without a visit, which is precisely the gap between two parties. Private windows start empty. A laptop passed around a room is several hosts wearing one identity. `arrived_from: "organic"` is likewise a catch-all that absorbs every lost attribution.

Attribution is last loop touch within 60 days rather than same-pageview — the conversion happens at a *later* party, so crediting only the visit that carried the `?ref=` would record almost every real conversion as organic.

## Incidental fixes

- **`dayBucket()` extracted to `lib/kv.ts`**, replacing copies in `lib/playlist-cache.ts` and `lib/preview-cache.ts`. Writer and reader live in different modules, so a divergence addresses a different key without throwing anything. Pinned by a test on the literal.
- **`parseInt("1e309", 10)` returns `1`** — a real defect found while writing `lib/host-session.ts`. A corrupted counter would read as a plausible number instead of as damage. Now a strict all-digits check.
- **jsdom gives `window` but not `localStorage`** in this vitest setup. Without a stub, every test of a storage module takes the "unavailable" branch and passes while covering nothing. The tests install one and a canary asserts it is there.

## Verification

- `npm test` — 351 passing (+59), 22 files (+5)
- `npm run build` — clean; `/` remains `○ (Static)`
- `npx eslint app lib components` — clean
- `npx tsc --noEmit` — clean

## Not in this PR

**The weekly digest.** The counters are being written and nothing reads them yet, which means this release still has the defect every release before it had: the numbers exist and require a human to go and fetch them. That is the next change, and it is in `CHANGELOG.md` under Known gaps.

One thing with a deadline, unaffected by this PR: **GA4 Admin → Data Settings → Data Retention is at the 2-month default and is continuously deleting data from June onward.** Changing it to 14 months is one click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)