### PR TITLE
feat: npm run stats, and a tracked docs/ directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,16 @@ half nobody had written.
   a genuine zero looks like too — without it, "the CTA does nothing", the single
   most important negative result available here, would render as "no data yet"
   forever.
+- **`npm run stats`** (`scripts/loop-stats.mjs`), which prints the counters as a
+  table: shown/followed/rate per surface, games started, repeat hosts, the
+  distribution by host game number, and how many clicks the limiter dropped.
+  Keys are **discovered** (`KEYS loop:stats:*`) rather than rebuilt from a
+  hardcoded list, so this file holds no second copy of the metric names — that
+  drift would be silent, printing a confident table of zeros for keys nobody
+  writes, and discovery also means a metric added later appears here on its own.
+  The output leads with the caveats, because every number in it is a floor and
+  the failure mode is reading a low one as "the CTA does not work" rather than
+  as "we could not see that it did".
 - **`dayBucket()` in `lib/kv.ts`**, replacing the copies that had accumulated in
   `lib/playlist-cache.ts` and `lib/preview-cache.ts`. The writer and the reader
   of a day-bucketed counter always live in different modules, so the exact
@@ -149,10 +159,16 @@ half nobody had written.
   someone scanning a QR out of a forwarded image rather than typing an address,
   which is a large improvement over nothing but still the only surface whose hit
   does not originate on a page of ours.
