### PR TITLE
feat: add Google AdSense loader and ads.txt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ NEXT_PUBLIC_BASE_URL=
 # Optional — enables GA4 when set
 NEXT_PUBLIC_GA_MEASUREMENT_ID=
 
+# Optional — the AdSense publisher id ("ca-pub-…"). Defaults to the project's
+# own id, so set this only when running under a different AdSense account, and
+# update public/ads.txt to match. The loader only renders in production builds.
+NEXT_PUBLIC_ADSENSE_CLIENT_ID=
+
 # Optional for local dev (falls back to an in-memory store), but REQUIRED on
 # serverless/multi-instance deploys (e.g. Vercel) — backs the QR-code room
 # store used by Mixed Playlist Mode (lib/kv.ts). Get a free database at

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,8 @@ The host is the judge — there is no automated answer checking. Correct song gu
 
 Production domain is `https://www.guessong.app` (fallback in `app/layout.tsx`, `app/sitemap.ts`, `app/robots.ts`). `app/layout.tsx` also injects GA4 when `NEXT_PUBLIC_GA_MEASUREMENT_ID` is set.
 
+**AdSense's loader lives in `app/layout.tsx`'s `<head>`, not in a `next/script`.** Google's site review looks for it there, and `afterInteractive` would inject it into the body instead. It renders only when `NODE_ENV === "production"`, so `next dev` never reports impressions against the account. `public/ads.txt` carries the same publisher id with the `ca-` prefix stripped — AdSense flags "Earnings at risk" if the file is missing or the two disagree, so changing `NEXT_PUBLIC_ADSENSE_CLIENT_ID` means changing both.
+
 **The five generated images must stay build-time, which means none of them may declare `runtime = "edge"`.** `app/opengraph-image.tsx`, `app/icon.tsx` and the three sizes of `app/icons/[size]` are rasterised by satori, the most CPU-expensive thing the app does. All three carried `runtime = "edge"` from the day they were written until this was found, and edge *disables static generation for the route* — Next says so in a build warning that is easy to read past ("Using edge runtime on a page currently disables static generation for that page"). They were `ƒ` in the route table, ran per request as `edge-function`, and showed up in production logs as `cache: MISS`. The fix was deleting three lines; the output bytes are identical either way, so nothing about this is visible on the page and nothing but the route table will tell you it regressed. `app/icons/[size]` additionally needs its `generateStaticParams` + `dynamicParams = false` to stay — that pair is what prerenders the three sizes and 404s everything else without an invocation.
 
 After touching any of them, check `npm run build`'s route table: `/icon` and `/opengraph-image` must be `○`, `/icons/[size]` must be `●` with all three sizes listed under it. An `ƒ` there is the regression.
@@ -109,6 +111,7 @@ SPOTIFY_CLIENT_ID / SPOTIFY_CLIENT_SECRET   # Required — Client Credentials on
 UPSTASH_REDIS_REST_URL / _TOKEN             # Required in production — see below
 NEXT_PUBLIC_BASE_URL                        # Optional — defaults to https://www.guessong.app
 NEXT_PUBLIC_GA_MEASUREMENT_ID               # Optional — enables GA4
