### PR TITLE
v1.3.1 perf: cut Vercel Active CPU by making the image routes static and stopping playlist retry storms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,66 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-08-10
+
+Vercel's Fluid Compute bills Active CPU, and this project was at 79.9% of the
+Hobby month's 4 hours. Two things were spending it, and neither was the work the
+app exists to do. A two-minute sample of production logs put **42 of 54 billed
+invocations (78%) on `POST /api/playlist` returning 404** — one host, one dead
+link, tapped over and over. The other 10 were image routes that were supposed to
+be built once and were being rendered per request instead.
+
+Neither is visible on the page: the images come out byte-identical, and the
+retry loop looked like a working error message. Both are the kind of cost that
+only shows up on the bill.
+
+### Fixed
+
+- **The three generated-image routes no longer run per request.** `app/icon.tsx`,
+  `app/opengraph-image.tsx` and `app/icons/[size]/route.tsx` each carried
+  `export const runtime = "edge"`, which opts a route out of static generation —
+  Next says so in a build warning that is easy to read past, and the route table
+  showed them as `ƒ` while the logs showed `edge-function` / `cache: MISS`. They
+  were satori rasterisations, the most CPU-expensive thing here, and the OG image
+  is fetched once per share. Deleting three lines makes them `○`/`●`; the
+  prerendered bytes are identical to what production was serving (685 / 125706 /
+  3460 / 10094 / 5583). `app/icons/[size]` also gains `generateStaticParams` and
+  `dynamicParams = false`, so the three sizes prerender and any other segment
+  404s without an invocation at all.
+- **A refused playlist is no longer re-requested.** A 404 comes back from
+  `lib/playlist-cache.ts`'s negative cache in about 100ms — faster than the Start
+  button re-enables — so a host mashing Start produced bursts of fourteen
+  identical requests 150–300ms apart, each a billed invocation replaying a
+  decision already made. `isDeterministicPlaylistFailure` (`lib/error-messages.ts`)
+  names the codes where resubmitting the same URL provably cannot answer
+  differently; `app/page.tsx` re-shows the error instead of sending. Measured:
+  6 taps → 1 request, and editing the link rearms it.
+- **Mixed Playlist Mode gets the same guard, keyed on the whole roster**
+  (`mixedRosterKey`, `lib/mixed-playlist.ts`), where a mash cost one request per
+  contributor. Measured: 6 taps on a two-contributor roster → 2 requests, and
+  swapping a contributor rearms it. `mixed_playlists_failed` is an aggregate and
+  is *not* treated as final on its own — `shouldRememberAllRejections` requires
+  every individual rejection to be deterministic, so one contributor's transient
+  500 cannot write off the whole party.
+
+### Changed
+
+- `/icons/<anything-else>` now returns Next's 404 page rather than a plain-text
+  "Not found" body. Same status, no invocation, and nothing reads that body —
+  `public/manifest.json` only ever requests the three real sizes.
+
+### Known gaps
+
+- Throttling codes are deliberately excluded from the deterministic set, so a
+  host throttled by Spotify's shared quota can still retry. `tests/error-messages.test.ts`
+  pins that in both directions, including a complement test that defaults any
+  newly added `AppErrorCode` to retryable.
+- `app/j/[code]` and `app/buzz/[code]` are still `ƒ` — pure client components
+  paying an SSR invocation per QR scan. They did not appear once in the sampled
+  logs, and making them static risks rendering the wrong room code before
+  hydration, so they were left alone.
+- The 78% figure is one two-minute sample, not a 30-day average.
+
 ## [1.3.0] - 2026-08-09
 
 Buzzer Mode has been putting a phone in every hand for weeks, and none of those

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,11 @@ The host is the judge — there is no automated answer checking. Correct song gu
 
 ### SEO / Metadata
 
-Production domain is `https://www.guessong.app` (fallback in `app/layout.tsx`, `app/sitemap.ts`, `app/robots.ts`). `app/layout.tsx` also injects GA4 when `NEXT_PUBLIC_GA_MEASUREMENT_ID` is set. `app/opengraph-image.tsx` and `app/icon.tsx` generate images at build time.
+Production domain is `https://www.guessong.app` (fallback in `app/layout.tsx`, `app/sitemap.ts`, `app/robots.ts`). `app/layout.tsx` also injects GA4 when `NEXT_PUBLIC_GA_MEASUREMENT_ID` is set.
+
+**The five generated images must stay build-time, which means none of them may declare `runtime = "edge"`.** `app/opengraph-image.tsx`, `app/icon.tsx` and the three sizes of `app/icons/[size]` are rasterised by satori, the most CPU-expensive thing the app does. All three carried `runtime = "edge"` from the day they were written until this was found, and edge *disables static generation for the route* — Next says so in a build warning that is easy to read past ("Using edge runtime on a page currently disables static generation for that page"). They were `ƒ` in the route table, ran per request as `edge-function`, and showed up in production logs as `cache: MISS`. The fix was deleting three lines; the output bytes are identical either way, so nothing about this is visible on the page and nothing but the route table will tell you it regressed. `app/icons/[size]` additionally needs its `generateStaticParams` + `dynamicParams = false` to stay — that pair is what prerenders the three sizes and 404s everything else without an invocation.
+
+After touching any of them, check `npm run build`'s route table: `/icon` and `/opengraph-image` must be `○`, `/icons/[size]` must be `●` with all three sizes listed under it. An `ƒ` there is the regression.
 
 ## Environment Variables
 