-- **No digest yet.** The counters are being written and nothing reads them. That
-  is the next change, and until it lands this release has the same defect as
-  everything before it: the numbers exist and require a human to go and fetch
-  them.
+- **`npm run stats` is the only reader, and it is a manual command.** A
+  scheduled push was designed and then dropped on the maintainer's call, which
+  was the right call: a webhook adds a deploy surface, three environment
+  variables and another feed to read, and the variable that actually predicts
+  whether a number gets looked at is not push-versus-pull but whether reading
+  it requires leaving the editor. What makes the command work is the line in
+  CLAUDE.md telling an agent to run it — delivery moved from a human habit with
+  a 0/4 record to something that happens at the start of a session. If that
+  line gets deleted, this reverts to the same defect every release before it
+  had.
 - `host_game_index` is capped at 10 in KV to bound the key space. Fine for the
   question being asked; it would need revisiting before anyone studies the tail.
 - The buzzer wire protocol still has no end-of-game signal (`BuzzerPhase` is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@ Use `127.0.0.1:8000` (not `localhost`) — the Spotify app is configured for thi
 
 **Run `npm run stats` at the start of any session about growth, the loop, retention, or "what should we build next", and lead with what it says.** Not a nicety. The product's own telemetry went unread for eight weeks across four separate attempts to go and open GA4, and every feature decision in that period was made on an n of 1. The counters exist so that question has an answer; a command nobody runs is the same failure with a shorter path. If the Upstash variables are missing, say so and ask for them rather than reasoning from guesses.
 
+**Read `dev_docs/loop-stats-how-to-read.md` before interpreting the output.** Every number it prints is a floor, and the failure mode is reading a low one as "the CTA does not work" rather than "we could not see that it did".
+
 ## What This Is
 
 **GuessSong** — a local party music guessing game built on **Next.js 15 App Router**. The host pastes a public Spotify playlist URL, adds player names, and plays short audio clips; everyone guesses out loud and the host awards points. **No login and no user accounts** — a single game's state lives in React state, handed off between pages via `sessionStorage`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,12 @@ npm run build      # Production build
 npm run start      # Start production server
 npm run lint       # Run ESLint
 npm test           # Run vitest suite (tests/)
+npm run stats      # Print the viral-loop counters (needs the Upstash env vars)
 ```
 
 Use `127.0.0.1:8000` (not `localhost`) — the Spotify app is configured for this origin.
+
+**Run `npm run stats` at the start of any session about growth, the loop, retention, or "what should we build next", and lead with what it says.** Not a nicety. The product's own telemetry went unread for eight weeks across four separate attempts to go and open GA4, and every feature decision in that period was made on an n of 1. The counters exist so that question has an answer; a command nobody runs is the same failure with a shorter path. If the Upstash variables are missing, say so and ask for them rather than reasoning from guesses.
 
 ## What This Is
 
@@ -135,6 +138,20 @@ Two conventions worth keeping:
 - **Every funnel needs a denominator.** `room_join_opened` exists so a QR code that people scan but fail to get through is distinguishable from one nobody scanned. Pure helpers that shape params (e.g. `roomJobs()`) live here rather than in the calling component, because the test suite only reaches `lib/`.
 
 New params do not appear in GA4 reports until they are registered as custom dimensions (Admin → Custom definitions, scope **Event**), and registration is not retroactive.
+
+### The loop counters are a second, deliberate copy
+
+Everything about the viral loop is recorded twice: once in GA4 through `trackEvent`, and once in KV through `lib/loop-stats.ts` (written by `app/r/[surface]` and `app/api/pulse`, read by `npm run stats`). This is not redundancy to clean up.
+
+**KV is authoritative for any decision.** GA4 is for cohorting and for questions nobody has asked yet. The two will disagree — an ad blocker kills the GA4 event and not the redirect, a spent rate-limit window drops the KV increment and not the GA4 event — and the gap between them is itself a reading of how much of this audience blocks analytics. The reason the second copy exists at all is that GA4 requires someone to go and look, and the measured rate at which that happens here is zero.
+
+Three things in that path are easy to undo by accident:
+
+- **The loop link must stay a real navigation to `/r/[surface]`.** Replacing it with a click handler that reports and then routes loses the click it is measuring: browsers cancel in-flight requests as a document tears down, and this fires on the click that leaves the page. That is also why it is a plain `<a>` and not `next/link` — prefetching a counting endpoint invents hits — and why `/r` is in `app/robots.ts`'s disallow list.
+- **`/r/[surface]` must redirect on every branch.** Unknown segment, spent limiter, KV unavailable: the visitor still reaches `/`, and only the count is lost. The person clicking is precisely the person the loop exists to reach.
+- **Counters carry a liveness marker and are held 30 days, not the 7 the cache stats use.** `mget` returns null for a key that was never written, which is indistinguishable from a genuine zero, and "the CTA does nothing" is the most important negative result available here — without the marker it would render as "no data yet" forever. The 30 days is because a report that looks a week back would otherwise expire its own oldest day.
+
+Every surface name is declared once in `lib/loop-links.ts` and derived from there by the link, the analytics param, and the server-side validator. Hand-syncing those three fails silently: a stale validator still redirects, the counter just stops, and that arm reads as "nobody clicked it".
 
 ## Styling Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+Longer-form reference lives in [`docs/`](docs/README.md): [architecture](docs/architecture.md) (the system in diagrams), [viral-loop](docs/viral-loop.md) (the loop and how to read `npm run stats`), [operations](docs/operations.md) (deploys and what to do when something breaks), and [decisions](docs/decisions.md) (why it is like this, and what was rejected). This file stays the place for invariants and hazards — rules you must not undo. `docs/` is the place for explanation.
+
 ## Commands
 
 ```bash
@@ -17,7 +19,7 @@ Use `127.0.0.1:8000` (not `localhost`) — the Spotify app is configured for thi
 
 **Run `npm run stats` at the start of any session about growth, the loop, retention, or "what should we build next", and lead with what it says.** Not a nicety. The product's own telemetry went unread for eight weeks across four separate attempts to go and open GA4, and every feature decision in that period was made on an n of 1. The counters exist so that question has an answer; a command nobody runs is the same failure with a shorter path. If the Upstash variables are missing, say so and ask for them rather than reasoning from guesses.
 
-**Read `dev_docs/loop-stats-how-to-read.md` before interpreting the output.** Every number it prints is a floor, and the failure mode is reading a low one as "the CTA does not work" rather than "we could not see that it did".
+**Read `docs/viral-loop.md` before interpreting the output.** Every number it prints is a floor, and the failure mode is reading a low one as "the CTA does not work" rather than "we could not see that it did".
 
 ## What This Is
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,24 @@ The root suite covers the pure logic (pooling, taste card, share-target parsing,
 - **Scoring** — the host is the judge. No automated answer checking.
 - **Found a bug?** — use the "Report a problem" link in the footer.
 
+## Docs
+
+This README gets you running. [`docs/`](docs/README.md) explains the parts that
+need more than a paragraph:
+
+- [**architecture**](docs/architecture.md) — the system in diagrams: the
+  Vercel/Cloudflare split, one game end to end, and the four-layer shape shared
+  by all three caches
+- [**viral-loop**](docs/viral-loop.md) — the five loop surfaces, and how to run
+  and read `npm run stats` without drawing the wrong conclusion
+- [**operations**](docs/operations.md) — deploying (the Worker is manual),
+  reading the cache logs, and symptom-by-symptom troubleshooting
+- [**decisions**](docs/decisions.md) — why there are no accounts, why buzzer
+  rooms are Durable Objects, and what was considered and rejected
+
+`CLAUDE.md` is the other half: the invariants and hazards, written for whoever
+or whatever edits this next.
+
 ## License
 
 [MIT](./LICENSE) — fork it, remix it, host your own.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,46 @@
+# Docs
+
+Reference material for working on GuessSong. Four documents, each answering a
+question the others do not.
+
+| Document | Answers |
+|---|---|
+| [architecture.md](architecture.md) | How the pieces fit, in diagrams |
+| [viral-loop.md](viral-loop.md) | How the loop works, and how to read `npm run stats` |
+| [operations.md](operations.md) | It is broken / it is slow / how do I deploy the Worker |
+| [decisions.md](decisions.md) | Why it is like this, and what was rejected |
+
+---
+
+## What belongs here, and what does not
+
+This project already documents itself in four other places, and the way a
+`docs/` directory dies is by becoming a fifth copy that slowly disagrees with
+all of them. So the boundary is explicit:
+
+| Lives in | Contains | Do not duplicate it here |
+|---|---|---|
+| `README.md` | Setup, scripts, project layout, API route list | Getting started |
+| `CLAUDE.md` | Invariants and hazards an agent must not undo | Rules and constraints |
+| `CHANGELOG.md` | What changed, when, and the reasoning at the time | Per-release detail |
+| `lib/changelog.ts` | The same releases in plain language, bilingual, for players | Anything player-facing |
+| Code comments | Why *this line* is the way it is | Line-level rationale |
+
+**`docs/` is for the things that do not fit any of those**: a picture of the
+whole system, a runbook for when something is wrong, an end-to-end walkthrough
+of one feature, and a record of decisions with the alternatives that were
+rejected. Everything here should still be true in six months; anything that is
+only true for one release belongs in `CHANGELOG.md`.
+
+`dev_docs/` is gitignored and stays that way. It holds planning artifacts for
+features that have since shipped — the buzzer plan written at 4,000 users, the
+Mixed Playlist specs — which are useful history and would be stale content in a
+tracked directory.
+
+## Keeping it honest
+
+Every claim about the code here should name a file, and ideally a line. That is
+not decoration: a documented behaviour with no pointer is unverifiable, and
+unverifiable documentation is how a directory like this stops being trusted.
+When a pointer goes stale, the fix is to follow it and correct the prose, not
+to remove the pointer.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,205 @@
+# Architecture
+
+The system in pictures. `CLAUDE.md` carries the invariants and the hazards;
+this is the shape they sit on.
+
+---
+
+## 1. The whole thing
+
+Two hosts, and the split is not arbitrary. Vercel serves the app and everything
+request-shaped. Cloudflare serves the one thing Vercel structurally cannot: a
+live room that several phones are connected to at once. See
+[decisions.md](decisions.md#d3--buzzer-rooms-run-on-cloudflare-durable-objects).
+
+```
+                    ┌───────────────────────────────────────┐
+   host's laptop    │            VERCEL (Next.js)           │
+   ┌──────────┐     │                                       │
+   │  /       │────▶│  POST /api/playlist ──┐               │
+   │  /game   │     │  GET  /api/preview    │               │
+   └──────────┘     │  POST /api/preview/   │  lib/kv.ts    │      ┌──────────┐
+        │           │       batch        ───┼─────────────────────▶│ UPSTASH  │
+        │           │  POST /api/room/…     │  (the only    │      │  REDIS   │
+        │           │  GET  /r/[surface]    │   server      │      └──────────┘
+        │           │  POST /api/pulse   ───┘   state)      │       TTL'd only:
+        │           │                                       │       rooms, rate
+        │           └──────────┬────────────────────────────┘       limits, caches,
+        │                      │                                    loop counters
+        │                      ▼
+        │       ┌──────────────────────────────┐
+        │       │  Spotify  ·  iTunes  ·  Deezer│  all rate limited per app / per IP,
+        │       └──────────────────────────────┘  never per user — see §3
+        │
+        │  WebSocket
+        ▼
+   ┌─────────────────────────┐        ┌──────────────────────┐
+   │   CLOUDFLARE WORKER     │◀──────▶│  players' phones     │
+   │   worker/src/           │   WS   │  /buzz/[code]        │
+   │   one Durable Object    │        └──────────────────────┘
+   │   per room code         │
+   └─────────────────────────┘
+```
+
+**There are no user accounts and no database.** Everything in Upstash has a TTL
+and belongs to a room, an IP, a cached lookup, or a daily counter. Nothing is
+keyed to a person. That is a product decision, not an omission — see
+[decisions.md](decisions.md#d1--no-accounts-ever).
+
+---
+
+## 2. One game, start to finish
+
+```
+SETUP  app/page.tsx
+  │
+  │  paste playlist URL, add players, pick clip length
+  ▼
+  POST /api/playlist ──▶ lib/playlist-cache.ts ──▶ lib/spotify.ts ──▶ Spotify
+  │                       cache → coalesce → budget → cooldown
+  │                       (§3 — all four exist to protect one shared quota)
+  ▼
+  shuffle, write the whole payload to sessionStorage under `guesssong_game`
+  │
+  ▼
+GAME  app/game/page.tsx
+  │
+  │  on mount: POST /api/preview/batch for the entire game at once
+  │            anything unresolved falls back to GET /api/preview lazily
+  │
+  │  per track:   waiting → playing → guessing → revealed
+  │                                                 │
+  │               host awards points by tapping a name  (+3 song, +1 album)
+  │               there is no automated answer checking — the host is the judge
+  │                                                 │
+  └─────────────────── next track ──────────────────┘
+                              │
+                              ▼
+                          finished
+```
+
+The state machine lives entirely in React state. A reload loses the game, which
+is why `sessionStorage` holds the payload but not the score: recovering a
+half-played party would need a server-side game record, and that is the first
+step towards accounts.
+
+---
+
+## 3. Three caches, one shape
+
+The single most important thing to understand about this codebase. All three
+upstreams throttle on something the app cannot spread out — Spotify on the
+**client id**, iTunes and Deezer on the **egress IP** — while every limiter in
+`lib/rate-limit.ts` is keyed per visitor IP and therefore hands each new arrival
+a fresh allowance. Per-IP limits bound one abusive client. They do nothing about
+aggregate load, and aggregate load is the entire problem.
+
+So each cache is four layers, and they read the same way on purpose:
+
+```
+     request
+        │
+        ▼
+   ┌─────────┐   hit
+   │  CACHE  │────────▶ answer, zero upstream calls
+   └────┬────┘
+        │ miss
+        ▼
+   ┌─────────────┐   already in flight
+   │ COALESCING  │──────────────────────▶ await the sibling
+   └────┬────────┘   (one Mixed-mode Start fans out to N identical loads;
+        │             the cache write lands too late to help its own siblings)
+        ▼
+   ┌──────────────┐   over budget
+   │GLOBAL BUDGET │──────────────────────▶ refuse here, before upstream does
+   └────┬─────────┘   a KV incr shared across instances
+        │
+        ▼
+   ┌──────────────┐   upstream said 429
+   │  COOLDOWN    │──────────────────────▶ park all uncached loads
+   └────┬─────────┘   without it a throttled window is self-sustaining:
+        │              everyone errors, everyone retries, the quota stays pinned
+        ▼
+     upstream
+```
+
+| | `lib/playlist-cache.ts` | `lib/preview-cache.ts` |
+|---|---|---|
+| Called once per | playlist | **track** |
+| Cold 50-song game | 1 load | **50 lookups, up to 5 calls each** |
+| Budget env var | `SPOTIFY_MAX_LOADS_PER_MINUTE` (40) | `PREVIEW_MAX_LOOKUPS_PER_MINUTE` (120) |
+| Positive TTL | 6h (1h if sampled) | 1 year |
+| Negative TTL | 10 min | 1 week (`absent`) / **90s** (`unavailable`) |
+
+**Every layer fails open.** Losing the safety net must mean "back to how it was",
+never "nobody can play".
+
+The third cache is the Spotify token in `lib/spotify.ts`, deliberately at module
+scope rather than in KV: a token is the one thing with no fallback, so a KV
+outage on that path would take playlist loading down entirely.
+
+### The distinction that keeps getting collapsed
+
+`absent` and `unavailable` are both "no clip", and treating them as one value is
+a bug that already shipped once:
+
+- **`absent`** — a fact about the recording. Nothing anywhere has a clip.
+  Cached a week.
+- **`unavailable`** — a fact about *us*. Throttled, out of budget, or the
+  request never got through. Cached **90 seconds**.
+
+A wrong `absent` lasts a week and is invisible. A wrong `unavailable` costs one
+retry. Only a clean, complete reply from upstream may produce `absent`.
+
+---
+
+## 4. Buzzer rooms
+
+```
+  host's laptop                DURABLE OBJECT               phones
+  BuzzerHostPanel              one per room code            /buzz/[code]
+       │                              │                          │
+       │──── host:open ──────────────▶│                          │
+       │                              │───── round:open ────────▶│  buttons live
+       │                              │                          │
+       │                              │◀──────── buzz ───────────│  ×N, racing
+       │                              │                          │
+       │                              │  single-threaded: order  │
+       │                              │  is decided by arrival,  │
+       │                              │  no locks, no CAS        │
+       │                              │                          │
+       │◀───── state (locked) ────────│──── state (locked) ─────▶│  first name up
+       │                              │                          │
+       │─ host:verdict / host:reveal ▶│                          │
+       │                              │──── round:resolved ─────▶│  phase → idle
+       │──── host:next ──────────────▶│  roundIndex += 1         │
+       └──────────────────────────────┘                          │
+```
+
+`lib/buzzer-protocol.ts` is imported from **both** sides of that boundary — the
+Next.js client and the Worker — so it must stay dependency-free. Types and plain
+constants only.
+
+**The protocol has no end-of-game signal.** `BuzzerPhase` is
+`idle | open | locked`; `ClientMessage` has `host:open`, `host:verdict`,
+`host:reveal`, `host:next` and nothing else. Anything on a player's phone that
+needs to react to the game finishing would need a protocol change, a Worker
+change, and a `wrangler deploy`. This is why the loop's call to action on that
+page is gated on "a round has resolved" rather than "the game ended" — see
+[viral-loop.md](viral-loop.md#the-buzz-cta-gate).
+
+---
+
+## 5. Where state actually lives
+
+| Where | What | Lifetime |
+|---|---|---|
+| React state | the running game — phase, scores, current track | until reload |
+| `sessionStorage` | the game payload handed from `/` to `/game` | the tab |
+| `localStorage` | player id, host name, host game count, last loop ref | the device, until ITP clears it |
+| Upstash KV | rooms, rate limits, playlist + preview caches, loop counters | 30s – 1 year, always a TTL |
+| Durable Object | one live buzzer room | 3h idle timeout, sliding |
+| GA4 | the funnel | Google's retention setting |
+
+Nothing in that table is keyed to a person, and nothing survives being cleared
+except the caches, which are keyed to content rather than to anyone.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,232 @@
+# Decisions
+
+Why the product is shaped this way, and what was considered and rejected.
+
+Kept in the repo on purpose. Most of these were argued out in design documents
+that live outside it, which means a fresh clone — or the same person in six
+months — has the constraints without the reasoning, and re-litigates a settled
+question from scratch. Each entry names the alternative and what would make it
+worth reopening.
+
+---
+
+## D1 — No accounts, ever
+
+**Decided:** from launch. Reaffirmed 2026-08.
+
+There is no login, no user record, and nothing in storage keyed to a person. A
+host pastes a link and starts; a player scans a QR and types a name.
+
+**Rejected:** accounts, so that scores, history, and repeat hosting could be
+tracked properly.
+
+**Why:** the entire product advantage is that a party can start in about twenty
+seconds, at a moment when everyone is already half-distracted. An auth screen at
+that moment is not a small tax, it is the whole funnel. Every measurement
+problem downstream of this — see D6 — is a price knowingly paid.
+
+**Would reopen if:** something genuinely impossible without identity becomes the
+main thing people want. Wanting *better analytics* is not that; it is the
+motivation this decision exists to refuse.
+
+---
+
+## D2 — Web and PWA, not an App Store listing
+
+**Decided:** 2026-07-29.
+
+**Rejected:** shipping a native app.
+
+**Why:** there was no user signal for it — no requests, no GA4 evidence, no
+capability the PWA lacked. The actual driver was a feeling that a website "is
+not a real product", and that feeling does not survive contact with the App
+Store; it just changes units to "not enough downloads". Meanwhile the cost is
+two platforms and a human review cycle, which turns a one-line copy change from
+three minutes into three days.
+
+The legitimacy problem was real and got a product answer instead: Buzzer Mode.
+What makes Jackbox feel like a real game is not that it is installed, it is that
+everybody's phone is in it.
+
+**Unchecked risk if this is reopened:** Spotify's developer terms on game usage
+are loosely enforced against a website and would be read line by line in a
+manual app review. Verify that *first* — it could be an architectural rejection,
+not a screen to fix.
+
+**Would reopen if:** a concrete user signal appears, or a real PWA capability
+gap. Not a feeling.
+
+---
+
+## D3 — Buzzer rooms run on Cloudflare Durable Objects
+
+**Decided:** 2026-07-29. This reversed an earlier decision to avoid a realtime
+layer entirely.
+
+**Rejected:** Vercel's native WebSockets, self-hosted Socket.IO, PartyKit,
+Supabase Realtime, and short-interval polling.
+
+**Why:**
+
+- **Vercel WebSockets cannot broadcast.** The documentation is explicit that new
+  connections are not guaranteed to reach the same function instance and that
+  rooms and pub/sub belong in external storage. So `io.to(room).emit()` has no
+  meaning there, and Upstash's REST API has no `SUBSCRIBE` to back one. Staying
+  on one platform would still have required a second dependency, without any of
+  the benefit.
+- **Connections are bounded by `maxDuration`** — 300s on Hobby. A thirty-minute
+  game means every player reconnecting six times.
+- **Polling was the original plan and does not survive contact with the rate
+  limiter.** `app/api/room/[code]/status` allows 200 requests per 10 minutes,
+  i.e. one every three seconds, and buzzing needs sub-second. The key is also
+  `room:status:${ip}`, so an entire party shares one bucket.
+- A Durable Object is **single-threaded per room**, which makes "who pressed
+  first" an ordinary function call instead of a distributed consensus problem.
+  No locks, no CAS, no retry loop. Hibernation means an idle room costs nothing.
+
+**Cost accepted:** a second platform, a second deploy that is not automatic
+(see [operations.md](operations.md#1-two-deploys-and-only-one-is-automatic)),
+and a protocol file that must stay dependency-free because both sides import it.
+
+---
+
+## D4 — Playlists are sampled, not read whole
+
+**Decided:** 2026-08-03.
+
+`fetchPlaylistTracks` reads at most `MAX_PLAYLIST_TRACKS` (500), choosing random
+pages when a playlist is larger.
+
+**Rejected:** following `next` until the playlist ends.
+
+**Why:** Spotify throttles on the **client id**, so every visitor shares one
+budget. An unbounded loop made a 4,000-track playlist cost 40 upstream requests
+for a game that plays at most 50 songs. Sampling by *page* rather than by track
+because a page is what a request buys.
+
+**Cost accepted:** "All" now means "a random 500". Invisible for any playlist a
+party would realistically use, but a real behaviour change — `truncated` is
+returned and still not surfaced in the UI, so a host with a huge playlist gets
+no indication they are hearing a sample. Sampled results cache for 1h rather
+than 6h, because the TTL is also how long everyone is stuck with the same draw.
+
+---
+
+## D5 — Loop before monetisation
+
+**Decided:** 2026-08-09, at 13,000+ MAU, 100% organic, zero revenue.
+
+Order: close the loop, make repeat hosting countable, then ask about money.
+
+**Rejected:** a paid fake door first.
+
+**Why:** the product has no limit worth paying to remove. It is free and
+unrestricted — `ROOM_MAX_SUBMISSIONS = 12`, `MAX_PLAYLIST_TRACKS = 500`, 5–30s
+clips — and none of those hurt. A fake door needs a door. Creating a pain worth
+charging for is a separate design problem and was not solved.
+
+The loop went first for a different reason than "it is more important": it is
+the only item that is correct **regardless of what the data says**. If nobody
+returns, that proves the loop is needed; if many do, the loop amplifies it. It
+was therefore not blocked on evidence nobody had.
+
+**A related premise was wrong and is recorded here so it is not repeated.** The
+first version of this argument claimed the product *structurally could not*
+recognise a repeat host and deferred monetisation a full quarter on that basis.
+The mechanism already existed — `getPersistentPlayerId` in
+`lib/use-buzzer-socket.ts`, a persisted host name in `components/room-panel.tsx`,
+and GA4's own `client_id`. The true statement was "nobody ever attached a host
+identity to an event", which is a small change, not a quarter. An adversarial
+review caught it. **Watch for that shape of error: an observation failure
+laundered into an architectural constraint.**
+
+**Would reopen if:** the share of games at `host_game_index >= 2` climbs. That
+is the number that moves monetisation from next quarter to next month.
+
+---
+
+## D6 — Measure in KV as well as GA4
+
+**Decided:** 2026-08-09.
+
+Loop events are recorded twice: GA4 through `trackEvent`, and KV through
+`lib/loop-stats.ts`, read by `npm run stats`.
+
+**Rejected:** GA4 alone, and — separately — the GA4 Data API behind a scheduled
+digest.
+
+**Why GA4 alone is not enough:** it requires someone to open it, and across four
+attempts over eight weeks that did not happen once. Every feature decision in
+that period was made on an n of 1. Treat a step with a measured completion rate
+of zero as unavailable and design around it, rather than assigning it a fifth
+time.
+
+**Why not the GA4 Data API:** parameter-level breakdowns need the parameter
+registered as a custom dimension, registration is **not retroactive**, and GA4's
+default event retention is 2 months — so the historical questions were already
+unanswerable. It also put a five-step Google Cloud service-account setup on the
+critical path of a plan whose entire premise was that manual steps do not get
+done.
+
+**KV is authoritative for decisions.** GA4 keeps cohorting and the questions
+nobody has asked yet. They will disagree, and the gap approximates how much of
+this audience blocks analytics.
+
+---
+
+## D7 — A command, not a scheduled digest
+
+**Decided:** 2026-08-09, overturning the plan from earlier the same day.
+
+`npm run stats` reads the counters. There is no cron and no webhook.
+
+**Rejected:** a weekly Vercel Cron posting a digest to Discord or Slack.
+
+**Why:** the digest was designed on the premise that data must *arrive*. That
+framing was wrong. The variable is not push versus pull, it is whether reading
+requires **leaving the editor**. A webhook adds a deploy surface, three
+environment variables, and one more feed to ignore. A command in the repo runs
+from the terminal that is already open — and, decisively, a coding agent can run
+it unprompted.
+
+**The line in `CLAUDE.md` telling an agent to run it is the delivery
+mechanism**, not documentation of one. Delete that line and this reverts to the
+same defect as GA4.
+
+**A corollary worth generalising:** a single discrete setting change is a
+reliable thing to ask a human for — flipping GA4 retention from 2 to 14 months
+happened within minutes. "Open the dashboard, find the report, work out what it
+means" is not. Size asks accordingly, and turn the second kind into a command.
+
+---
+
+## D8 — `absent` and `unavailable` are different nulls
+
+**Decided:** 2026-08-03, after the collapsed version shipped and caused an
+outage.
+
+**Why it is here rather than only in the changelog:** it is the most expensive
+mistake this codebase has made, and it is the kind that looks like a
+simplification. Mapping every failure onto "no preview" and caching it for a
+week meant one throttled minute at peak marked a slice of the catalogue silent
+for seven days. It never reproduced locally, because a laptop's own IP is never
+the one being throttled, and it presented as a catalogue gap rather than as
+throttling.
+
+Only a clean, complete reply from upstream may produce `absent`. Everything else
+is `unavailable`, cached 90 seconds. **A wrong `absent` lasts a week and is
+invisible; a wrong `unavailable` costs one retry.**
+
+---
+
+## Rejected and still rejected
+
+Short entries, so they are not re-proposed as new ideas.
+
+| Idea | Why not | Reopen if |
+|---|---|---|
+| Automated answer checking | The host being the judge is what makes it a party game rather than a quiz app; arguing with a string matcher is not fun | never, probably |
+| Full-site Chinese localisation | Real leak — Chinese-keyword SEO lands on an English UI — but it connects no feedback loop, and `useErrorLocale` starts at `"en"` and switches in an effect, which is fine for an empty error slot and a full-page flash for body copy | after the loop numbers arrive, with a server-side `Accept-Language` hint |
+| More game modes | Presume repeat play, the one evidence category that is entirely absent | `host_game_index >= 2` climbs |
+| A `/admin` stats page | Same failure mode as GA4 with a different URL — you still have to remember to open it | never; extend `npm run stats` instead |
+| Apple Music, Discord bot | Proposed and withdrawn by the author for lack of evidence, twice | a concrete user signal |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,188 @@
+# Operations
+
+Deploying, and what to do when something is wrong. `README.md` covers first-time
+setup; this is the part you need at 11pm.
+
+---
+
+## 1. Two deploys, and only one is automatic
+
+| | Where | How | When |
+|---|---|---|---|
+| The app | Vercel | auto-deploys on merge to `main` | every merge |
+| The buzzer Worker | Cloudflare | `cd worker && npm run deploy` | **manually, never automatically** |
+
+**The Worker does not deploy itself.** Nothing in CI touches it. A change to
+`worker/src/` that is merged and not deployed leaves production running the
+previous version, and the symptom is not an error — buzzer rooms simply behave
+like the old code.
+
+`lib/buzzer-protocol.ts` is imported by both sides. Changing it means deploying
+both, and **the Worker first**: an old Worker talking to a new client fails on
+messages it does not recognise, while a new Worker talking to an old client
+usually still works, because the protocol only ever gains message types.
+
+```bash
+cd worker
+npm run typecheck
+npm test
+npm run deploy
+```
+
+## 2. There is no CI
+
+No `.github/workflows`. Nothing runs the suite before a merge. Before opening a
+pull request:
+
+```bash
+npm test              # 351 tests, ~1.5s
+npx tsc --noEmit
+npx eslint app lib components
+npm run build         # see the warning below
+```
+
+> **Never run `npm run build` while `npm run dev` is running.** The production
+> output overwrites `.next` and the dev server then answers every request with
+> `Cannot find module ./331.js`. `rm -rf .next` is not enough — the running
+> process still holds the old chunk table in memory, so the dev server has to be
+> restarted. Stop dev first.
+
+## 3. Environment variables
+
+Full annotated list in `.env.example`. What actually breaks without each:
+
+| Variable | Missing means |
+|---|---|
+| `SPOTIFY_CLIENT_ID` / `_SECRET` | pasting a playlist URL fails; the three built-in trial playlists still work |
+| `UPSTASH_REDIS_REST_URL` / `_TOKEN` | falls back to an in-process `Map`. Fine for `next dev`; **broken on Vercel** — rooms created by one lambda are invisible to another, rate limits reset per instance, caches lose most of their hit rate |
+| `NEXT_PUBLIC_BUZZER_WS_URL` | Buzzer Mode reports rooms unavailable rather than failing at connect time |
+| `NEXT_PUBLIC_GA_MEASUREMENT_ID` | no GA4. The KV loop counters still work |
+| `NEXT_PUBLIC_BASE_URL` | defaults to `https://www.guessong.app` |
+| `SPOTIFY_MAX_LOADS_PER_MINUTE` | defaults to 40 |
+| `PREVIEW_MAX_LOOKUPS_PER_MINUTE` | defaults to 120 |
+
+---
+
+## 4. Reading what production is doing
+
+### The loop
+
+```bash
+npm run stats
+```
+
+Full guide: [viral-loop.md](viral-loop.md#5-running-npm-run-stats). Every number
+it prints is a floor — §6 there explains why that matters more than it sounds.
+
+### The caches
+
+No endpoint, by design; an endpoint would need an auth story for what is a
+two-line grep. In the Vercel logs:
+
+```
+[playlist-cache] miss id=… source=… hits=… negative=… misses=… rate=…
+[preview-cache]  miss hits=… misses=… unavailable=… rate=…
+```
+
+Both log **only on a miss**, so the instrumentation gets quieter as things get
+healthier and a sudden run of lines is itself the signal.
+
+Two traps in reading those lines, both of which have cost a debugging detour:
+
+- **Trust `source=`, not the log row's method.** Only `POST /api/playlist` and
+  `POST /api/room/[code]/submit` can emit the line, but Vercel attributes it to
+  whichever request the instance happened to be serving, so it frequently
+  appears against an unrelated `GET`.
+- **`rate` counts a replayed 404 as a hit.** Correctly — it answered without
+  touching Spotify — so a host retrying a dead link pushes the rate *up*.
+  `negative=` is that subset; `hits - negative` is the part describing real
+  playlists. The bucket is a **UTC** day, so a rate read just after 00:00 UTC is
+  measuring almost nothing.
+
+---
+
+## 5. Symptoms
+
+### "Songs have no audio"
+
+First distinguish the two causes, because they call for opposite responses:
+
+- `absent` — nothing anywhere has a clip for that recording. A catalogue gap.
+  Curate around it.
+- `unavailable` — **our** problem: throttled, out of budget, or the request did
+  not get through.
+
+`preview_miss` in GA4 carries this as a bucketed `reason`, and
+`[preview-cache] … unavailable=` rising while `misses=` stays flat is the
+throttling signature. Reading the second as the first is how a previous
+investigation went hunting for songs that were never missing.
+
+Note that iTunes signals throttling with **403**, not 429, and Deezer returns
+its quota error in the body of a **200**.
+
+### "Spotify says 429"
+
+The cooldown in `lib/playlist-cache.ts` parks all *uncached* loads for the
+`Retry-After` duration (clamped 30s–15min), shared across instances via KV.
+Cached playlists keep serving throughout, so a party already mid-game is
+unaffected.
+
+If it is persistent rather than a spike, lower `SPOTIFY_MAX_LOADS_PER_MINUTE`.
+Its default of 40 is a guess — the right value depends on which quota tier the
+Spotify app is on, which the code cannot discover, which is why it is an env
+var. Watch the hit-rate log for a week and tune.
+
+**Never flatten an upstream 429 into a generic 400.** The client has to be able
+to tell "your playlist is wrong" from "we are throttled"; an earlier version
+told throttled hosts to check their URL was public, which sent them straight
+back into retrying against a spent quota.
+
+### "The buzzer room will not connect"
+
+In order of likelihood:
+
+1. `NEXT_PUBLIC_BUZZER_WS_URL` unset or pointing at a dead Worker
+2. The Worker was not deployed after a merge (see §1)
+3. The room expired — the DO has a **3h idle timeout**, and it slides on host
+   activity
+
+A room that does not exist is refused at the WebSocket upgrade, which means the
+client can never receive an app-level error — there is no socket to send one
+over. `lib/use-buzzer-socket.ts` therefore counts consecutive never-opened
+attempts and gives up at three. The threshold cannot be one: a phone waking on a
+flaky network legitimately fails the first attempt or two.
+
+### "The room disappeared mid-game"
+
+Mixed Playlist rooms use `ROOM_TTL_SECONDS = 30 * 60`, counted from **creation**
+and deliberately not extended by activity (`types/room.ts`, `lib/room.ts`). That
+is correct for a one-shot playlist mailbox and wrong for anything that must
+outlive a full game. Buzzer rooms are a different system with a sliding timeout.
+
+### "A clip plays but the answer card disagrees"
+
+A wrong recording was cached as correct. Positive preview entries are held a
+**year**, and `&refresh=1` repairs rotted URLs, not wrong songs. The matching
+rules are in `lib/preview-cache.ts` — see the 1.2.0 changelog entry for why the
+tier list is ordered the way it is. Fixing one means invalidating that track's
+key, not bumping the cache version: a version bump cold-starts every entry in
+production simultaneously, which is the upstream stampede the module exists to
+prevent.
+
+---
+
+## 6. Release
+
+Both changelogs, always. `tests/changelog.test.ts` fails if `package.json`'s
+version moves without a matching entry in `lib/changelog.ts`.
+
+1. `CHANGELOG.md` — the maintainer's record. Technical, names files and
+   functions, carries a "Known gaps" list.
+2. `lib/changelog.ts` — what players read in the footer overlay. Plain language
+   and **bilingual**: every entry needs `text`/`textZh` and
+   `headline`/`headlineZh`. `/zh` is written natively, so an English string
+   leaking through is a visible defect.
+3. `package.json` version.
+
+Purely internal changes — a script, a doc, a refactor with no user-visible
+effect — take no version bump and no `lib/changelog.ts` entry.

--- a/docs/viral-loop.md
+++ b/docs/viral-loop.md
@@ -1,0 +1,262 @@
+# The viral loop
+
+Shipped in 1.3.0. How it works, and — the longer half — how to read what it
+measures without drawing the wrong conclusion.
+
+---
+
+## 1. The gap it closes
+
+Buzzer Mode had been putting a phone in every hand for weeks and never told any
+of them what they were holding:
+
+- `app/buzz/[code]/page.tsx` — 264 lines, zero `<a>` tags, and not one
+  occurrence of the string "GuessSong"
+- `app/j/[code]/page.tsx` — ended at a confirmation card with nowhere to go
+- `lib/result-image.ts` — printed "Played with GuessSong" on the one artifact
+  that leaves the party, with no address on it
+
+Every party put four or five phones on those pages, and the product never spoke
+to any of them. The expensive half of a loop — rooms, live sockets, canvas share
+cards — had already shipped. This is the cheap half nobody had written.
+
+---
+
+## 2. The five surfaces
+
+Each is declared **once** in `lib/loop-links.ts` and derived from there by the
+link, the analytics param, and the server-side validator.
+
+| Surface | Where | When |
+|---|---|---|
+| `buzz_footer` | buzzer page, all three return paths | always, including the pre-join form |
+| `buzz_cta` | buzzer page, full-width button | between rounds, after the first resolves |
+| `join_submitted` | Mixed Playlist confirmation screen | after a playlist is submitted |
+| `game_over` | QR on the host's Game Over screen | party mode, end of game |
+| `share` | QR drawn into the result card image | wherever the picture ends up |
+
+### Why one declaration
+
+The name is needed in three places at once, and hand-syncing them fails
+*silently*. A renamed `href` against a stale validator still redirects — the
+counter simply stops incrementing, and that arm reads as "nobody clicked it".
+You would then correctly conclude the call to action was useless and delete one
+that was working. Same single-union trick `lib/buzzer-protocol.ts` uses across
+the Worker boundary.
+
+### The buzz CTA gate
+
+`snapshot.phase === "idle" && snapshot.roundIndex >= 1`.
+
+Two things about that are easy to get wrong:
+
+- **Not a `locked → idle` transition.** `handleResolve` in
+  `worker/src/buzzer-room.ts` reaches `idle` from both `open` and `locked`, so a
+  round nobody buzzed at is indistinguishable from one that was answered.
+  `roundIndex` advances only on `host:next`, which is exactly "a round
+  finished".
+- **Read off the snapshot, not a component ref.** A reconnect adopts the whole
+  snapshot by design, so a ref would reset and the button would vanish for the
+  rest of the game.
+
+It stays mounted and hidden rather than unmounting, so appearing between rounds
+cannot shove the buzz button down the screen under someone's thumb.
+
+---
+
+## 3. How a click is counted
+
+```
+  player taps ──▶ GET /r/buzz_cta ──▶ 302 to /?ref=buzz_cta ──▶ app/page.tsx
+                        │                                            │
+                        │ KV: click:buzz_cta ++                      │ remembers
+                        │                                            │ the ref for
+                        ▼                                            │ 60 days
+                  lib/loop-redirect.ts                               │
+                  decides; the route is a shell                      ▼
+                                                          later: game_started
+                                                          carries arrived_from
+```
+
+**The link is a real navigation, not a click handler.** The click being measured
+is the click that leaves the page, and browsers cancel in-flight requests as a
+document tears down — so a background report fired at that moment is the report
+most likely to be lost, silently, in exactly the cases worth measuring. Routing
+through the server makes the navigation itself the measurement. There is nothing
+left to cancel.
+
+Consequences worth not undoing:
+
+- Plain `<a>`, never `next/link`. Prefetching a counting endpoint invents hits.
+- `Cache-Control: no-store`, or an intermediary caches the 302 and later clicks
+  from that network never reach the counter — the redirect keeps working while
+  the measurement stops.
+- `/r` is in `app/robots.ts`'s disallow list, for the same reason.
+
+**Every branch still redirects.** Unknown segment, spent rate limit, KV
+unavailable: the visitor reaches `/` regardless, and only the count is lost. The
+person clicking is precisely the person this feature exists to reach.
+
+### Attribution is delayed on purpose
+
+`arrived_from` is credited to the **last loop touch within 60 days**, not to the
+visit that carried the `?ref=`. The conversion is not same-session: somebody
+taps a call to action on a friend's sofa and hosts their own party a fortnight
+later. Crediting only within the pageview would record almost every real
+conversion as organic and report a working loop as dead.
+
+---
+
+## 4. Counted twice, on purpose
+
+| | GA4 | KV (`lib/loop-stats.ts`) |
+|---|---|---|
+| Read by | a human, in a browser | `npm run stats` |
+| Good for | cohorts, sessions, unasked questions | decisions |
+| Dies to | ad blockers | a spent rate-limit window |
+
+**KV is authoritative for any decision.** The reason the second copy exists is
+that GA4 requires someone to go and look, and the measured rate at which that
+happened here was zero across four attempts over eight weeks — during which
+every feature decision was made on an n of 1.
+
+The two will disagree, and the gap is itself a reading: it is roughly how much
+of this audience blocks analytics.
+
+---
+
+## 5. Running `npm run stats`
+
+```bash
+npm run stats           # last 7 UTC days
+npm run stats -- 30     # last 30 (the cap — counters have a 30-day TTL)
+```
+
+No setup needed. The script reads `.env.local` and `.env` (both gitignored) via
+Node's built-in `process.loadEnvFile`, the same files `next dev` reads.
+Precedence matches Next: **shell export > `.env.local` > `.env`**, so pointing
+at another database is a prefix away:
+
+```bash
+UPSTASH_REDIS_REST_URL=https://other-db.upstash.io npm run stats
+```
+
+> The load order in the script is *inverted* (`.env.local` first) because
+> `loadEnvFile` does not overwrite a variable that is already set — first writer
+> wins. Remember that if you touch it.
+
+These are production values, from the Vercel project's environment variables.
+Without them there is nothing to read: `lib/kv.ts` falls back to an in-process
+`Map`, so a local run has no data. The script says where it looked and exits 1
+rather than printing a misleading empty table.
+
+### Output
+
+```
+GuessSong loop — last 7 days (UTC)
+Days with any activity: 2/7
+
+Surface            shown    followed     rate
+────────────────────────────────────────────────
+buzz_cta            136          14    10.3%
+buzz_footer         120           4     3.3%
+game_over            22           9    40.9%
+join_submitted       31           7    22.6%
+share                14           1     7.1%
+
+Games started       33
+Repeat hosts        4    12.1% of games
+
+Games by host's game number
+   1     21  █████████████████████████
+   2      3  ████
+  10+     1  █
+```
+
+| Field | Meaning |
+|---|---|
+| `Days with any activity` | days that recorded anything. **Read this first** |
+| `shown` | the surface was rendered, once per surface per tab |
+| `followed` | someone clicked and the server saw it |
+| `rate` | `followed ÷ shown` |
+| `Games started` | real hosted parties. Solo built-in trials are excluded |
+| `Repeat hosts` | games at index ≥ 2. **The number this work is waiting on** |
+
+---
+
+## 6. Every figure here is a floor
+
+This is the section that matters. **The failure mode is reading a low number as
+"the call to action does not work" when it means "we could not see that it
+did".**
+
+- **Repeat hosts are systematically undercounted.** The count lives in
+  `localStorage`, and iOS clears script-writable storage after seven days
+  without a visit — precisely the gap between two parties. Private windows start
+  empty. A laptop passed around a room is several hosts wearing one identity.
+  Only the direction of this number over time means anything.
+- **`followed` misses clicks that never reached the server.** Throttled ones are
+  reported separately; a dropped connection is invisible.
+- **`share` is the weakest arm.** It needs someone to scan a QR out of a
+  forwarded image — the only surface whose hit does not start on a page of ours.
+- **`organic` is a catch-all** for every lost attribution: a PWA launched from
+  the home screen, a stripped query string, a retyped bare domain. Organic is
+  already nearly all traffic, so the loop's share of starts is a floor.
+
+What the table answers reliably is **trend** and **relative difference between
+surfaces**. Not absolute level.
+
+---
+
+## 7. What to do about what you see
+
+No hard thresholds, because there is no baseline yet and the first version's
+placement and wording dominate the numbers. A made-up percentage would get a
+working call to action deleted. Collect two weeks first. Shapes, not numbers:
+
+| Observation | Reading | Next |
+|---|---|---|
+| `Days with any activity` is 0 | **plumbing, not a result** — a real zero still bumps the liveness marker | check credentials, that `/r` deployed, that robots did not over-block |
+| one arm's `shown` is 0, others fine | that surface is not being counted at all | its surface string or `active` condition broke — it is not that nobody saw it |
+| arms differ sharply | placement and timing are being measured | make the low arm look like the high arm; do not delete it |
+| `buzz_cta` well below `join_submitted` | "a round resolved" is the wrong proxy for the right moment | that is the signal that changing the buzzer protocol for a real end-of-game CTA is worth it |
+| `Repeat hosts` share rising | someone actually came back | monetisation moves from next quarter to next month |
+| `Repeat hosts` stays low | **not** "nobody returns" | cross-check against GA4 returning users, which rides a cookie and is unaffected by the ITP eviction above |
+
+---
+
+## 8. Troubleshooting
+
+**`No counters found under "loop:stats:"`** — not empty data, a missing
+namespace. Either nothing has been recorded yet, or the key prefix in
+`lib/loop-stats.ts` changed without the script. Deliberately loud rather than a
+table of zeros.
+
+**Table empty but `Days with any activity` is not 0** — something is writing,
+but not loop events. If only `games` moves, people are playing and no surface is
+being shown; usually a component that stopped rendering.
+
+**Everything low, just after a deploy** — expected. Counters start at deploy and
+do not backfill, and the 60-day attribution window means today's clicks convert
+weeks from now. **The first few days carry almost no information.**
+
+**`N click(s) were dropped by the rate limiter`** — expected, not an attack. The
+limiter is keyed by IP and a party is a dozen phones behind one Wi-Fi address.
+It means every rate above is understated by that much. Only a persistently large
+figure justifies raising `LOOP_LIMIT` in `app/r/[surface]/route.ts`.
+
+---
+
+## 9. Why the script holds no metric list
+
+`scripts/loop-stats.mjs` runs `KEYS loop:stats:*` and parses what comes back
+rather than rebuilding keys from a hardcoded list. That list already exists in
+`lib/loop-stats.ts`, and a second copy would drift silently — the script would
+read keys nobody writes and print a confident table of zeros. Discovery also
+means a metric added later appears here without anyone editing the script.
+
+The only shared knowledge is the `loop:stats:` prefix, and changing that makes
+the script print "no counters found", which is loud rather than wrong.
+
+`KEYS` is the wrong tool on a large database. This namespace is a few hundred
+keys with a 30-day TTL and the command runs by hand.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "stats": "node scripts/loop-stats.mjs"
   },
   "dependencies": {
     "@radix-ui/react-label": "^2.1.8",

--- a/scripts/loop-stats.mjs
+++ b/scripts/loop-stats.mjs
@@ -29,12 +29,39 @@
  * objection does not apply.
  *
  * Usage:
- *   export UPSTASH_REDIS_REST_URL=... UPSTASH_REDIS_REST_TOKEN=...
  *   npm run stats            # last 7 complete days
  *   npm run stats -- 30      # last 30
+ *
+ * Credentials come from `.env.local` or `.env` (both gitignored), or from the
+ * environment if you would rather export them.
  */
 
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
 const PREFIX = "loop:stats:";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Same files Next reads, so there is one place to keep these.
+ *
+ * `process.loadEnvFile` is a Node built-in (20.12+) — no dotenv, which would be
+ * a dependency added purely to read a file the runtime already parses.
+ *
+ * **Order is inverted on purpose.** It does not overwrite a variable that is
+ * already set, so first writer wins; loading `.env.local` first is what gives
+ * it precedence over `.env`, matching Next. Anything exported in the shell was
+ * set before either call and still beats both.
+ */
+for (const file of [".env.local", ".env"]) {
+  try {
+    process.loadEnvFile(join(repoRoot, file));
+  } catch {
+    // Absent, or unreadable. Either is fine — the check below is the one that
+    // decides whether we actually have what we need.
+  }
+}
 
 const url = process.env.UPSTASH_REDIS_REST_URL;
 const token = process.env.UPSTASH_REDIS_REST_TOKEN;
@@ -42,6 +69,7 @@ const token = process.env.UPSTASH_REDIS_REST_TOKEN;
 if (!url || !token) {
   console.error(
     "Missing UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN.\n" +
+      "Looked in .env.local, .env, and the environment.\n\n" +
       "These are the production values — the local fallback in lib/kv.ts is an\n" +
       "in-process Map, so there is nothing to read without them. Copy them from\n" +
       "the Vercel project's environment variables."
@@ -55,16 +83,40 @@ if (!Number.isInteger(days) || days < 1 || days > 30) {
   process.exit(1);
 }
 
-/** One Upstash REST command. */
+/**
+ * One Upstash REST command.
+ *
+ * Failures are rewritten before they surface. The raw ones are an undici
+ * `TypeError: fetch failed` with a stack into Node internals, which says
+ * nothing about the two things actually likely to be wrong here — a typo'd URL
+ * or a token from the wrong project.
+ */
 async function redis(command) {
-  const res = await fetch(url, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(command),
-  });
+  let res;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(command),
+    });
+  } catch (cause) {
+    throw new Error(
+      `Could not reach Upstash at ${url}\n` +
+        `  ${cause instanceof Error ? cause.message : String(cause)}\n` +
+        "  Check UPSTASH_REDIS_REST_URL — it should be the full https:// REST\n" +
+        "  endpoint from the Vercel project, not the redis:// connection string."
+    );
+  }
+  if (res.status === 401 || res.status === 403) {
+    throw new Error(
+      "Upstash rejected the token.\n" +
+        "  UPSTASH_REDIS_REST_TOKEN does not match UPSTASH_REDIS_REST_URL —\n" +
+        "  usually a token copied from a different database."
+    );
+  }
   if (!res.ok) {
     throw new Error(`Upstash ${res.status}: ${await res.text()}`);
   }
@@ -89,7 +141,13 @@ function pct(numerator, denominator) {
   return `${((numerator / denominator) * 100).toFixed(1).padStart(5)}%`;
 }
 
-const keys = (await redis(["KEYS", `${PREFIX}*`])) ?? [];
+let keys;
+try {
+  keys = (await redis(["KEYS", `${PREFIX}*`])) ?? [];
+} catch (err) {
+  console.error(`\n${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+}
 if (keys.length === 0) {
   console.log(
     `No counters found under "${PREFIX}".\n\n` +

--- a/scripts/loop-stats.mjs
+++ b/scripts/loop-stats.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * Prints the viral-loop counters. `npm run stats`.
+ *
+ * The counters written by `/r/[surface]` and `/api/pulse` are useless until
+ * something reads them, and the thing that reads them cannot be a dashboard:
+ * four separate attempts to go and open GA4 did not happen over eight weeks,
+ * which makes "and then go look at it" a step with a measured completion rate
+ * of zero rather than a step with a cost. A command in this repo is a
+ * different proposition — it runs from the terminal that is already open, and
+ * a coding agent can run it unprompted at the start of a session, which is the
+ * actual delivery mechanism here.
+ *
+ * ## Keys are discovered, not reconstructed
+ *
+ * This script does not hold a copy of the metric list. It asks Redis for
+ * everything under `loop:stats:` and parses what comes back. Rebuilding the
+ * keys from a hardcoded list here would be a second definition of a format
+ * that already lives in `lib/loop-stats.ts`, and that class of drift fails
+ * silently — the script would read keys nobody writes and print a confident
+ * table of zeros. Discovery also means a metric added later shows up here
+ * without anyone remembering to update this file.
+ *
+ * The only shared knowledge is the `loop:stats:` prefix. If that ever changes
+ * this prints "no counters found", which is loud rather than wrong.
+ *
+ * `KEYS` is the wrong tool on a large database. This namespace is a few
+ * hundred keys with a 30-day TTL and the command runs by hand, so the usual
+ * objection does not apply.
+ *
+ * Usage:
+ *   export UPSTASH_REDIS_REST_URL=... UPSTASH_REDIS_REST_TOKEN=...
+ *   npm run stats            # last 7 complete days
+ *   npm run stats -- 30      # last 30
+ */
+
+const PREFIX = "loop:stats:";
+
+const url = process.env.UPSTASH_REDIS_REST_URL;
+const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+if (!url || !token) {
+  console.error(
+    "Missing UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN.\n" +
+      "These are the production values — the local fallback in lib/kv.ts is an\n" +
+      "in-process Map, so there is nothing to read without them. Copy them from\n" +
+      "the Vercel project's environment variables."
+  );
+  process.exit(1);
+}
+
+const days = Number.parseInt(process.argv[2] ?? "7", 10);
+if (!Number.isInteger(days) || days < 1 || days > 30) {
+  console.error("Day count must be 1-30 (counters are held 30 days).");
+  process.exit(1);
+}
+
+/** One Upstash REST command. */
+async function redis(command) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(command),
+  });
+  if (!res.ok) {
+    throw new Error(`Upstash ${res.status}: ${await res.text()}`);
+  }
+  const { result } = await res.json();
+  return result;
+}
+
+/** UTC, matching `dayBucket()` in lib/kv.ts. */
+function bucketsFor(count) {
+  const out = [];
+  const now = new Date();
+  for (let i = 0; i < count; i += 1) {
+    const d = new Date(now);
+    d.setUTCDate(d.getUTCDate() - i);
+    out.push(d.toISOString().slice(0, 10));
+  }
+  return out;
+}
+
+function pct(numerator, denominator) {
+  if (!denominator) return "     —";
+  return `${((numerator / denominator) * 100).toFixed(1).padStart(5)}%`;
+}
+
+const keys = (await redis(["KEYS", `${PREFIX}*`])) ?? [];
+if (keys.length === 0) {
+  console.log(
+    `No counters found under "${PREFIX}".\n\n` +
+      "Either nothing has been recorded yet, or the key prefix in\n" +
+      "lib/loop-stats.ts changed and this script was not updated."
+  );
+  process.exit(0);
+}
+
+const values = await redis(["MGET", ...keys]);
+const window = new Set(bucketsFor(days));
+
+/** metric -> total, and the set of days that recorded anything at all. */
+const totals = new Map();
+const liveDays = new Set();
+
+keys.forEach((key, i) => {
+  const rest = key.slice(PREFIX.length);
+  const firstColon = rest.indexOf(":");
+  if (firstColon === -1) return;
+  const day = rest.slice(0, firstColon);
+  const metric = rest.slice(firstColon + 1);
+  if (!window.has(day)) return;
+
+  const count = Number(values[i] ?? 0);
+  if (!Number.isFinite(count)) return;
+  if (metric === "live") {
+    if (count > 0) liveDays.add(day);
+    return;
+  }
+  totals.set(metric, (totals.get(metric) ?? 0) + count);
+});
+
+const get = (metric) => totals.get(metric) ?? 0;
+
+const surfaces = [
+  ...new Set(
+    [...totals.keys()]
+      .filter((m) => m.startsWith("impression:") || m.startsWith("click:"))
+      .map((m) => m.slice(m.indexOf(":") + 1))
+  ),
+].sort();
+
+const games = get("games");
+const repeatHost = get("repeat_host");
+const throttled = get("throttled");
+
+console.log(`\nGuessSong loop — last ${days} days (UTC)`);
+console.log(`Days with any activity: ${liveDays.size}/${days}\n`);
+
+if (liveDays.size === 0) {
+  console.log(
+    "No day in this window recorded anything. That is a plumbing problem,\n" +
+      "not a result — a real zero still bumps the liveness marker.\n"
+  );
+}
+
+console.log("Surface            shown    followed     rate");
+console.log("─".repeat(48));
+if (surfaces.length === 0) {
+  console.log("(nothing recorded)");
+} else {
+  for (const surface of surfaces) {
+    const shown = get(`impression:${surface}`);
+    const clicked = get(`click:${surface}`);
+    console.log(
+      `${surface.padEnd(18)}${String(shown).padStart(5)}` +
+        `${String(clicked).padStart(12)}   ${pct(clicked, shown)}`
+    );
+  }
+}
+
+console.log(`\nGames started       ${games}`);
+console.log(
+  `Repeat hosts        ${repeatHost}   ${pct(repeatHost, games)} of games`
+);
+
+const indices = [...totals.keys()]
+  .filter((m) => m.startsWith("host_index:"))
+  .map((m) => Number(m.slice("host_index:".length)))
+  .filter(Number.isFinite)
+  .sort((a, b) => a - b);
+
+if (indices.length > 0) {
+  console.log("\nGames by host's game number");
+  for (const n of indices) {
+    const count = get(`host_index:${n}`);
+    const bar = "█".repeat(Math.min(40, Math.round((count / games) * 40)));
+    console.log(`  ${String(n).padStart(2)}${n === 10 ? "+" : " "} ${String(count).padStart(5)}  ${bar}`);
+  }
+}
+
+if (throttled > 0) {
+  console.log(
+    `\n⚠  ${throttled} click(s) were dropped by the rate limiter and are NOT in\n` +
+      "   the numbers above, so every rate here is understated by that much.\n" +
+      "   A party is a dozen phones behind one IP, so this is expected rather\n" +
+      "   than hostile."
+  );
+}
+
+console.log(
+  "\nRead these as floors, not measurements:\n" +
+    "  · Repeat hosts are undercounted — iOS clears localStorage after 7 days\n" +
+    "    idle, which is exactly the gap between two parties.\n" +
+    "  · Followed counts miss anyone whose click never reached the server.\n" +
+    "  · A low number can mean the CTA does not work, or that we could not see\n" +
+    "    that it did. Only the direction over time is trustworthy.\n"
+);


### PR DESCRIPTION
1.3.0 shipped the loop counters with nothing reading them. The plan called for a weekly cron + webhook digest; that was dropped on the maintainer's call, and the call was right.

A webhook adds a deploy surface, three environment variables, and another feed to read. The variable that actually predicts whether a number gets looked at is not push-versus-pull — it is whether reading it requires leaving the editor. A command in the repo does not, and an agent can run it unprompted, which moves delivery off a human habit with a 0-for-4 record.

## What's here

`npm run stats` → shown / followed / rate per surface, games started, repeat hosts, distribution by host game number, dropped-click count.

```
GuessSong loop — last 7 days (UTC)
Days with any activity: 2/7

Surface            shown    followed     rate
────────────────────────────────────────────────
buzz_cta            136          14    10.3%
buzz_footer         120           4     3.3%
game_over            22           9    40.9%
join_submitted       31           7    22.6%
share                14           1     7.1%

Games started       33
Repeat hosts        4    12.1% of games
```

(Numbers above are from a fake Upstash used to verify parsing — multi-day aggregation, out-of-window exclusion, and the liveness count are all checked.)

## Two decisions worth reviewing

**Keys are discovered, not reconstructed.** The script runs `KEYS loop:stats:*` and parses what comes back rather than rebuilding keys from a hardcoded metric list. A second copy of that list would drift from `lib/loop-stats.ts` silently — the script would read keys nobody writes and print a confident table of zeros — and discovery means a metric added later shows up without anyone editing this file. The only shared knowledge is the `loop:stats:` prefix, and if that changes the script prints "no counters found", which is loud rather than wrong. `KEYS` is the wrong tool on a large database; this namespace is a few hundred keys with a 30-day TTL and the command runs by hand.

**The output leads with its own caveats.** Every number here is a floor: repeat hosts are undercounted because iOS clears `localStorage` after seven days idle, which is exactly the gap between two parties; followed counts miss any click that never reached the server. The failure mode this guards against is reading a low number as "the CTA does not work" rather than "we could not see that it did".

## CLAUDE.md

Two additions:

- A line telling an agent to run `npm run stats` at the start of any session about growth, the loop, or what to build next, and to lead with what it says. **This line is the delivery mechanism** — if it is deleted, this reverts to the same defect every release before it had.
- A section on why the loop is counted twice (KV authoritative for decisions, GA4 for cohorting) and the three things in that path that are easy to undo by accident: the link must stay a real navigation, `/r` must redirect on every branch, and the counters need their liveness marker and 30-day TTL.

## Verification

- `npm test` — 351 passing, unchanged
- Script verified against a fake Upstash: aggregation, out-of-window exclusion, missing-env and bad-argument guards
- No version bump; nothing user-facing, so `lib/changelog.ts` is untouched and `LATEST_VERSION` stays pinned at 1.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Scope grew: `docs/`

The PR started as the stats script. Writing the guide for it surfaced that the natural home was gitignored, so it now also adds a tracked `docs/` directory (933 lines, 5 files).

`docs/README.md` states the boundary explicitly, because the way a docs directory dies is by becoming a fifth copy of what README, CLAUDE.md, CHANGELOG.md and the code comments already say. Only what fits none of those goes in.

- **architecture.md** — the system in diagrams: the Vercel/Cloudflare split and why it is not arbitrary, one game end to end, the four-layer shape shared by all three caches, the buzzer message flow, where state actually lives
- **viral-loop.md** — the five surfaces, why the surface name is declared once, why the link is a real navigation, and how to run and read `npm run stats`. Over a third of it is "every figure here is a floor"
- **operations.md** — the Worker deploys manually and nothing in CI touches it; there is no CI; the two traps in reading the cache-hit logs; symptom-by-symptom troubleshooting; the release checklist
- **decisions.md** — each call with its rejected alternative and what would justify reopening. These were argued out in design docs that live outside the repo, so a fresh clone had the constraints without the reasoning

`dev_docs/` stays gitignored — its eight files are planning artifacts for shipped features, and migrating them would fill a tracked directory with stale content on day one.

Verified: 21 distinct code paths referenced across `docs/` all resolve to real files, and every internal link and anchor resolves.