+NEXT_PUBLIC_ADSENSE_CLIENT_ID               # Optional — AdSense publisher id, defaults to ca-pub-2238954049312975
 SPOTIFY_MAX_LOADS_PER_MINUTE                # Optional — global upstream ceiling, default 40
 PREVIEW_MAX_LOOKUPS_PER_MINUTE              # Optional — global iTunes/Deezer ceiling, default 120
 ```

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,10 @@ import "./globals.css";
 
 const GA_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://www.guessong.app";
+// The publisher id is a public identifier, not a secret — it ships in the
+// script URL on every page and in public/ads.txt, which has to match it.
+const ADSENSE_CLIENT =
+  process.env.NEXT_PUBLIC_ADSENSE_CLIENT_ID || "ca-pub-2238954049312975";
 
 export const metadata: Metadata = {
   metadataBase: new URL(BASE_URL),
@@ -104,6 +108,17 @@ export default function RootLayout({
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
+        {/* AdSense's loader goes in <head>, which is where the account's site
+            review looks for it — next/script's afterInteractive would put it in
+            the body instead. Skipped outside production so localhost and
+            `next dev` never register impressions against the account. */}
+        {ADSENSE_CLIENT && process.env.NODE_ENV === "production" && (
+          <script
+            async
+            src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT}`}
+            crossOrigin="anonymous"
+          />
+        )}
       </head>
       <body>
         {/* Catch beforeinstallprompt before React hydrates — Chrome can fire

--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,4 @@
+# Served at https://www.guessong.app/ads.txt out of public/.
+# AdSense reports "Earnings at risk" until this file exists and the publisher
+# id matches NEXT_PUBLIC_ADSENSE_CLIENT_ID in app/layout.tsx (minus the "ca-").
+google.com, pub-2238954049312975, DIRECT, f08c47fec0942fa0

--- a/tests/adsense.test.ts
+++ b/tests/adsense.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// The loader's publisher id lives in app/layout.tsx and the same id, minus the
+// "ca-" prefix, has to appear in public/ads.txt. Nothing connects the two but
+// this test: if they drift, the script still loads and the page still renders,
+// AdSense just stops attributing the inventory and reports "Earnings at risk"
+// somewhere nobody in this repo is looking. Same class of hand-sync failure as
+// lib/loop-links.ts's three derived copies.
+const layoutSource = readFileSync(
+  join(process.cwd(), "app/layout.tsx"),
+  "utf8"
+);
+const adsTxt = readFileSync(join(process.cwd(), "public/ads.txt"), "utf8");
+
+/** The lines ads.txt crawlers actually read — comments and blanks dropped. */
+function records(): string[][] {
+  return adsTxt
+    .split("\n")
+    .map((line) => line.split("#")[0].trim())
+    .filter(Boolean)
+    .map((line) => line.split(",").map((field) => field.trim()));
+}
+
+describe("AdSense", () => {
+  it("declares a publisher id in app/layout.tsx", () => {
+    expect(layoutSource).toMatch(/ca-pub-\d+/);
+  });
+
+  it("serves an ads.txt whose publisher id matches the loader", () => {
+    const inLayout = layoutSource.match(/ca-pub-(\d+)/)?.[1];
+    const inAdsTxt = records().map((fields) => fields[1]);
+    expect(inAdsTxt).toContain(`pub-${inLayout}`);
+  });
+
+  it("writes ads.txt in the four-field IAB format", () => {
+    // A malformed line is skipped silently by the crawler, which reads exactly
+    // like having no ads.txt at all.
+    for (const fields of records()) {
+      expect(fields.length).toBeGreaterThanOrEqual(3);
+      expect(fields[0]).toBe("google.com");
+      expect(fields[2]).toBe("DIRECT");
+    }
+    expect(records().length).toBeGreaterThan(0);
+  });
+
+  it("loads the script from Google's own host", () => {
+    // A typo'd host is a script that never loads and never errors visibly.
+    expect(layoutSource).toContain(
+      "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds the AdSense loader to the site. Verification-ready state only — no ad units are placed yet, so nothing changes visually on any page.

- `app/layout.tsx` — the loader in `<head>`, not a `next/script`. That is where AdSense's site review looks for it; `afterInteractive` would inject it into the body instead. Rendered output verified in the build: `/`, `/zh` and `/about` all carry `<script async src="…?client=ca-pub-…" crossorigin="anonymous">` before `</head>`.
- Gated on `NODE_ENV === "production"`, so `next dev` on 127.0.0.1 never registers impressions against the account.
- Publisher id reads from `NEXT_PUBLIC_ADSENSE_CLIENT_ID` and defaults to the project's own, following the `NEXT_PUBLIC_BASE_URL` pattern. **No env var needs setting on Vercel.**
- `public/ads.txt` — AdSense reports "Earnings at risk" without it. Served at `/ads.txt` out of `public/`.
- `tests/adsense.test.ts` — pins the ads.txt publisher id to the one in `layout.tsx`. Nothing else connects them, and drift is silent: the script still loads and the page still renders, the inventory just stops being attributed. Same class of hand-sync failure as `lib/loop-links.ts`'s three derived copies.

## Verification

- `npm test` — 387 passed (24 files), up from 383.
- Drift test mutation-checked: changing the pub id in `ads.txt` fails the suite, so it is not a test that always passes.
- `npm run build` route table unchanged — `/icon` and `/opengraph-image` still `○`, `/icons/[size]` still `●` with all three sizes. (The `runtime = "edge"` regression documented in CLAUDE.md.)
- `npm run lint` clean.
- No CSP headers in `next.config.js` and `public/sw.js`'s fetch handler is a no-op, so neither blocks the cross-origin script.

## Not in this PR

- **No ad units.** The loader alone is what site review needs; where slots go is a separate call. `/game` in particular should probably stay ad-free — it plays audio clips on a timer, and an auto-playing ad would talk over the question.
- **No version bump / changelog entry.** `lib/changelog.ts` is what players read in the "What's new" overlay, and there is nothing player-visible here yet. The bump belongs with whichever PR actually places slots.
- **No consent mechanism.** For EEA/UK traffic, AdSense needs a consent message; it can be configured from the AdSense dashboard without a code change, but it is not handled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)