@@ -126,9 +130,12 @@ A release updates **both** of these, and they are not the same document:
 
 Clients render with `errorMessage` / `describeError` and get the locale from `useErrorLocale()` (device language, resolved in an effect so the server-rendered join pages don't hydrate against a different string). `apiError(body, fallbackCode)` turns a failed response into an `AppError`; the fallback should name what the caller was doing, not `unknown`.
 
-Two things `tests/error-messages.test.ts` will catch, both easy to do by accident:
+Three things `tests/error-messages.test.ts` will catch, all easy to do by accident:
 - **A placeholder only exists if its callers pass params.** `{seconds}` with no `params` renders literally at the player, so the test pins the exact set of codes allowed to have one.
 - **No throttling message may blame the host's playlist**, in *either* language. That is the `spotify_*` hazard documented above, and a translation is just as capable of reintroducing it.
+- **No throttling code may join `isDeterministicPlaylistFailure`.** That predicate names the codes where resubmitting the identical URL provably cannot answer differently — the URL is malformed, or `lib/playlist-cache.ts` is replaying a 404 it will keep replaying for `NOT_FOUND_TTL_SECONDS`. `app/page.tsx` uses it to re-show the error the host already has instead of spending a request to be told it again, keyed on the exact URL string so editing the link needs no explicit reset. This is the same `spotify_*` hazard one step further on: a spent quota clears by itself, so listing a throttling code there would strand a host whose playlist was always fine behind a button that has quietly stopped asking. `playlist_load_failed`, `unknown` and `server_error` stay out for the mirror-image reason — "we don't know" must not harden into "don't ask".
+
+  Why it exists: a refused playlist returns from the negative cache in ~100ms, which is faster than the Start button re-enables, so a host mashing Start on a private link generated bursts of fourteen identical `POST /api/playlist` calls 150–300ms apart. In a two-minute production log sample those 404s were **78% of all billed function invocations** — the single largest consumer of the Vercel Active-CPU budget, well ahead of anything doing real work. Nothing upstream was being hit; the cost was the invocations themselves, which is exactly the class of waste a per-IP rate limit does not catch (the bursts sat comfortably inside the 30-per-10-minute allowance).
 
 The buzzer Worker keeps its own wire codes (`BuzzerErrorCode` in `lib/buzzer-protocol.ts`, which is shared verbatim with the Worker and must stay dependency-free). `BUZZER_ERROR_CODES` maps them onto app codes — that mapping is the only thing connecting the two, so a new wire code needs an entry there.
 

--- a/README.md
+++ b/README.md
@@ -179,14 +179,14 @@ app/
   j/[code]/                  Mixed Playlist Mode join page
   buzz/[code]/               Buzzer Mode player page (holds the live WebSocket)
   share/                     Web Share Target handler + /share/unsupported explainer
-  icons/[size]/              PWA icons generated at the edge
+  icons/[size]/              PWA icons, prerendered at build (never per request)
   api/                       See the table below
   icon.tsx, opengraph-image.tsx, robots.ts, sitemap.ts
 components/                  Buzzer button + host panel, room panel, mixed collector,
                              install banner, changelog modal, ui/ (shadcn primitives)
 lib/                         All shared logic — see "Architecture" below
 worker/                      Cloudflare Worker + BuzzerRoom Durable Object
-tests/                       17 Vitest files, 273 cases
+tests/                       22 Vitest files, 366 cases
 types/                       Track, room, and preview wire types
 ```
 

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,6 +1,10 @@
 import { ImageResponse } from "next/og";
 
-export const runtime = "edge";
+// Deliberately NOT `runtime = "edge"`. Edge disables static generation for the
+// route ("Using edge runtime on a page currently disables static generation for
+// that page"), which turned this into a per-request satori rasterisation billed
+// as Active CPU. On the Node runtime it is rendered once at build time and
+// served as a static asset, which is what the favicon always wanted to be.
 export const size = { width: 32, height: 32 };
 export const contentType = "image/png";
 

--- a/app/icons/[size]/route.tsx
+++ b/app/icons/[size]/route.tsx
@@ -1,12 +1,24 @@
 import { ImageResponse } from "next/og";
 
-export const runtime = "edge";
-
 /**
  * Serves the PWA manifest icons (/icons/192, /icons/512, /icons/maskable)
  * as generated PNGs, matching the app/icon.tsx favicon design so no binary
  * assets need to live in the repo.
+ *
+ * There are exactly three of these and they never change, so they are enumerated
+ * below and rendered at build time. Previously this carried `runtime = "edge"`,
+ * which opts a route out of static generation entirely — every icon fetch ran a
+ * satori rasterisation on demand, billed as Active CPU, for three files whose
+ * bytes are fixed at build. `dynamicParams = false` makes any other segment a
+ * 404 without invoking a function at all, which is what the hand-written size
+ * check here used to do one invocation too late.
  */
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return [{ size: "192" }, { size: "512" }, { size: "maskable" }];
+}
+
 export async function GET(
   _req: Request,
   { params }: { params: Promise<{ size: string }> }
@@ -15,9 +27,6 @@ export async function GET(
 
   const px = size === "192" ? 192 : 512;
   const maskable = size === "maskable";
-  if (size !== "192" && size !== "512" && !maskable) {
-    return new Response("Not found", { status: 404 });
-  }
 
   // Maskable icons must keep content inside the central 80% safe zone.
   const fontSize = maskable ? px * 0.5 : px * 0.68;

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,6 +1,9 @@
 import { ImageResponse } from "next/og";
 
-export const runtime = "edge";
+// See app/icon.tsx: `runtime = "edge"` opts the route out of static generation,
+// so this 1200x630 render ran on demand. It is the single most expensive render
+// in the app (~125KB PNG) and it is fetched by link crawlers, i.e. once per
+// share — the hottest thing in a viral loop. Built once, now.
 export const alt = "GuessSong — Spotify Party Game";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,8 @@ import {
   apiError,
   describeError,
   errorMessage,
+  shouldRememberAllRejections,
+  shouldRememberRejection,
 } from "@/lib/error-messages";
 import { useErrorLocale } from "@/lib/use-error-locale";
 import { buildGamePayload, GAME_STORAGE_KEY } from "@/lib/game-session";
@@ -27,7 +29,7 @@ import {
   MixedPlaylistCollector,
   type MixedContribution,
 } from "@/components/mixed-playlist-collector";
-import { poolContributions } from "@/lib/mixed-playlist";
+import { mixedRosterKey, poolContributions } from "@/lib/mixed-playlist";
 
 const CLIP_DURATIONS = [5, 10, 15, 20, 30];
 const SONG_COUNTS: (number | "all")[] = [10, 20, 30, 50, "all"];
@@ -171,6 +173,23 @@ export default function SetupPage() {
   const [mounted, setMounted] = useState(false);
   const locale = useErrorLocale();
   const firstInputRef = useRef<HTMLInputElement>(null);
+
+  /**
+   * The last submission that failed in a way the submission itself determines,
+   * and the sentence the host was shown for it.
+   *
+   * Start is already disabled while a load is in flight, but a refused playlist
+   * comes back from the negative cache in about 100ms, so the button re-enables
+   * between mashes and every extra tap is another billed invocation that can
+   * only replay the same refusal. Keyed on what was submitted — the URL for a
+   * single playlist, the whole roster for a mix — so changing it needs no
+   * explicit reset: the key simply stops matching.
+   *
+   * One ref rather than one per mode: the modes share a Start button, and a
+   * host who switches mode has changed the question, so losing the other
+   * mode's memo costs at most one request.
+   */
+  const lastRejectedRef = useRef<{ key: string; message: string } | null>(null);
 
   // What the one room has to do, given the modes picked above. Pass-the-phone
   // with the buzzer off needs no room at all, and never opens one.
@@ -327,6 +346,16 @@ export default function SetupPage() {
       setError(errorMessage("players_required", locale));
       return;
     }
+    // Same link, same refusal. Re-show it rather than spending a request to be
+    // told the identical thing — see `lastRejectedRef`. Deliberately silent
+    // about the shortcut: from the host's side this is the error they are
+    // already looking at, and the fix is still to change the link.
+    const submissionKey = `own:${playlistUrl}`;
+    const rejected = lastRejectedRef.current;
+    if (rejected && rejected.key === submissionKey) {
+      setError(rejected.message);
+      return;
+    }
     setLoading(true);
     trackEvent("playlist_submitted", { playlist_source: "own" });
     try {
@@ -374,7 +403,14 @@ export default function SetupPage() {
       });
       router.push("/game");
     } catch (e: unknown) {
-      setError(describeError(e, locale, "playlist_load_failed"));
+      const message = describeError(e, locale, "playlist_load_failed");
+      // Only failures the URL itself determines are remembered. A throttled or
+      // unknown one has to stay retryable — the host's link may be perfect and
+      // the next attempt may well be the one that works.
+      lastRejectedRef.current = shouldRememberRejection(e)
+        ? { key: submissionKey, message }
+        : null;
+      setError(message);
     } finally {
       setLoading(false);
     }
@@ -390,6 +426,24 @@ export default function SetupPage() {
       );
       return;
     }
+    // Same roster, same refusal — the single-playlist reasoning one flow over,
+    // except a mash here re-fires one request per contributor rather than one.
+    const submissionKey = `mixed:${mixedRosterKey(
+      mixedContributions.map((c) => c.playlistUrl)
+    )}`;
+    const rejected = lastRejectedRef.current;
+    if (rejected && rejected.key === submissionKey) {
+      setError(rejected.message);
+      return;
+    }
+    /**
+     * Whether every contributor that failed did so for a reason the link
+     * itself decides. Computed inside the try, where the individual reasons
+     * are still in scope, and read in the catch, where only the aggregate
+     * `mixed_playlists_failed` survives — and that code is not evidence of
+     * anything permanent on its own. See `shouldRememberAllRejections`.
+     */
+    let allFailuresFinal = false;
     setLoading(true);
     trackEvent("playlist_submitted", { playlist_source: "mixed" });
     try {
@@ -435,6 +489,11 @@ export default function SetupPage() {
         .map((r, i) => (r.status === "rejected" ? mixedContributions[i].name : null))
         .filter((n): n is string => n !== null);
       if (failedNames.length > 0) {
+        allFailuresFinal = shouldRememberAllRejections(
+          results
+            .filter((r): r is PromiseRejectedResult => r.status === "rejected")
+            .map((r) => r.reason)
+        );
         throw new AppError("mixed_playlists_failed", { names: failedNames.join(", ") });
       }
 
@@ -480,7 +539,12 @@ export default function SetupPage() {
       });
       router.push("/game");
     } catch (e: unknown) {
-      setError(describeError(e, locale, "playlist_load_failed"));
+      const message = describeError(e, locale, "playlist_load_failed");
+      // `allFailuresFinal` stays false for the throttled rethrow above and for
+      // anything that failed before the per-contributor loop, so both remain
+      // retryable — a shared quota clears on its own.
+      lastRejectedRef.current = allFailuresFinal ? { key: submissionKey, message } : null;
+      setError(message);
     } finally {
       setLoading(false);
     }

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -120,6 +120,43 @@ investigation went hunting for songs that were never missing.
 Note that iTunes signals throttling with **403**, not 429, and Deezer returns
 its quota error in the body of a **200**.
 
+### "Vercel says the CPU budget is nearly spent"
+
+Fluid Compute bills **Active CPU** — time your code actually runs. Waiting on
+Spotify, iTunes or Upstash is free, so the bill is not a story about slow
+upstreams. It is a story about how many function invocations happen at all, and
+how expensive each one is. Hobby is 4 CPU-hours a month; going over does not
+cost money, it suspends the project until you deal with it.
+
+Do not reason about this from the code. Get the distribution first:
+
+```bash
+vercel logs <production-deployment-url> --json > /tmp/logs.jsonl
+```
+
+Then count by `source` and `requestPath`. Only `source: "serverless"` and
+`source: "edge-function"` are billed; `source: "static"` is served from the CDN
+and costs nothing. That one command is what turned a guess into an answer here —
+the two things that had been quietly dominating the bill were:
+
+- **Routes that should have been static and were not.** A page or route handler
+  carrying `export const runtime = "edge"` is opted out of static generation, so
+  it runs per request. Next prints a warning at build time and it is easy to
+  read past. The reliable check is the route table from `npm run build`: `○` and
+  `●` cost nothing, `ƒ` runs every time. Three image routes were `ƒ` for months
+  and nothing on the page looked wrong, because the bytes are identical either
+  way.
+- **A client retrying something that can never succeed.** A cached 404 answers
+  in ~100ms, which is faster than a button re-enables, so a host tapping Start on
+  a dead playlist generated bursts of fourteen billed invocations that all
+  replayed the same cached refusal. Per-IP rate limiting does not catch this —
+  the bursts sit well inside the allowance. See CLAUDE.md's
+  `isDeterministicPlaylistFailure` note for why only some failures may be
+  written off this way.
+
+The general shape: an expensive-looking route with a good cache is usually fine,
+and a cheap route invoked in a loop is usually the problem.
+
 ### "Spotify says 429"
 
 The cooldown in `lib/playlist-cache.ts` parks all *uncached* loads for the

--- a/lib/changelog.ts
+++ b/lib/changelog.ts
@@ -49,6 +49,28 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "1.3.1",
+    date: "2026-08-10",
+    headline:
+      "When a playlist will not open, the game says so straight away instead of making you wait for the same answer twice.",
+    headlineZh:
+      "遇到打不開的歌單，現在會馬上告訴你，不用再等一次一樣的答案。",
+    changes: [
+      {
+        kind: "better",
+        text: "Tapping Start again on a playlist we cannot open now answers instantly. Before, every tap went off and came back with the same message.",
+        textZh:
+          "歌單打不開時再按一次「開始遊戲」，會立刻顯示原因。以前每按一次都要重新問一遍，再回來給你同樣的訊息。",
+      },
+      {
+        kind: "better",
+        text: "The app icons and the preview image on shared links are now made ahead of time, so pages and shared links open faster.",
+        textZh:
+          "App 圖示和分享連結的預覽圖改成事先做好，開啟頁面或點開分享連結都更快。",
+      },
+    ],
+  },
+  {
     version: "1.3.0",
     date: "2026-08-09",
     headline:

--- a/lib/error-messages.ts
+++ b/lib/error-messages.ts
@@ -398,6 +398,53 @@ export function errorMessage(
 }
 
 /**
+ * Codes that describe the *link*, not the moment.
+ *
+ * Resubmitting a byte-identical URL after one of these cannot produce a
+ * different answer: `lib/playlist-cache.ts` caches the 404 for
+ * NOT_FOUND_TTL_SECONDS (10 minutes), so for that whole window the server is
+ * replaying a decision it has already made, and the ones that never reach
+ * Spotify at all are pure string checks on the URL.
+ *
+ * This exists because of what the production logs actually show. A host who
+ * pastes a private playlist gets a 404 back in ~100ms — fast enough that the
+ * Start button re-enables between mashes — and the observed result is bursts of
+ * fourteen identical `POST /api/playlist` calls 150-300ms apart. Every one is a
+ * billed function invocation spent re-reading the same cached refusal, and they
+ * were 78% of all billed invocations in a two-minute sample.
+ *
+ * ## What must never be listed here
+ *
+ * Only failures that are a fact about the URL. Every throttling code is
+ * excluded, and must stay excluded: `spotify_rate_limited`, `spotify_cooldown`
+ * and `spotify_busy` are facts about a shared quota that clears on its own, so
+ * suppressing the retry would strand a host whose playlist was always fine —
+ * the same class of mistake as the message that used to tell throttled hosts to
+ * check their URL was public. `playlist_load_failed`, `unknown` and
+ * `server_error` are excluded for the opposite reason: we do not know what went
+ * wrong, and "we don't know" must never harden into "don't bother asking".
+ *
+ * `tests/error-messages.test.ts` pins both halves of that.
+ */
+const DETERMINISTIC_PLAYLIST_CODES = new Set<AppErrorCode>([
+  "missing_playlist_url",
+  "playlist_url_required",
+  "invalid_playlist_url",
+  "playlist_not_found",
+  "playlist_editorial",
+  "playlist_empty",
+]);
+
+/**
+ * Whether resubmitting the same playlist URL is guaranteed to fail the same
+ * way. Callers use it to re-show the error they already have instead of
+ * spending a request to be told it again — see the set above.
+ */
+export function isDeterministicPlaylistFailure(code: unknown): boolean {
+  return isAppErrorCode(code) && DETERMINISTIC_PLAYLIST_CODES.has(code);
+}
+
+/**
  * An error that already knows which message it is. Thrown by the client-side
  * helpers (`lib/room-client.ts`, `lib/buzzer-client.ts`) and by every `fetch`
  * wrapper, so a `catch` block can localise without re-deriving what went wrong
@@ -464,4 +511,37 @@ export function describeError(
     });
   }
   return errorMessage(fallback, locale);
+}
+
+/**
+ * Whether a failed playlist submit should be remembered, so that resubmitting
+ * the identical URL re-shows the error instead of spending another request.
+ *
+ * Lives here rather than at the call site for the reason `roomJobs()` does: the
+ * suite only reaches `lib/`, and this is the half worth protecting. It is two
+ * conditions, and dropping either one is a bug with no symptom in development —
+ * lose the `AppError` check and a dropped connection (a `TypeError`, no `code`
+ * at all) starts being remembered as though the link were bad, stranding a host
+ * behind a button that has stopped asking; lose the code check and every
+ * failure is remembered, throttling included.
+ */
+export function shouldRememberRejection(err: unknown): boolean {
+  return err instanceof AppError && isDeterministicPlaylistFailure(err.code);
+}
+
+/**
+ * The same question for a batch: may this whole submission be written off?
+ *
+ * Mixed Playlist Mode loads every contributor's playlist at once and reports
+ * them as one `mixed_playlists_failed`, which is emphatically NOT a
+ * deterministic code — it aggregates whatever went wrong, and a single 500 or
+ * dropped socket lands in it alongside genuinely private links. Reading the
+ * aggregate as final would strand a whole party on one contributor's transient
+ * blip, so the decision has to be made from the individual reasons instead.
+ *
+ * Requires at least one reason, because `[].every()` is `true` and "nothing
+ * failed" must never be read as "everything failed permanently".
+ */
+export function shouldRememberAllRejections(reasons: unknown[]): boolean {
+  return reasons.length > 0 && reasons.every(shouldRememberRejection);
 }

--- a/lib/mixed-playlist.ts
+++ b/lib/mixed-playlist.ts
@@ -18,6 +18,23 @@ export interface PooledTrack extends Track {
 }
 
 /**
+ * A stable identity for one roster of contributor playlists.
+ *
+ * The single-playlist start remembers a doomed submission by its URL string;
+ * mixed mode has no single URL, so it remembers the whole roster. Sorted, so
+ * that dragging the same people into a different order is recognised as the
+ * same question — reordering cannot change which playlists are unreadable.
+ * Removing or fixing one contributor does change it, which is exactly when
+ * asking again is worth a request.
+ *
+ * `JSON.stringify` rather than `join`, so a URL containing the delimiter
+ * cannot make two different rosters collide into one key.
+ */
+export function mixedRosterKey(playlistUrls: string[]): string {
+  return JSON.stringify([...playlistUrls].sort());
+}
+
+/**
  * Normalize a track's name + primary artist into a cross-platform dedupe
  * key. Strips remaster/live/feat. suffixes and punctuation/casing noise so
  * the same song contributed from different playlists (or platforms, once

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guesssong",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/tests/error-messages.test.ts
+++ b/tests/error-messages.test.ts
@@ -8,6 +8,9 @@ import {
   detectErrorLocale,
   errorMessage,
   isAppErrorCode,
+  isDeterministicPlaylistFailure,
+  shouldRememberAllRejections,
+  shouldRememberRejection,
   type AppErrorCode,
   type ErrorLocale,
 } from "@/lib/error-messages";
@@ -86,6 +89,129 @@ describe("the message table", () => {
     }
   });
 });
+
+describe("isDeterministicPlaylistFailure", () => {
+  it("suppresses a retry only for failures the URL itself decides", () => {
+    // The whole set, not a sample. A member dropped from it silently restores
+    // the retry storm this exists to stop, and nothing else would catch that.
+    for (const code of [
+      "missing_playlist_url",
+      "playlist_url_required",
+      "invalid_playlist_url",
+      "playlist_not_found",
+      "playlist_editorial",
+      "playlist_empty",
+    ] as const) {
+      expect(isDeterministicPlaylistFailure(code), code).toBe(true);
+    }
+  });
+
+  it("holds every other code retryable", () => {
+    // The complement, derived rather than listed: a code added to the union
+    // later defaults to retryable, and if someone makes it deterministic they
+    // have to come here and say so deliberately.
+    const deterministic = new Set([
+      "missing_playlist_url",
+      "playlist_url_required",
+      "invalid_playlist_url",
+      "playlist_not_found",
+      "playlist_editorial",
+      "playlist_empty",
+    ]);
+    for (const code of CODES) {
+      if (deterministic.has(code)) continue;
+      expect(isDeterministicPlaylistFailure(code), code).toBe(false);
+    }
+  });
+
+  it("never suppresses a retry after throttling", () => {
+    // The counterpart of "never blames the host's playlist" above, and the same
+    // hazard one step later: a spent quota clears by itself, so a host whose
+    // link was always fine has to be able to press Start again and succeed.
+    // Listing any of these as deterministic would strand them on a dead button.
+    for (const code of [
+      "spotify_rate_limited",
+      "spotify_cooldown",
+      "spotify_busy",
+      "rate_limited",
+      "rate_limited_playlist",
+    ] as const) {
+      expect(isDeterministicPlaylistFailure(code), code).toBe(false);
+    }
+  });
+
+  it("never suppresses a retry after a failure of unknown cause", () => {
+    // "We don't know what happened" must not harden into "don't bother asking".
+    for (const code of ["playlist_load_failed", "unknown", "server_error"] as const) {
+      expect(isDeterministicPlaylistFailure(code), code).toBe(false);
+    }
+  });
+
+  it("says no to anything that isn't a code at all", () => {
+    for (const value of [undefined, null, "", "not_a_code", 7]) {
+      expect(isDeterministicPlaylistFailure(value)).toBe(false);
+    }
+  });
+});
+
+describe("shouldRememberRejection", () => {
+  it("remembers a playlist that the link itself dooms", () => {
+    expect(shouldRememberRejection(new AppError("playlist_not_found"))).toBe(true);
+    expect(shouldRememberRejection(new AppError("playlist_editorial"))).toBe(true);
+  });
+
+  it("forgets a throttling refusal, so the host can try again", () => {
+    expect(shouldRememberRejection(new AppError("spotify_rate_limited"))).toBe(false);
+    expect(shouldRememberRejection(new AppError("spotify_cooldown"))).toBe(false);
+    expect(shouldRememberRejection(new AppError("rate_limited_playlist"))).toBe(false);
+  });
+
+  it("forgets anything that isn't an AppError", () => {
+    // The case with no symptom in development: a dropped connection throws a
+    // TypeError with no `code`, and remembering it would leave the host tapping
+    // a button that had quietly stopped sending anything.
+    expect(shouldRememberRejection(new TypeError("Failed to fetch"))).toBe(false);
+    expect(shouldRememberRejection(new Error("boom"))).toBe(false);
+    expect(shouldRememberRejection(undefined)).toBe(false);
+    expect(shouldRememberRejection({ code: "playlist_not_found" })).toBe(false);
+  });
+});
+
+describe("shouldRememberAllRejections", () => {
+  it("writes off a roster only when every contributor is finally doomed", () => {
+    expect(
+      shouldRememberAllRejections([
+        new AppError("playlist_not_found"),
+        new AppError("playlist_editorial"),
+      ])
+    ).toBe(true);
+  });
+
+  it("keeps the whole roster retryable if even one failure was transient", () => {
+    // The reason the aggregate code cannot be trusted: four private links and
+    // one dropped socket still reads as `mixed_playlists_failed`, and writing
+    // that off would strand the party on the one contributor who was fine.
+    expect(
+      shouldRememberAllRejections([
+        new AppError("playlist_not_found"),
+        new TypeError("Failed to fetch"),
+      ])
+    ).toBe(false);
+    expect(
+      shouldRememberAllRejections([
+        new AppError("playlist_not_found"),
+        new AppError("spotify_rate_limited"),
+      ])
+    ).toBe(false);
+  });
+
+  it("treats no rejections as nothing to write off", () => {
+    // `[].every()` is true, so without the length guard a clean run would
+    // arm the memo and block the next start outright.
+    expect(shouldRememberAllRejections([])).toBe(false);
+  });
+});
+
 
 describe("detectErrorLocale", () => {
   it("reads Chinese from any of its tags", () => {

--- a/tests/mixed-playlist.test.ts
+++ b/tests/mixed-playlist.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { fingerprint, poolContributions, type PlaylistContribution } from "@/lib/mixed-playlist";
+import {
+  fingerprint,
+  mixedRosterKey,
+  poolContributions,
+  type PlaylistContribution,
+} from "@/lib/mixed-playlist";
 import type { Track } from "@/types";
 
 function makeTrack(overrides: Partial<Track> = {}): Track {
@@ -95,5 +100,34 @@ describe("poolContributions", () => {
 
   it("returns an empty pool for no contributions", () => {
     expect(poolContributions([], 8)).toEqual([]);
+  });
+});
+
+describe("mixedRosterKey", () => {
+  it("reads a reordered roster as the same question", () => {
+    // Order cannot change which playlists are unreadable, so reordering must
+    // not buy another round of requests.
+    expect(mixedRosterKey(["b", "a", "c"])).toBe(mixedRosterKey(["a", "b", "c"]));
+  });
+
+  it("changes when a contributor is added, removed, or swapped", () => {
+    const roster = mixedRosterKey(["a", "b"]);
+    expect(mixedRosterKey(["a"])).not.toBe(roster);
+    expect(mixedRosterKey(["a", "b", "c"])).not.toBe(roster);
+    expect(mixedRosterKey(["a", "z"])).not.toBe(roster);
+  });
+
+  it("does not collide when a URL contains the delimiter", () => {
+    // The reason this is JSON and not a join: these two rosters are different
+    // and a naive `join(",")` would render both as the same string.
+    expect(mixedRosterKey(["a,b"])).not.toBe(mixedRosterKey(["a", "b"]));
+  });
+
+  it("leaves the caller's array alone", () => {
+    // It sorts, and sorting in place would quietly reorder the contributor
+    // list the component is rendering from.
+    const urls = ["c", "a", "b"];
+    mixedRosterKey(urls);
+    expect(urls).toEqual(["c", "a", "b"]);
   });
 });


### PR DESCRIPTION
## Summary

The project was at **79.9% of the Hobby month's 4 CPU-hours** (3h13m). Fluid Compute bills Active CPU, so I/O waits are free and the bill is a story about how many function invocations happen at all. A two-minute sample of production logs (`vercel logs --json`, grouped by `source` and `requestPath`) put **96% of billed invocations on two things, neither of which was doing any work**:

| Route | Billed invocations | Cause |
|---|---:|---|
| `POST /api/playlist` → 404 | 42 / 54 (78%) | retry storm |
| `/opengraph-image`, `/icon`, `/icons/512` | 10 / 54 (18%) | `runtime = "edge"` |
| `POST /api/preview/batch` | 2 / 54 | legitimate work |

**Performance**

- `e72467a` — **The three generated-image routes no longer run per request.** `app/icon.tsx`, `app/opengraph-image.tsx` and `app/icons/[size]/route.tsx` each carried `export const runtime = "edge"`, which opts a route out of static generation. Next warns about this at build time and it is easy to read past; the route table listed all three as `ƒ`, and the logs confirmed it with `source: edge-function` / `cache: MISS`. These are satori rasterisations — the most CPU-expensive thing in the app — and the OG image is fetched once per share, i.e. the hottest thing in a viral loop. `app/icons/[size]` also gains `generateStaticParams` + `dynamicParams = false`, so the three real sizes prerender and any other segment 404s without an invocation.

  The prerendered bytes are **identical** to what production was serving (685 / 125706 / 3460 / 10094 / 5583), so this changes only *when* they are computed.

- `b3c266f` — **A refused playlist is no longer re-requested.** A 404 returns from the negative cache in ~100ms, which is faster than the Start button re-enables, so a host pasting a private link and tapping Start produced bursts of fourteen identical requests 150–300ms apart. Each was a billed invocation replaying a decision already made. Per-IP rate limiting cannot catch this — the bursts sat comfortably inside the 30-per-10-minute allowance.

  `isDeterministicPlaylistFailure` names the codes where resubmitting the same URL provably cannot answer differently. Mixed Playlist Mode gets the same guard keyed on the whole roster, where a mash cost one request *per contributor*.

**Documentation**

- `240e712` — README described the icon route as "generated at the edge" (which was the bug); stale test counts corrected. `docs/operations.md` gains the symptom, since the diagnosis is not derivable from the code.

### Two things deliberately not done

- `app/j/[code]` and `app/buzz/[code]` are still `ƒ` — pure client components paying an SSR invocation per QR scan. They did not appear **once** in the sampled logs, and making them static risks rendering the wrong room code before hydration.
- The 78% figure is one two-minute sample, not a 30-day average. The direction is unambiguous; the exact reduction is not predicted.

## Test Coverage

```
CODE PATHS                                                  USER FLOWS
[+] lib/error-messages.ts                                   [+] Unusable playlist
  ├── isDeterministicPlaylistFailure()                        ├── [VERIFIED] error shown, re-tap sends nothing
  │   ├── [★★★ TESTED] non-code input → false                 └── [VERIFIED] editing the link retries
  │   ├── [★★★ TESTED] all 6 members → true (exhaustive)    [+] Good playlist
  │   └── [★★★ TESTED] complement of union → false (derived)  └── [VERIFIED] loads, game starts
  ├── shouldRememberRejection()
  │   ├── [★★★ TESTED] AppError + deterministic → true
  │   ├── [★★★ TESTED] AppError + throttling → false
  │   └── [★★★ TESTED] non-AppError → false
  └── shouldRememberAllRejections()
      ├── [★★★ TESTED] every rejection final → true
      ├── [★★★ TESTED] one transient among them → false
      └── [★★★ TESTED] empty array → false (the [].every() trap)
[+] lib/mixed-playlist.ts — mixedRosterKey()
  ├── [★★★ TESTED] reorder → same key
  ├── [★★★ TESTED] add/remove/swap → different key
  ├── [★★★ TESTED] delimiter in URL → no collision
  └── [★★★ TESTED] does not mutate caller's array
[+] app/page.tsx — guard wiring   [suite reaches lib/ only, per CLAUDE.md]
[+] image routes — [BUILD-VERIFIED] static in route table, bytes identical

COVERAGE: decision logic 12/12 (100%)   QUALITY: ★★★:12   GAPS: 0
```

Coverage gate: **PASS (100%)**. Tests: 355 → 366 (+11).

Measured in a browser against a local production build:

| Scenario | Taps | Requests |
|---|---:|---:|
| Single, same URL | 6 | **1** |
| Single, URL edited | 6 | 1 (rearmed) |
| Mixed, same roster (2 contributors) | 6 | **2** (one round) |
| Mixed, roster changed | 3 | 2 (rearmed) |
| Transient failure (server down) | 3 | **3** (stays retryable) |
| `/icons/999`, `/icons/foo` | — | 404, no invocation |

## Pre-Landing Review

1 issue (0 critical, 1 informational) — 0 auto-fixed, 1 asked, 1 fixed, 0 skipped.

- `[INFORMATIONAL]` (confidence: 8/10) `app/page.tsx:413` — `handleMixedStart` had the same retry-storm shape unguarded, costing one request per contributor per tap. **Fixed** in `b3c266f` at the author's direction.

  While fixing it: `mixed_playlists_failed` is an *aggregate* and is **not** treated as final on its own. A single transient 500 lands in it alongside genuinely private links, so `shouldRememberAllRejections` requires every individual rejection to be deterministic — otherwise one contributor's blip would write off the whole party.

Red Team pass raised one concern that did not survive: the memoized message is locale-stamped at failure time, but `useErrorLocale` runs once on mount with `[]` deps and never changes, so it cannot go stale.

## Design Review

No visual changes. `gstack-diff-scope` reported `SCOPE_FRONTEND=false`; the only component edit is non-visual control flow, and the five generated images are byte-for-byte identical to what production serves.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

**Scope Check: CLEAN.** Intent: cut Vercel Active CPU. Delivered: exactly that, plus its documentation. Every changed file traces to one of the two fixes or to recording them.

## Plan Completion

No plan file detected — this started from a production symptom rather than a spec.

## Documentation

- `README.md` — corrected `app/icons/[size]` from "generated at the edge" to prerendered at build; refreshed stale test counts.
- `docs/operations.md` — new symptom entry, "Vercel says the CPU budget is nearly spent", covering how Active CPU is billed, the `vercel logs --json` grouping that finds it, and the two shapes it took here.
- `CLAUDE.md` — both hazards recorded as invariants, since neither is visible on the page: the images come out identical either way, and a restored retry loop looks like a working error message.

## Test plan

- [x] All Vitest tests pass (366 tests, 22 files, 0 failures)
- [x] `npm run lint` clean
- [x] `npm run build` clean, no edge-runtime warning, route table shows `○ /icon`, `○ /opengraph-image`, `● /icons/[size]` with all three sizes
- [x] Prerendered image bytes compared against production — 5/5 identical
- [x] Guard behaviour verified in a browser on a production build (table above)
- [x] Unknown icon segments still 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
