### PR TITLE
feat(mixed): count mixed games, hand back the mix, and fix the reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,128 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-08-15
+
+Mixed Playlist Mode gets an artifact and an instrument, and the loop counters
+learn that it exists at all.
+
+The load-bearing finding is that `npm run stats` could not see Mixed mode.
+`join_submitted` — the highest-converting surface in the product at 32.6%
+(92 shown, 30 followed), against 12.0% for `buzz_cta` and 0.8% for `game_over`
+— is rendered only by `app/j/[code]/page.tsx`, and `roomJoinUrl` sends players
+to `/buzz/[code]?p=1` whenever the buzzer is on (`lib/room-client.ts:125-127`).
+So that number describes *Mixed·QR with the buzzer off* and nothing else: a QR
+room with a buzzer, and the entire `phone` sub-mode, wrote to no counter
+anywhere. It was being read as "Mixed converts at a third" when its denominator
+excluded the ordinary configuration.
+
+The fix is one optional field, not a new event. `recordHostedStart` in
+`app/page.tsx` already beacons `game_started` from all three start paths, so a
+mixed game was already reaching KV — only the discriminator was missing. A
+separate `mixed_pool_built` event was designed and rejected: it would have
+described one occurrence twice and cost a mixed game eight KV commands where
+this costs five.
+
+### Added
+
+- **`mixed` on the `game_started` pulse** (`lib/pulse.ts`, `lib/loop-stats.ts`)
+  — `"room" | "phone"`, absent on a single-playlist game. `MixedSubMode` and
+  `MIXED_SUB_MODES` live in `lib/loop-stats.ts` beside `HOST_INDEX_CEILING`,
+  because that module owns the `loop:stats:` key space and these two strings
+  become the tail of a key. `parsePulse` drops an unrecognised value rather than
+  rejecting the body: the game is real either way, and `mixed_pool:${anything}`
+  from an unauthenticated endpoint is how a counter namespace becomes a bill.
+- **`lib/round-summary.ts`** — `summarizeRounds` / `describeRounds`, the
+  per-round tally printed under the final scores. In `lib/` because the suite
+  only reaches `lib/`, the same reason `lib/song-count.ts` and
+  `lib/room-poll.ts` live there. Counts, never a rate: the denominator is rounds
+  *played*, not rounds possible, so a percentage would invite comparison between
+  games of different lengths stopped for different reasons.
+- **`lib/mix-export.ts`** — `formatMixList`, the merged tracklist as text.
+  **The roster is passed in rather than derived from the tracks.** Deriving it
+  would be shorter and would silently erase anybody whose playlist was sampled
+  down to nothing — `poolContributions` fills to a target and stops, so with
+  enough contributors somebody gets zero, and they queued, scanned, and handed
+  over their music. Text rather than a Spotify playlist because creating one
+  needs user OAuth, and having no accounts is the product's premise.
+- **A generic "Other counters" block in `scripts/loop-stats.mjs`.** `KEYS`
+  discovery already found every metric, but every renderer was written against
+  one key shape, so a newly added counter was read, summed and silently dropped
+  — while the file header promised the opposite. The number then looks like a
+  zero rather than like a missing renderer, and zero is a real answer here.
+  Closing it generically means the next metric never hits this.
+
+### Fixed
+
+- **The taste card drew an `AWARDS` heading over nothing.** `sharedSectionH`
+  was guarded, the awards section was not, so a group with no shared songs and
+  no popularity data got a heading and blank space — which is precisely the
+  cross-culture case the card is most likely to be saved from.
+- **`computeMostObscure` crowned whoever the Map saw first on an all-zero tie.**
+  Every rate is 0 when nobody places anybody's music, so `rate < best.rate`
+  never fired and the award went to whoever submitted earliest. It now breaks
+  the tie on contributed-track count, using the `totals` map the function
+  already builds — no signature change, no extra data.
+- **`mixedPlaylistMeta` had no reader.** Written by both mixed start paths since
+  1.2 and consumed nowhere, so a contributor sampled to zero tracks was
+  invisible to everyone including themselves. `formatMixList` is its first
+  reader.
+
+### Changed
+
+- **`MixedSubMode` is declared once.** `app/page.tsx` had a local copy with the
+  same two members; it is now imported. A second copy of a union whose members
+  become part of a KV key drifts silently — the toggle keeps working, the
+  counter keeps counting, and they count different things.
+- **Five files documented a weekly digest that does not exist.** `lib/kv.ts:74`
+  named `lib/digest.ts` specifically; the cron digest was dropped in favour of
+  `npm run stats` and the comments never followed. Corrected in `lib/kv.ts`,
+  `lib/loop-stats.ts`, `lib/loop-client.ts`, `lib/loop-links.ts` and
+  `lib/analytics.ts`. This cost two wrong conclusions during the review that
+  produced this release.
+- **`loopStatsKeys` gains `mixedPool` and an honest docstring.** It is not the
+  reader's contract — `scripts/loop-stats.mjs` uses `KEYS` — it is the writer's
+  description of itself, held together by one test that asserts with
+  `toContain`, so an omission fails nothing.
+- **`scripts/loop-stats.mjs` walks the namespace with `SCAN`, not `KEYS`.**
+  Found by running `npm run stats` mid-release and getting nothing but
+  `ERR KEYS command is disabled because total number of keys is too large`.
+  `KEYS` matches against every key in the instance, so this namespace's size was
+  never the number that mattered: `lib/preview-cache.ts` writes one key per
+  track and holds positive entries for a year, and that set crossing Upstash's
+  ceiling took the whole report down. **It had been degrading silently before it
+  failed** — the same seven-day window read 5/7 live days, 4918 games and a
+  45.2% `join_submitted` rate under `KEYS`, and 7/7, 6740 and 32.6% under
+  `SCAN`. Every figure from a `KEYS`-era run is a partial sum and the script
+  gave no sign of it. `MGET` is chunked at 256 for the same class of reason: one
+  request body that grows with the namespace.
+
+### Known gaps
+
+- **A room is still single-use.** `consumeRoomPool` claims `consumed` and the
+  room is dead (`lib/room.ts:427`), and `ROOM_TTL_SECONDS` counts down from
+  creation. A second game at the same party needs everyone to re-scan and
+  re-submit. Untouched here; likely to be hit in real use before it is fixed.
+- **The `+2` source guess still has no buzzer affordance.** It uses the player
+  picker even when `buzzerControls` exists, so the most distinctive mechanic in
+  the product is the one part the host must referee by hand.
+- **`game_over` is where the loop's volume is** — 936 impressions in seven days,
+  more than every other surface combined, converting at 0.9%. Its bottleneck is
+  modality, not copy: it is a QR on a TV across the room. Moving it to the
+  phones already holding a socket needs one new `ServerMessage`, which is a
+  Worker deploy. `lib/loop-links.ts:38-41` already documents why `buzz_cta`
+  cannot cover the end of a game.
+- **`game_over` impressions are undercounted.** `firstTimeThisSession` keys
+  sessionStorage by surface alone (`lib/loop-client.ts:39-52`) and `playAgain`
+  is a same-tab `router.push("/")`, so the second game in a tab reports a start
+  and no impression. The rate is therefore *overstated*: real `game_over`
+  conversion is worse than 0.9%. Deliberately deferred — the fix collides with
+  the documented `share`/`game_over` dedupe parity at `app/game/page.tsx:83-85`
+  and changes what `share` counts, and no decision turns on it.
+- **The retreat headcount is unverified.** `ROOM_MAX_SUBMISSIONS` and
+  `BUZZER_MAX_PLAYERS` are both 12, and raising the latter is a Worker deploy
+  because the constant is shared verbatim with it.
+
 ## [1.5.0] - 2026-08-13
 
 A host-facing control and a deletion, which are the same change seen twice: the

--- a/app/api/pulse/route.ts
+++ b/app/api/pulse/route.ts
@@ -57,7 +57,7 @@ export async function POST(req: NextRequest) {
   if (event.kind === "loop_impression") {
     await recordLoopImpression(event.surface);
   } else {
-    await recordGameStart(event.hostGameIndex);
+    await recordGameStart(event.hostGameIndex, event.mixed);
   }
 
   return new NextResponse(null, { status: 204 });

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -13,12 +13,15 @@ import {
   type GameMode,
   type GamePlayer as Player,
   type BuzzerRoomHandle,
+  type MixedPlaylistMeta,
 } from "@/lib/game-session";
 import { fetchPreview, fetchPreviewBatch } from "@/lib/preview-client";
 import { isPreviewSettled, type PreviewBatchTrack } from "@/types/preview";
 import { BuzzerHostPanel, type BuzzerControls } from "@/components/buzzer-host-panel";
 import { LoopQr } from "@/components/loop-qr";
 import type { RoundHistoryEntry } from "@/lib/round-history";
+import { describeRounds, summarizeRounds } from "@/lib/round-summary";
+import { formatMixList } from "@/lib/mix-export";
 import { buildTasteCard } from "@/lib/taste-card";
 import {
   CARD_FOOTER_HEIGHT,
@@ -121,6 +124,9 @@ export default function GamePage() {
   const [noAudio, setNoAudio] = useState(false);
   const [loadingSkipVisible, setLoadingSkipVisible] = useState(false);
   const [playlistSource, setPlaylistSource] = useState<PlaylistSource>("own");
+  const [mixedMeta, setMixedMeta] = useState<MixedPlaylistMeta | null>(null);
+  const [mixCopied, setMixCopied] = useState(false);
+  const [mixFallback, setMixFallback] = useState<string | null>(null);
   const [mode, setMode] = useState<GameMode>("party");
   const [installCta, setInstallCta] = useState(false);
   // Buzzer Mode only. Null in every other mode, which is also how the panel
@@ -217,6 +223,11 @@ export default function GamePage() {
     setPlaylistSource(data.playlistSource);
     setMode(data.mode);
     setBuzzerRoom(data.buzzerRoom ?? null);
+    // The roster, kept separately from the tracks on purpose. `contributorNames`
+    // is the only record of somebody whose playlist was sampled down to nothing:
+    // they are absent from every track, so anything derived from `tracks` erases
+    // them from an evening they took part in.
+    setMixedMeta(data.mixedPlaylistMeta ?? null);
     gameStartTimeRef.current = Date.now();
   }, [router]);
 
@@ -581,6 +592,30 @@ export default function GamePage() {
     router.push("/");
   }
 
+  /**
+   * Put the merged tracklist on the clipboard.
+   *
+   * The failure path shows the text instead of silently doing nothing: clipboard
+   * access is refused often enough (insecure context, Safari outside a user
+   * gesture, a locked-down work phone) that a button which sometimes no-ops
+   * teaches the host it is broken. A selectable block still gets the list to the
+   * group chat, which is the whole point of the button.
+   */
+  async function copyMixList() {
+    const text = formatMixList({
+      tracks,
+      contributorNames: mixedMeta?.contributorNames ?? [],
+      playlistName,
+    });
+    try {
+      await navigator.clipboard.writeText(text);
+      setMixCopied(true);
+      window.setTimeout(() => setMixCopied(false), 2500);
+    } catch {
+      setMixFallback(text);
+    }
+  }
+
   async function downloadResultImage() {
     const W = 640;
     const rowH = 64;
@@ -664,7 +699,12 @@ export default function GamePage() {
     const sharedSectionH =
       sharedTracks.length > 0 ? 40 + sharedTracks.length * sharedRowH + 20 : 0;
     const awardCount = (tasteCard.mostObscure ? 1 : 0) + (tasteCard.mostMainstream ? 1 : 0);
-    const awardsSectionH = 40 + awardCount * 70 + 20;
+    // Zero awards means zero height, matching how `sharedSectionH` above is
+    // computed. Without this the card reserved room for a heading it then drew
+    // over nothing: both awards are absent exactly when a room shares no taste
+    // and carries no popularity data, which is the cross-culture case this card
+    // is most likely to be saved from.
+    const awardsSectionH = awardCount > 0 ? 40 + awardCount * 70 + 20 : 0;
     const footerH = CARD_FOOTER_HEIGHT;
     const qr = await loopQrDataUrl();
     const H = headerH + sharedSectionH + awardsSectionH + footerH;
@@ -708,11 +748,13 @@ export default function GamePage() {
       y += 20;
     }
 
-    ctx.fillStyle = "#1DB954";
-    ctx.font = "bold 13px sans-serif";
-    ctx.letterSpacing = "1px";
-    ctx.fillText("AWARDS", 40, y + 24);
-    y += 40;
+    if (awardCount > 0) {
+      ctx.fillStyle = "#1DB954";
+      ctx.font = "bold 13px sans-serif";
+      ctx.letterSpacing = "1px";
+      ctx.fillText("AWARDS", 40, y + 24);
+      y += 40;
+    }
 
     if (tasteCard.mostObscure) {
       ctx.font = "13px sans-serif";
@@ -762,6 +804,9 @@ export default function GamePage() {
   const isRevealed = phase === "revealed" || phase === "finished";
   const showAlbumArt = isRevealed || albumHintShown;
   const sortedPlayers = [...players].sort((a, b) => b.score - a.score);
+  // Null on an empty history, so an abandoned or non-mixed game renders nothing
+  // rather than a sentence made of zeroes.
+  const roundSummaryLine = describeRounds(summarizeRounds(roundHistory));
   const maxScore = sortedPlayers[0]?.score ?? 0;
 
   if (tracks.length === 0) {
@@ -1255,12 +1300,44 @@ export default function GamePage() {
         }
         .final-score.podium { color: #888; }
 
+        /* Quiet on purpose. This is a description of the evening, not a result,
+           and it sits directly under a scoreboard that already has the room's
+           attention. */
+        .round-summary {
+          color: #666;
+          font-size: 13px;
+          text-align: center;
+          margin: 4px 0 0;
+          flex-shrink: 0;
+          max-width: 480px;
+        }
+
+        /* Wraps rather than scrolls horizontally, because the point is to
+           select all of it. */
+        .mix-fallback {
+          width: 100%;
+          max-width: 480px;
+          height: 160px;
+          margin-top: 12px;
+          padding: 10px 12px;
+          background: #1a1a1a;
+          color: #ddd;
+          border: 1px solid #333;
+          border-radius: 8px;
+          font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+          font-size: 12px;
+          line-height: 1.5;
+          resize: vertical;
+          flex-shrink: 0;
+        }
+
         .finished-btn-row {
           display: flex;
           gap: 12px;
           flex-shrink: 0;
           width: 100%;
           max-width: 480px;
+          flex-wrap: wrap;
         }
         .btn-lg {
           flex: 1;
@@ -1741,6 +1818,15 @@ export default function GamePage() {
                 </div>
               )}
 
+              {/* How the scoring actually went, which the scoreboard cannot
+                  show: two rooms reach the same final scores with completely
+                  different rounds behind them. Mixed only, because
+                  `setRoundHistory` only records mixed rounds — a non-mixed game
+                  would render a line built from an empty array. */}
+              {playlistSource === "mixed" && roundSummaryLine && (
+                <p className="round-summary">{roundSummaryLine}</p>
+              )}
+
               {installCta && <InstallCta onInstall={handleInstall} />}
 
               {/* Buttons — always visible, pinned at bottom */}
@@ -1756,7 +1842,25 @@ export default function GamePage() {
                     Save Taste Card
                   </button>
                 )}
+                {playlistSource === "mixed" && (
+                  <button className="btn-lg outline" onClick={copyMixList}>
+                    {mixCopied ? "Copied ✓" : "Copy the Mix"}
+                  </button>
+                )}
               </div>
+
+              {/* Clipboard refused. Showing the text is not a consolation
+                  prize — it is the same payload by a route the browser cannot
+                  veto. */}
+              {mixFallback && (
+                <textarea
+                  className="mix-fallback"
+                  readOnly
+                  value={mixFallback}
+                  onFocus={(e) => e.currentTarget.select()}
+                  aria-label="The mixed playlist, ready to copy"
+                />
+              )}
 
               {/* The room is looking at this screen with their phones already
                   in hand, which is the one moment in the game when a way onward

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { trackEvent } from "@/lib/analytics";
 import { arrivedFrom } from "@/lib/loop-links";
 import { bumpHostGameCount, recallLoopRef, rememberLoopRef } from "@/lib/host-session";
 import { reportGameStart } from "@/lib/loop-client";
+import type { MixedSubMode } from "@/lib/loop-stats";
 import { REPORT_PROBLEM_MAILTO } from "@/lib/contact";
 import {
   AppError,
@@ -115,7 +116,13 @@ const FAQS: { q: string; a: string }[] = [
 ];
 
 type SetupMode = "single" | "mixed";
-type MixedSubMode = "room" | "phone";
+
+// `MixedSubMode` is imported rather than redeclared here. It was a local copy
+// with the same two members until the KV counters started keying off it, and a
+// second copy of a union whose members become part of a key is the shape that
+// drifts silently: the toggle would keep working, the counter would keep
+// counting, and they would be counting different things. Same reason
+// `lib/loop-links.ts` declares its surfaces once.
 
 function SpotifyIcon() {
   return (
@@ -265,7 +272,7 @@ export default function SetupPage() {
         song_count: data.tracks.length,
         playlist_source: "mixed",
         game_mode: room ? "buzzer" : "party",
-        ...recordHostedStart(),
+        ...recordHostedStart("room"),
       });
       trackEvent("room_started", {
         contributor_count: data.players.length,
@@ -313,11 +320,19 @@ export default function SetupPage() {
    *
    * Has side effects: it advances the device's game counter and beacons the
    * new index to `/api/pulse`, which is the only path by which that number
-   * reaches the weekly digest. GA4 gets the same value as a param below.
+   * reaches `npm run stats`. GA4 gets the same value as a param below.
+   *
+   * `mixed` names which route collected the playlists, and the two mixed
+   * callers must pass it. It is the only way either of them appears in KV at
+   * all: the `join_submitted` surface is rendered by `/j/[code]`, but
+   * `roomJoinUrl` sends players to `/buzz/[code]` as soon as the buzzer is on,
+   * and the phone route never shows a join page to anybody. Both were therefore
+   * invisible to every counter, which is not the same as unused — and a
+   * question `npm run stats` cannot answer is one nobody will answer.
    */
-  function recordHostedStart() {
+  function recordHostedStart(mixed?: MixedSubMode) {
     const hostGameIndex = bumpHostGameCount();
-    reportGameStart(hostGameIndex);
+    reportGameStart(hostGameIndex, mixed);
     return {
       host_game_index: hostGameIndex,
       arrived_from: arrivedFrom(recallLoopRef()),
@@ -538,7 +553,7 @@ export default function SetupPage() {
         song_count: pooled.length,
         playlist_source: "mixed",
         game_mode: room ? "buzzer" : "party",
-        ...recordHostedStart(),
+        ...recordHostedStart("phone"),
       });
       trackEvent("mixed_pool_built", {
         contributor_count: mixedContributions.length,

--- a/docs/viral-loop.md
+++ b/docs/viral-loop.md
@@ -264,14 +264,48 @@ figure justifies raising `LOOP_LIMIT` in `app/r/[surface]/route.ts`.
 
 ## 9. Why the script holds no metric list
 
-`scripts/loop-stats.mjs` runs `KEYS loop:stats:*` and parses what comes back
+`scripts/loop-stats.mjs` walks `loop:stats:*` with `SCAN` and parses what comes back
 rather than rebuilding keys from a hardcoded list. That list already exists in
 `lib/loop-stats.ts`, and a second copy would drift silently — the script would
 read keys nobody writes and print a confident table of zeros. Discovery also
-means a metric added later appears here without anyone editing the script.
+means a metric added later appears here without anyone editing the script — as
+far as the *counting* goes. Rendering is per key shape, so a new metric that no
+block recognises falls into the "Other counters" list at the bottom rather than
+being read, summed and silently dropped, which is what used to happen.
 
 The only shared knowledge is the `loop:stats:` prefix, and changing that makes
 the script print "no counters found", which is loud rather than wrong.
 
-`KEYS` is the wrong tool on a large database. This namespace is a few hundred
-keys with a 30-day TTL and the command runs by hand.
+### `SCAN`, not `KEYS`, and the difference is not academic
+
+`KEYS` matches against **every key in the instance**, not every key under the
+prefix — so the size of this namespace was never the number that decided
+whether it worked. `lib/preview-cache.ts` writes one key per track and holds
+positive entries for a year, and when that set crossed Upstash's ceiling the
+server started refusing outright:
+
+```
+ERR KEYS command is disabled because total number of keys is too large, please use SCAN
+```
+
+`npm run stats` then exits 1 and prints nothing, for a reason with no
+connection to the loop. **And it had been wrong before it was loud.** On
+2026-08-15 the same seven-day window read, minutes apart:
+
+| | `KEYS` | `SCAN` |
+|---|---|---|
+| Days with any activity | 5/7 | 7/7 |
+| Games started | 4918 | 6740 |
+| `join_submitted` | 42 shown / 19 followed — 45.2% | 92 / 30 — 32.6% |
+| `game_over` | 936 / 8 — 0.9% | 1274 / 10 — 0.8% |
+
+The truncation was silent and it was not uniform: two whole days of liveness
+markers were missing, which is why the report claimed 5/7 — the exact reading
+§7 says to treat as a plumbing problem rather than a result. **Any figure quoted
+from a run before this fix is a partial sum.** The relative ordering of the
+surfaces survived, which is what §6 says the table is good for; the levels did
+not, which is what §6 says it is not.
+
+`MGET` is chunked at 256 for the neighbouring reason: the REST transport puts
+the whole command in one request body, and that body would otherwise grow with
+the namespace.

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -96,8 +96,8 @@ export type AnalyticsEvent =
          * the hazard is cardinality and user input. Every count param already
          * here (`round_index`, `player_count`, `rounds_played`) is raw, and
          * bucketing at collection time would freeze the boundaries before the
-         * distribution is known. The KV counter behind the digest caps its own
-         * key space separately, where the cardinality actually matters.
+         * distribution is known. The KV counter caps its own key space
+         * separately, where the cardinality actually matters.
          */
         host_game_index?: number;
       };
@@ -315,7 +315,7 @@ export type AnalyticsEvent =
        * The GA4 copy of a number the server also counts on `/r/[surface]`.
        * Both exist on purpose and they will disagree: an ad blocker kills this
        * one and not the redirect, a spent rate-limit window drops the redirect's
-       * count and not this one. **KV is authoritative for the digest**; this
+       * count and not this one. **KV is authoritative**; this
        * half is here for cohorting and for the questions nobody has thought of
        * yet — and the gap between the two is itself a reading of how much of
        * this audience blocks analytics.

--- a/lib/changelog.ts
+++ b/lib/changelog.ts
@@ -49,6 +49,35 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "1.6.0",
+    date: "2026-08-15",
+    headline:
+      "Mixed Playlist games now hand the merged playlist back at the end, and tell you how the guessing actually went.",
+    headlineZh: "混合歌單模式現在會在結束時把合併好的歌單交還給你，並告訴你這一場猜得如何。",
+    changes: [
+      {
+        kind: "new",
+        text: "Copy the Mix. At the end of a Mixed Playlist game there is a button that copies the whole merged tracklist, with each song credited to whoever brought it, ready to paste into your group chat. Anyone who submitted a playlist is named even if none of their songs made the cut — they turned up, so they are on the list.",
+        textZh: "「複製這份混音」。混合歌單模式結束時多了一個按鈕，會把合併後的完整曲目複製起來，每首歌都標著是誰帶來的，可以直接貼到群組裡。有交歌單但一首都沒被抽到的人也會列在名單上 —— 人有來，名字就在。",
+      },
+      {
+        kind: "new",
+        text: "A line under the final scores saying how many songs nobody could name and how many were traced back to the right playlist. Two parties can end on the same scoreboard having had completely different evenings, and this is the part the scoreboard cannot show.",
+        textZh: "最終比分下面多了一行，寫著有幾首歌全場都叫不出名字、有幾首被猜對了出處。兩場派對可能以一樣的比分收場，過程卻完全不同，而那正是比分表看不出來的部分。",
+      },
+      {
+        kind: "fixed",
+        text: "The taste card no longer prints an empty AWARDS heading when a group shares no songs and no awards can be worked out — which is exactly what happens when everyone's music comes from somewhere different.",
+        textZh: "當一群人完全沒有重疊的歌、算不出任何獎項時，品味卡不會再印出一個空的 AWARDS 標題 —— 而那正好是每個人的音樂各來自一方時會發生的情況。",
+      },
+      {
+        kind: "fixed",
+        text: "\"Most obscure taste\" used to go to whoever submitted their playlist first whenever nobody guessed anyone's songs correctly. It now goes to whoever brought the most songs that nobody could place.",
+        textZh: "以前只要全場都沒人猜對任何人的歌，「最冷門品味」就會頒給最早交歌單的那個人。現在會頒給帶了最多首、而且沒人認得出來的那一位。",
+      },
+    ],
+  },
+  {
     version: "1.5.0",
     date: "2026-08-13",
     headline:

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -71,7 +71,7 @@ export interface KvStore {
  *
  * It lives here, next to the store, because the writer and the reader are
  * always in different modules — `lib/loop-redirect.ts` increments a bucket that
- * `lib/digest.ts` reads back a week later — and the two have to produce a
+ * `scripts/loop-stats.mjs` reads back a week later — and the two have to produce a
  * byte-identical string or they address different keys. That failure is silent:
  * nothing errors, the counter simply reads zero forever. Three copies of
  * `new Date().toISOString().slice(0, 10)` were already drifting distance apart

--- a/lib/loop-client.ts
+++ b/lib/loop-client.ts
@@ -6,12 +6,12 @@
  *
  *   - **GA4** — cohorting, sessions, the questions nobody has asked yet. Dies
  *     to an ad blocker.
- *   - **KV, via `/api/pulse` and `/r/[surface]`** — the numbers the weekly
- *     digest pushes to a human without anyone opening a dashboard. Dies to a
- *     spent rate-limit window.
+ *   - **KV, via `/api/pulse` and `/r/[surface]`** — the numbers `npm run stats`
+ *     prints without anyone opening a dashboard. Dies to a spent rate-limit
+ *     window.
  *
- * Neither is a superset. KV is authoritative for the digest; the gap between
- * the two is itself a reading of how much of this audience blocks analytics.
+ * Neither is a superset. KV is authoritative; the gap between the two is itself
+ * a reading of how much of this audience blocks analytics.
  *
  * Keeping both calls behind one function is the point: two call sites per
  * surface would drift, and the drift is silent — one number keeps moving, the
@@ -20,6 +20,7 @@
 
 import { trackEvent } from "@/lib/analytics";
 import type { LoopSurface } from "@/lib/loop-links";
+import type { MixedSubMode } from "@/lib/loop-stats";
 import { sendPulse } from "@/lib/pulse-client";
 
 const SEEN_PREFIX = "guesssong_loop_seen:";
@@ -71,12 +72,17 @@ export function reportLoopClick(surface: LoopSurface): void {
 }
 
 /**
- * Call as a hosted game starts, with the device's 1-based game index.
+ * Call as a hosted game starts, with the device's 1-based game index and, for
+ * Mixed Playlist Mode, which route collected the playlists.
  *
  * Sent as a beacon because the caller navigates to `/game` immediately after.
- * GA4 gets the same number as a param on `game_started`; this is the copy the
- * digest can read.
+ * GA4 gets the same numbers as params on `game_started`; this is the copy
+ * `npm run stats` can read.
+ *
+ * `mixed` is omitted rather than sent as a sentinel on a single-playlist game,
+ * so the field's presence is the whole signal and nothing has to agree on what
+ * "none" is called.
  */
-export function reportGameStart(hostGameIndex: number): void {
-  sendPulse({ kind: "game_started", hostGameIndex });
+export function reportGameStart(hostGameIndex: number, mixed?: MixedSubMode): void {
+  sendPulse(mixed ? { kind: "game_started", hostGameIndex, mixed } : { kind: "game_started", hostGameIndex });
 }

--- a/lib/loop-links.ts
+++ b/lib/loop-links.ts
@@ -22,7 +22,7 @@
  * same trick `lib/buzzer-protocol.ts` uses to keep the Worker and the client
  * speaking one language. This module stays dependency-free for the same reason
  * that one does: it is imported from a client component, a route handler, and
- * the digest, and nothing here may drag `lib/kv.ts` into a browser bundle.
+ * the KV counters, and nothing here may drag `lib/kv.ts` into a browser bundle.
  */
 
 /**

--- a/lib/loop-stats.ts
+++ b/lib/loop-stats.ts
@@ -7,13 +7,20 @@
  * numbers have to arrive somewhere without anyone going to fetch them. Four
  * separate attempts to read the GA4 dashboard have not happened, so any plan
  * whose payoff is "and then open Analytics" has a measured completion rate of
- * zero and must be designed around rather than repeated. These counters feed a
- * digest that is pushed. GA4 keeps the cohorting and the exploration; this is
- * the half that gets read.
+ * zero and must be designed around rather than repeated. GA4 keeps the
+ * cohorting and the exploration; this is the half that gets read.
+ *
+ * **The reader is `npm run stats` (`scripts/loop-stats.mjs`), not a pushed
+ * digest.** An emailed weekly digest was designed and then dropped in favour of
+ * a command, so anything here describing "the digest" was describing a file
+ * that does not exist — `lib/digest.ts` was never written. The distinction
+ * matters when adding a metric: the script discovers keys with `KEYS` rather
+ * than being handed a list, so a new counter needs no registration to be
+ * *counted*, only to be *named* well enough to read.
  *
  * The two will disagree, and that is expected: an ad blocker kills the GA4
  * event and not the redirect, while a spent rate-limit window drops the KV
- * increment and not the GA4 event. **KV is authoritative for the digest.**
+ * increment and not the GA4 event. **KV is authoritative.**
  *
  * ## Every function here is fail-soft
  *
@@ -29,12 +36,11 @@ import type { LoopSurface } from "@/lib/loop-links";
 /**
  * 30 days, not the 7 that `lib/playlist-cache.ts` uses for its own stats.
  *
- * The digest reports a week at a time and its window ends a couple of days
- * back, so a 7-day TTL would expire the oldest day or two of every single
- * report right before it was read — and, worse, an expired key is
- * indistinguishable from one that was never written, so the loss would render
- * as "no data yet" rather than as a gap. 30 days also leaves room to miss a
- * few weeks of digests and still be able to look back.
+ * A report reads a week at a time, so a 7-day TTL would expire the oldest day
+ * or two of every single one right before it was read — and, worse, an expired
+ * key is indistinguishable from one that was never written, so the loss would
+ * render as "no data yet" rather than as a gap. 30 days also leaves room to go
+ * a few weeks without looking and still be able to look back.
  */
 export const LOOP_STATS_TTL_SECONDS = 30 * 24 * 60 * 60;
 
@@ -48,16 +54,46 @@ export const LOOP_STATS_TTL_SECONDS = 30 * 24 * 60 * 60;
  */
 export const HOST_INDEX_CEILING = 10;
 
+/**
+ * Which of Mixed Playlist Mode's two collection routes built a game's pool.
+ *
+ * Lives here rather than in `lib/pulse.ts` for the same reason
+ * `HOST_INDEX_CEILING` does: this module owns the `loop:stats:` key space, and
+ * these two strings become the tail of a key. A guard over this list is what
+ * stands between an unauthenticated request body and `mixed_pool:${anything}`.
+ *
+ * The sub-mode rides on `game_started` rather than arriving as an event of its
+ * own, because it is a property of the game that started rather than a second
+ * thing that happened. All three hosted-start paths already send that event
+ * (`recordHostedStart` in `app/page.tsx`), so a separate event would have
+ * described one occurrence twice and doubled a mixed game's KV cost for no
+ * extra fact.
+ *
+ * Both values are needed because neither is visible anywhere else. The
+ * `join_submitted` surface is rendered only by `/j/[code]`, and `roomJoinUrl`
+ * sends players to `/buzz/[code]` whenever the buzzer is on — so a QR room with
+ * a buzzer, which is the ordinary configuration, and the whole `"phone"` route
+ * are both invisible to every counter that existed before this one.
+ */
+export type MixedSubMode = "room" | "phone";
+
+export const MIXED_SUB_MODES: readonly MixedSubMode[] = ["room", "phone"];
+
 function key(day: string, metric: string): string {
   return `loop:stats:${day}:${metric}`;
 }
 
 /**
- * Every key the digest reads for one day.
+ * Every key one day of counters can hold.
  *
- * Exported so the reader and the writers derive their keys from one place —
- * the failure mode of two hand-written key formats is that the digest reads a
- * key nobody writes, reports zero, and never errors.
+ * `scripts/loop-stats.mjs` discovers keys with `KEYS` rather than reading this,
+ * so it is not the reader's contract; it is the writer's own description of
+ * itself, and `tests/loop-stats.test.ts` is what holds the two together. That
+ * makes it easy to forget when adding a metric, and forgetting is silent — the
+ * test asserts with `toContain`, so a key missing from here fails nothing. Add
+ * the field anyway: the value of this function is that one place answers "what
+ * can exist under `loop:stats:`", and a description that is only mostly true is
+ * the kind that gets trusted right up until it is wrong.
  */
 export function loopStatsKeys(
   day: string,
@@ -70,6 +106,7 @@ export function loopStatsKeys(
   impressions: Record<string, string>;
   clicks: Record<string, string>;
   hostIndex: string[];
+  mixedPool: Record<MixedSubMode, string>;
 } {
   const impressions: Record<string, string> = {};
   const clicks: Record<string, string> = {};
@@ -89,6 +126,10 @@ export function loopStatsKeys(
     impressions,
     clicks,
     hostIndex,
+    mixedPool: {
+      room: key(day, "mixed_pool:room"),
+      phone: key(day, "mixed_pool:phone"),
+    },
   };
 }
 
@@ -175,11 +216,18 @@ export function recordLoopThrottled(): Promise<void> {
  * without interaction, which is exactly the gap between two parties, so a host
  * on a monthly rhythm reads as first-time forever.
  */
-export async function recordGameStart(hostGameIndex: number): Promise<void> {
+export async function recordGameStart(
+  hostGameIndex: number,
+  mixed?: MixedSubMode
+): Promise<void> {
   const index = Number.isFinite(hostGameIndex)
     ? Math.max(1, Math.min(Math.trunc(hostGameIndex), HOST_INDEX_CEILING))
     : 1;
   await bump("games");
   await bump(`host_index:${index}`);
   if (index >= 2) await bump("repeat_host");
+  // One extra command on a mixed game and none on any other. The alternative
+  // considered was a second pulse event, which would have carried its own
+  // liveness marker and cost a mixed game eight commands where this costs five.
+  if (mixed) await bump(`mixed_pool:${mixed}`);
 }

--- a/lib/mix-export.ts
+++ b/lib/mix-export.ts
@@ -1,0 +1,103 @@
+/**
+ * The merged playlist, handed back as text.
+ *
+ * ## Why anything is handed back
+ *
+ * `poolContributions` (`lib/mixed-playlist.ts`) already builds the one artifact
+ * a group event actually wants — everyone's music, deduped, with each song
+ * still attached to whoever brought it — and then the game throws it away at
+ * the final screen. The party ends with a scoreboard and a picture, and the
+ * playlist that took a dozen people ten minutes to assemble exists nowhere.
+ *
+ * Text rather than a Spotify playlist, and that is not a shortcut: creating a
+ * playlist needs user OAuth, and having no accounts is the premise the entire
+ * product is built on. Text pastes into a group chat, which is where the people
+ * who made it already are.
+ *
+ * ## The roster comes from the roster, not from the tracks
+ *
+ * `contributorNames` is passed in separately and every name in it is printed,
+ * including names that no sampled track belongs to. Deriving the roster from
+ * the tracks would be shorter and would silently erase anybody whose playlist
+ * lost the sampling — they queued up, scanned a code, handed over their music,
+ * and would not appear anywhere in the record of the evening. Sampling makes
+ * that outcome ordinary rather than rare: `poolContributions` fills to a target
+ * and stops, so with enough contributors somebody gets zero.
+ */
+
+import type { Track } from "@/types";
+
+/** Roughly the width of a phone message before it starts wrapping badly. */
+const MAX_TITLE = 60;
+
+function truncate(value: string, max: number): string {
+  return value.length <= max ? value : `${value.slice(0, max - 1).trimEnd()}…`;
+}
+
+function creditFor(track: Track): string {
+  const names = track.contributors ?? [];
+  if (names.length === 0) return "";
+  if (names.length === 1) return ` (${names[0]})`;
+  return ` (${names.slice(0, -1).join(", ")} & ${names[names.length - 1]})`;
+}
+
+export interface MixExportInput {
+  tracks: readonly Track[];
+  /** Everyone who submitted, whether or not their songs made the pool. */
+  contributorNames: readonly string[];
+  playlistName: string;
+}
+
+/**
+ * Returns the whole thing as one string ready for the clipboard.
+ *
+ * Never throws and never returns null: a mix with no tracks still names the
+ * people who turned up, which is the part that would hurt to lose.
+ */
+export function formatMixList({
+  tracks,
+  contributorNames,
+  playlistName,
+}: MixExportInput): string {
+  const lines: string[] = [];
+
+  lines.push(`${playlistName} · guessong.app`);
+
+  const roster = contributorNames.filter((n) => n.trim().length > 0);
+  const songWord = tracks.length === 1 ? "song" : "songs";
+  lines.push(
+    roster.length > 0
+      ? `${tracks.length} ${songWord} from ${roster.join(", ")}`
+      : `${tracks.length} ${songWord}`
+  );
+
+  if (tracks.length > 0) {
+    lines.push("");
+    // Padded so the numbers line up in a monospaced chat client and stay
+    // readable in a proportional one. 144 is the pool ceiling (12 contributors
+    // times the largest per-player sample), so two columns is always enough.
+    const width = String(tracks.length).length;
+    tracks.forEach((track, i) => {
+      const n = String(i + 1).padStart(width, " ");
+      const title = truncate(track.name, MAX_TITLE);
+      const artist = track.artists[0] ?? "";
+      lines.push(`${n}. ${title}${artist ? ` — ${artist}` : ""}${creditFor(track)}`);
+    });
+  }
+
+  const credited = new Set<string>();
+  for (const track of tracks) {
+    for (const name of track.contributors ?? []) credited.add(name);
+  }
+  const empty = roster.filter((name) => !credited.has(name));
+  if (empty.length > 0) {
+    lines.push("");
+    lines.push(
+      empty.length === 1
+        ? `${empty[0]} submitted a playlist but none of it made this round.`
+        : `${empty.slice(0, -1).join(", ")} and ${empty[empty.length - 1]} submitted playlists but none of them made this round.`
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/lib/pulse.ts
+++ b/lib/pulse.ts
@@ -22,11 +22,15 @@
  */
 
 import { isLoopSurface, type LoopSurface } from "@/lib/loop-links";
-import { HOST_INDEX_CEILING } from "@/lib/loop-stats";
+import { HOST_INDEX_CEILING, MIXED_SUB_MODES, type MixedSubMode } from "@/lib/loop-stats";
+
+function isMixedSubMode(value: unknown): value is MixedSubMode {
+  return typeof value === "string" && (MIXED_SUB_MODES as readonly string[]).includes(value);
+}
 
 export type PulseEvent =
   | { kind: "loop_impression"; surface: LoopSurface }
-  | { kind: "game_started"; hostGameIndex: number };
+  | { kind: "game_started"; hostGameIndex: number; mixed?: MixedSubMode };
 
 /**
  * Narrows an untrusted request body, or returns null.
@@ -55,7 +59,15 @@ export function parsePulse(body: unknown): PulseEvent | null {
     // never have been accepted in the first place, and rejecting it outright
     // would drop a real game over a corrupted counter.
     const clamped = Math.max(1, Math.min(Math.trunc(index), HOST_INDEX_CEILING));
-    return { kind: "game_started", hostGameIndex: clamped };
+    // Dropped rather than rejected when it is not one of the two known values,
+    // for the same reason the index above is clamped rather than rejected: the
+    // game is real either way, and losing the sub-mode costs one row of detail
+    // while losing the game costs the only number anyone reads. An unrecognised
+    // string must never survive to `mixed_pool:${value}` — that is the field
+    // that becomes a KV key.
+    return isMixedSubMode(raw.mixed)
+      ? { kind: "game_started", hostGameIndex: clamped, mixed: raw.mixed }
+      : { kind: "game_started", hostGameIndex: clamped };
   }
 
   return null;

--- a/lib/round-summary.ts
+++ b/lib/round-summary.ts
@@ -1,0 +1,73 @@
+/**
+ * What a finished Mixed Playlist game looked like, in three numbers.
+ *
+ * ## Why this exists at all
+ *
+ * `lib/round-history.ts` has been recording every round's outcome since v1.5
+ * and nothing but the taste card has ever read it. That is fine for an award,
+ * which only needs to name a winner, and useless for the question that actually
+ * decides what to build next: **how much of the scoring worked in this room.**
+ *
+ * A cross-culture party is where that question stops being academic. Two rooms
+ * can produce the same final scoreboard while one of them had a song title
+ * named almost every round and the other had the host tapping "No one" three
+ * times a round because nobody in the room had heard any of it. The scoreboard
+ * cannot tell those apart. This can, and it prints on the screen the host is
+ * already looking at, which is the only place a number gets read without
+ * someone deciding to go and find it.
+ *
+ * ## Read the counts, not a rate
+ *
+ * There is deliberately no percentage here. The denominator is rounds *played*,
+ * which is not rounds *possible* — a host who ends a game early leaves the rest
+ * unrecorded — so a rate would invite comparison between games of different
+ * lengths that were stopped for different reasons. Counts with their total
+ * stated are honest about being a description of one evening.
+ */
+
+import type { RoundHistoryEntry } from "@/lib/round-history";
+
+export interface RoundSummary {
+  /** Rounds that produced a history entry. Mixed-mode rounds only. */
+  played: number;
+  /**
+   * Rounds where nobody was awarded the song point.
+   *
+   * **Includes rounds the host skipped past without awarding anything**, which
+   * is why the field is named for what was recorded rather than for what the
+   * room knew. A host moving quickly and a room that genuinely could not name
+   * the track are indistinguishable here, and pretending otherwise would put a
+   * confident claim on the screen that the data cannot support.
+   */
+  unnamed: number;
+  /** Rounds where someone correctly named whose playlist the track came from. */
+  sourceCorrect: number;
+}
+
+export function summarizeRounds(history: readonly RoundHistoryEntry[]): RoundSummary {
+  let unnamed = 0;
+  let sourceCorrect = 0;
+
+  for (const entry of history) {
+    if (entry.songWinner === null) unnamed += 1;
+    if (entry.sourceWinner !== null) sourceCorrect += 1;
+  }
+
+  return { played: history.length, unnamed, sourceCorrect };
+}
+
+/**
+ * One line for the Game Over screen, or null when there is nothing to say.
+ *
+ * Null rather than a zero-filled sentence for the empty case: a game that
+ * recorded no rounds is a non-mixed game or an abandoned one, and printing
+ * "0 of 0 songs nobody could name" on either of them is noise dressed as a
+ * finding. The caller renders nothing.
+ */
+export function describeRounds(summary: RoundSummary): string | null {
+  if (summary.played === 0) return null;
+  return (
+    `${summary.unnamed} of ${summary.played} songs nobody could name` +
+    ` · ${summary.sourceCorrect} traced back to the right playlist`
+  );
+}

--- a/lib/taste-card.ts
+++ b/lib/taste-card.ts
@@ -72,7 +72,20 @@ export function computeMostObscure(history: RoundHistoryEntry[]): ObscureAward |
   for (const [playerName, totalTracks] of totals) {
     const correctAttributions = correct.get(playerName) ?? 0;
     const rate = correctAttributions / totalTracks;
-    if (!best || rate < best.rate) {
+    // The tiebreak is load-bearing, not tidiness. A cross-culture room is the
+    // case this award exists for and it is also the case where every rate is
+    // 0 — nobody places anybody's music — so `rate < best.rate` never fires and
+    // a plain scan hands the award to whichever name the Map happened to see
+    // first, i.e. whoever submitted earliest. That reads as a finding and is an
+    // accident of insertion order.
+    //
+    // More tracks wins, because twelve songs nobody could place is a stronger
+    // claim than three. `totalTracks` is already the count of that
+    // contributor's solo tracks that were actually played, so this needs no
+    // extra data and no signature change.
+    const better =
+      !best || rate < best.rate || (rate === best.rate && totalTracks > best.totalTracks);
+    if (better) {
       best = { playerName, correctAttributions, totalTracks, rate };
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "guesssong",
-  "version": "1.4.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "guesssong",
-      "version": "1.4.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-label": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guesssong",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/scripts/loop-stats.mjs
+++ b/scripts/loop-stats.mjs
@@ -19,14 +19,20 @@
  * that already lives in `lib/loop-stats.ts`, and that class of drift fails
  * silently — the script would read keys nobody writes and print a confident
  * table of zeros. Discovery also means a metric added later shows up here
- * without anyone remembering to update this file.
+ * without anyone remembering to update this file — though only as far as the
+ * renderers go, which is what the "Other counters" block at the bottom is for.
  *
  * The only shared knowledge is the `loop:stats:` prefix. If that ever changes
  * this prints "no counters found", which is loud rather than wrong.
  *
- * `KEYS` is the wrong tool on a large database. This namespace is a few
- * hundred keys with a 30-day TTL and the command runs by hand, so the usual
- * objection does not apply.
+ * **Discovery uses `SCAN`, not `KEYS`, and that is not a style preference.**
+ * `KEYS` matches against every key in the instance rather than every key under
+ * the prefix, so this namespace's size was never the relevant number:
+ * `lib/preview-cache.ts` writes one key per track and holds positive entries
+ * for a year, and when that set crossed Upstash's ceiling the server began
+ * refusing the command outright. `npm run stats` then exits 1 and prints
+ * nothing, for a reason with no connection to the loop. Anything that walks
+ * this namespace must page a cursor.
  *
  * Usage:
  *   npm run stats            # last 7 complete days
@@ -141,9 +147,43 @@ function pct(numerator, denominator) {
   return `${((numerator / denominator) * 100).toFixed(1).padStart(5)}%`;
 }
 
+/**
+ * Every key under the prefix, walked with `SCAN` rather than `KEYS`.
+ *
+ * `KEYS` was correct about this namespace and wrong about the database. The
+ * loop counters are a few hundred keys with a 30-day TTL — but `KEYS` matches
+ * against *every* key in the instance, and `lib/preview-cache.ts` writes one
+ * per track and holds positive entries for a year. That set grows with the
+ * catalogue, not with the loop, and when it crossed Upstash's ceiling the
+ * server started refusing the command outright:
+ *
+ *     ERR KEYS command is disabled because total number of keys is too large
+ *
+ * The failure mode is what makes this worth the extra code. It is not a slow
+ * report or a partial one: `npm run stats` exits 1 and prints nothing, and it
+ * does so for a reason that has nothing to do with the loop. The one instrument
+ * anybody actually reads went dark because a different namespace grew.
+ *
+ * `SCAN` is O(1) per call and cursor-paged, so it never trips that ceiling.
+ * `MATCH` is applied server-side but *after* the per-call sample, so a page may
+ * legitimately come back empty while the cursor is still non-zero — stopping on
+ * an empty page instead of on cursor 0 is the classic way to read a fraction of
+ * a namespace and report it as the whole thing. `COUNT` is a hint, not a limit.
+ */
+async function scanKeys(match) {
+  const found = [];
+  let cursor = "0";
+  do {
+    const [next, batch] = await redis(["SCAN", cursor, "MATCH", match, "COUNT", "1000"]);
+    cursor = String(next);
+    if (Array.isArray(batch)) found.push(...batch);
+  } while (cursor !== "0");
+  return found;
+}
+
 let keys;
 try {
-  keys = (await redis(["KEYS", `${PREFIX}*`])) ?? [];
+  keys = await scanKeys(`${PREFIX}*`);
 } catch (err) {
   console.error(`\n${err instanceof Error ? err.message : String(err)}\n`);
   process.exit(1);
@@ -157,7 +197,16 @@ if (keys.length === 0) {
   process.exit(0);
 }
 
-const values = await redis(["MGET", ...keys]);
+/**
+ * Chunked because the REST transport puts the whole command in one request, so
+ * a single `MGET` over the namespace grows a request body without bound. 30
+ * days times the metric count is already a few hundred keys and the metric
+ * count only goes up.
+ */
+const values = [];
+for (let i = 0; i < keys.length; i += 256) {
+  values.push(...((await redis(["MGET", ...keys.slice(i, i + 256)])) ?? []));
+}
 const window = new Set(bucketsFor(days));
 
 /** metric -> total, and the set of days that recorded anything at all. */
@@ -237,6 +286,38 @@ if (indices.length > 0) {
     const count = get(`host_index:${n}`);
     const bar = "█".repeat(Math.min(40, Math.round((count / games) * 40)));
     console.log(`  ${String(n).padStart(2)}${n === 10 ? "+" : " "} ${String(count).padStart(5)}  ${bar}`);
+  }
+}
+
+/**
+ * Anything discovered under `loop:stats:` that no block above consumed.
+ *
+ * `KEYS` finds every metric, but every renderer above is written against one
+ * specific key shape, so until this existed a newly added counter was read,
+ * summed, and then silently dropped — and the header of this file promised the
+ * opposite ("a metric added later appears here without anyone editing the
+ * script"). It was true of the discovery and false of the output, which is the
+ * worst place for that split: the number looks like a zero rather than like a
+ * missing renderer, and zero is a real answer here.
+ *
+ * Printing the leftovers generically costs a few lines and closes the class.
+ * A metric that deserves better framing than a raw count gets its own block
+ * above and drops out of this one by being consumed.
+ */
+const RENDERED_EXACT = new Set(["live", "games", "repeat_host", "throttled"]);
+const RENDERED_PREFIXES = ["impression:", "click:", "host_index:"];
+
+const leftovers = [...totals.keys()]
+  .filter(
+    (m) =>
+      !RENDERED_EXACT.has(m) && !RENDERED_PREFIXES.some((p) => m.startsWith(p))
+  )
+  .sort();
+
+if (leftovers.length > 0) {
+  console.log("\nOther counters");
+  for (const metric of leftovers) {
+    console.log(`  ${metric.padEnd(24)}${String(get(metric)).padStart(6)}`);
   }
 }
 

--- a/tests/loop-stats.test.ts
+++ b/tests/loop-stats.test.ts
@@ -20,6 +20,7 @@ vi.mock("@/lib/kv", () => ({
 const {
   HOST_INDEX_CEILING,
   LOOP_STATS_TTL_SECONDS,
+  MIXED_SUB_MODES,
   loopStatsKeys,
   recordGameStart,
   recordLoopClick,
@@ -59,6 +60,12 @@ describe("the key format is the contract between writer and reader", () => {
     await recordGameStart(3);
     expect(keysWritten()).toContain(expected.games);
     expect(keysWritten()).toContain(expected.hostIndex[2]); // host_index:3
+
+    for (const mixed of ["room", "phone"] as const) {
+      kv.incrs = [];
+      await recordGameStart(1, mixed);
+      expect(keysWritten()).toContain(expected.mixedPool[mixed]);
+    }
   });
 
   it("covers every surface on both sides", () => {
@@ -70,6 +77,17 @@ describe("the key format is the contract between writer and reader", () => {
       expect(keys.clicks[surface]).toBe(`loop:stats:2026-08-09:click:${surface}`);
     }
     expect(keys.hostIndex).toHaveLength(HOST_INDEX_CEILING);
+  });
+
+  it("names a key for every declared mixed sub-mode", () => {
+    // The union and the key map are two places one list has to be right, and
+    // adding a member to the union while forgetting the map fails nothing at
+    // runtime — the counter just never appears.
+    const keys = loopStatsKeys("2026-08-09", LOOP_SURFACES);
+    for (const mode of MIXED_SUB_MODES) {
+      expect(keys.mixedPool[mode]).toBe(`loop:stats:2026-08-09:mixed_pool:${mode}`);
+    }
+    expect(Object.keys(keys.mixedPool)).toHaveLength(MIXED_SUB_MODES.length);
   });
 });
 
@@ -108,6 +126,28 @@ describe("the liveness marker", () => {
     const marker = kv.incrs.filter((i) => i.key === live);
     expect(marker).toHaveLength(1);
     expect(kv.incrs).toHaveLength(4);
+  });
+
+  it("adds exactly one command for a mixed game, and none for any other", async () => {
+    // The rejected design was a second pulse event for the pool, which would
+    // have carried its own liveness marker: eight commands for a repeat host's
+    // mixed game where this costs five. Pinning the number is what stops that
+    // creeping back in as "just one more counter".
+    await recordGameStart(2, "room");
+    expect(kv.incrs).toHaveLength(5);
+
+    // Reset the marker memo so the second call pays for it too, otherwise the
+    // comparison is 5-with-a-marker against 3-without and measures the memo
+    // rather than the mixed counter.
+    kv.incrs = [];
+    __resetLivenessForTests();
+    await recordGameStart(2);
+    expect(kv.incrs).toHaveLength(4);
+  });
+
+  it("does not write a mixed key for a single-playlist game", async () => {
+    await recordGameStart(1);
+    expect(keysWritten().some((k) => k.includes("mixed_pool"))).toBe(false);
   });
 
   it("retries the marker on a later event when its write failed", async () => {

--- a/tests/mix-export.test.ts
+++ b/tests/mix-export.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { formatMixList } from "@/lib/mix-export";
+import type { Track } from "@/types";
+
+function track(overrides: Partial<Track> = {}): Track {
+  return {
+    id: "t1",
+    name: "Tusa",
+    artists: ["KAROL G"],
+    durationMs: 200_000,
+    createdAt: "2026-08-14T00:00:00.000Z",
+    contributors: ["Ana"],
+    ...overrides,
+  };
+}
+
+describe("formatMixList", () => {
+  it("puts the playlist name, the count and the whole roster at the top", () => {
+    const out = formatMixList({
+      tracks: [track()],
+      contributorNames: ["Ana", "Ben"],
+      playlistName: "2-Player Mix",
+    });
+    expect(out.split("\n")[0]).toBe("2-Player Mix · guessong.app");
+    expect(out.split("\n")[1]).toBe("1 song from Ana, Ben");
+  });
+
+  it("numbers the tracks and credits whoever brought each one", () => {
+    const out = formatMixList({
+      tracks: [
+        track({ id: "a", name: "Tusa", artists: ["KAROL G"], contributors: ["Ana"] }),
+        track({ id: "b", name: "Hey Jude", artists: ["The Beatles"], contributors: ["Ben"] }),
+      ],
+      contributorNames: ["Ana", "Ben"],
+      playlistName: "2-Player Mix",
+    });
+    expect(out).toContain("1. Tusa — KAROL G (Ana)");
+    expect(out).toContain("2. Hey Jude — The Beatles (Ben)");
+  });
+
+  it("credits every contributor of a shared track", () => {
+    const out = formatMixList({
+      tracks: [track({ contributors: ["Ana", "Ben", "Carla"] })],
+      contributorNames: ["Ana", "Ben", "Carla"],
+      playlistName: "3-Player Mix",
+    });
+    expect(out).toContain("(Ana, Ben & Carla)");
+  });
+
+  it("names a contributor whose playlist was sampled down to nothing", () => {
+    // The whole reason the roster is passed in rather than derived from the
+    // tracks. Sampling fills to a target and stops, so with enough people
+    // somebody gets zero — and deriving the roster would delete them from the
+    // record of an evening they took part in.
+    const out = formatMixList({
+      tracks: [track({ contributors: ["Ana"] })],
+      contributorNames: ["Ana", "Dev"],
+      playlistName: "2-Player Mix",
+    });
+    expect(out).toContain("Ana, Dev");
+    expect(out).toContain("Dev submitted a playlist but none of it made this round.");
+  });
+
+  it("lists several empty-handed contributors in one sentence", () => {
+    const out = formatMixList({
+      tracks: [track({ contributors: ["Ana"] })],
+      contributorNames: ["Ana", "Dev", "Eve"],
+      playlistName: "3-Player Mix",
+    });
+    expect(out).toContain(
+      "Dev and Eve submitted playlists but none of them made this round."
+    );
+  });
+
+  it("says nothing about empty hands when everyone landed something", () => {
+    const out = formatMixList({
+      tracks: [
+        track({ id: "a", contributors: ["Ana"] }),
+        track({ id: "b", contributors: ["Ben"] }),
+      ],
+      contributorNames: ["Ana", "Ben"],
+      playlistName: "2-Player Mix",
+    });
+    expect(out).not.toContain("none of it made");
+    expect(out).not.toContain("none of them made");
+  });
+
+  it("still names the people when the pool is empty", () => {
+    const out = formatMixList({
+      tracks: [],
+      contributorNames: ["Ana", "Ben"],
+      playlistName: "2-Player Mix",
+    });
+    expect(out).toContain("0 songs from Ana, Ben");
+    expect(out).toContain("Ana and Ben submitted playlists");
+  });
+
+  it("survives a missing roster and missing credits without throwing", () => {
+    const out = formatMixList({
+      tracks: [track({ contributors: undefined })],
+      contributorNames: [],
+      playlistName: "Mix",
+    });
+    expect(out).toContain("1 song");
+    expect(out).toContain("1. Tusa — KAROL G");
+  });
+
+  it("drops blank names from the roster instead of printing a gap", () => {
+    const out = formatMixList({
+      tracks: [track()],
+      contributorNames: ["Ana", "   ", ""],
+      playlistName: "Mix",
+    });
+    expect(out.split("\n")[1]).toBe("1 song from Ana");
+  });
+
+  it("truncates a title long enough to wrap a phone message", () => {
+    const long = "A".repeat(120);
+    const out = formatMixList({
+      tracks: [track({ name: long })],
+      contributorNames: ["Ana"],
+      playlistName: "Mix",
+    });
+    expect(out).toContain("…");
+    expect(out).not.toContain(long);
+  });
+
+  it("pads the numbering so a three-digit pool still lines up", () => {
+    // 144 is the real ceiling: 12 contributors times the largest per-player
+    // sample.
+    const tracks = Array.from({ length: 100 }, (_, i) =>
+      track({ id: `t${i}`, name: `Song ${i}` })
+    );
+    const out = formatMixList({ tracks, contributorNames: ["Ana"], playlistName: "Mix" });
+    expect(out).toContain("  1. Song 0");
+    expect(out).toContain("100. Song 99");
+  });
+
+  it("handles a track with no artist credit", () => {
+    const out = formatMixList({
+      tracks: [track({ artists: [] })],
+      contributorNames: ["Ana"],
+      playlistName: "Mix",
+    });
+    expect(out).toContain("1. Tusa (Ana)");
+  });
+});

--- a/tests/pulse.test.ts
+++ b/tests/pulse.test.ts
@@ -51,6 +51,39 @@ describe("parsePulse — game starts", () => {
   });
 });
 
+describe("parsePulse — the mixed sub-mode", () => {
+  it("accepts both declared sub-modes", () => {
+    for (const mixed of ["room", "phone"] as const) {
+      expect(parsePulse({ kind: "game_started", hostGameIndex: 1, mixed })).toEqual({
+        kind: "game_started",
+        hostGameIndex: 1,
+        mixed,
+      });
+    }
+  });
+
+  it("omits the field entirely on a single-playlist game", () => {
+    const parsed = parsePulse({ kind: "game_started", hostGameIndex: 1 });
+    expect(parsed).toEqual({ kind: "game_started", hostGameIndex: 1 });
+    expect(parsed && "mixed" in parsed).toBe(false);
+  });
+
+  it("drops an undeclared sub-mode rather than letting it reach a KV key", () => {
+    // `mixed_pool:${value}` is a key. An unbounded string arriving there is how
+    // an unauthenticated endpoint turns a counter namespace into a bill.
+    for (const bad of ["Room", "qr", "", "__proto__", 1, true, null, {}]) {
+      const parsed = parsePulse({ kind: "game_started", hostGameIndex: 1, mixed: bad });
+      expect(parsed).toEqual({ kind: "game_started", hostGameIndex: 1 });
+    }
+  });
+
+  it("keeps the game when only the sub-mode is corrupt", () => {
+    // Same trade as the index clamp above: the game is real either way, and
+    // losing one row of detail beats losing the number anyone reads.
+    expect(parsePulse({ kind: "game_started", hostGameIndex: 4, mixed: "nonsense" })).not.toBeNull();
+  });
+});
+
 describe("parsePulse — everything else", () => {
   it("rejects bodies that are not objects", () => {
     for (const bad of [null, undefined, 0, "", "kind", [], true]) {
@@ -71,6 +104,21 @@ describe("parsePulse — everything else", () => {
       hostGameIndex: 99,
     });
     expect(parsed).toEqual({ kind: "loop_impression", surface: "share" });
+  });
+
+  it("still strips unknown fields now that one optional field is legitimate", () => {
+    // `mixed` became a real field on `game_started`, and the risk in adding the
+    // first optional member to a shape that had none is that the parser stops
+    // being a whitelist and starts being a passthrough. This pins that only the
+    // named field survives — including on the event that declares it.
+    const parsed = parsePulse({
+      kind: "game_started",
+      hostGameIndex: 2,
+      mixed: "room",
+      evil: "<script>",
+      surface: "share",
+    });
+    expect(parsed).toEqual({ kind: "game_started", hostGameIndex: 2, mixed: "room" });
   });
 
   it("is not fooled by a prototype-polluting body", () => {

--- a/tests/round-summary.test.ts
+++ b/tests/round-summary.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { describeRounds, summarizeRounds } from "@/lib/round-summary";
+import type { RoundHistoryEntry } from "@/lib/round-history";
+
+function round(overrides: Partial<RoundHistoryEntry> = {}): RoundHistoryEntry {
+  return {
+    trackId: "t1",
+    contributors: ["Ana"],
+    songWinner: null,
+    albumWinner: null,
+    sourceWinner: null,
+    ...overrides,
+  };
+}
+
+describe("summarizeRounds", () => {
+  it("counts rounds nobody named and rounds traced to the right playlist", () => {
+    const summary = summarizeRounds([
+      round({ songWinner: "Ana", sourceWinner: "Ben" }),
+      round({ songWinner: null, sourceWinner: "Ana" }),
+      round({ songWinner: null, sourceWinner: null }),
+    ]);
+    expect(summary).toEqual({ played: 3, unnamed: 2, sourceCorrect: 2 });
+  });
+
+  it("returns zeroes for no history rather than dividing by nothing", () => {
+    expect(summarizeRounds([])).toEqual({ played: 0, unnamed: 0, sourceCorrect: 0 });
+  });
+
+  it("counts every round unnamed when the room could not place any of it", () => {
+    // The cross-culture case, and the one the whole line exists to make visible:
+    // a scoreboard full of zeroes looks the same as a broken game.
+    const summary = summarizeRounds([round(), round(), round(), round()]);
+    expect(summary).toEqual({ played: 4, unnamed: 4, sourceCorrect: 0 });
+  });
+
+  it("counts every round named when the room knew all of it", () => {
+    const summary = summarizeRounds([
+      round({ songWinner: "Ana", sourceWinner: "Ana" }),
+      round({ songWinner: "Ben", sourceWinner: "Ben" }),
+    ]);
+    expect(summary).toEqual({ played: 2, unnamed: 0, sourceCorrect: 2 });
+  });
+
+  it("ignores the album point, which is not what this line is about", () => {
+    const summary = summarizeRounds([round({ albumWinner: "Ana" })]);
+    expect(summary).toEqual({ played: 1, unnamed: 1, sourceCorrect: 0 });
+  });
+});
+
+describe("describeRounds", () => {
+  it("names both counts against the total played", () => {
+    expect(describeRounds({ played: 20, unnamed: 14, sourceCorrect: 6 })).toBe(
+      "14 of 20 songs nobody could name · 6 traced back to the right playlist"
+    );
+  });
+
+  it("returns null with nothing recorded, so the caller renders nothing", () => {
+    // A non-mixed game never fills the history, and "0 of 0 songs nobody could
+    // name" is noise wearing the costume of a finding.
+    expect(describeRounds({ played: 0, unnamed: 0, sourceCorrect: 0 })).toBeNull();
+  });
+
+  it("still speaks when every round was a blank", () => {
+    expect(describeRounds({ played: 12, unnamed: 12, sourceCorrect: 0 })).toBe(
+      "12 of 12 songs nobody could name · 0 traced back to the right playlist"
+    );
+  });
+});

--- a/tests/taste-card.test.ts
+++ b/tests/taste-card.test.ts
@@ -72,6 +72,51 @@ describe("computeMostObscure", () => {
     expect(result?.rate).toBe(1);
   });
 
+  it("breaks an all-zero tie by who contributed more, not by insertion order", () => {
+    // The cross-culture room: nobody places anybody's music, so every rate is 0
+    // and a plain `rate < best.rate` scan never fires. Before the tiebreak this
+    // crowned whoever the Map saw first, i.e. whoever submitted earliest — an
+    // award that reads as a finding and is an accident of ordering.
+    const award = computeMostObscure([
+      { trackId: "a1", contributors: ["Ana"], songWinner: null, albumWinner: null, sourceWinner: null },
+      { trackId: "b1", contributors: ["Ben"], songWinner: null, albumWinner: null, sourceWinner: null },
+      { trackId: "b2", contributors: ["Ben"], songWinner: null, albumWinner: null, sourceWinner: null },
+      { trackId: "b3", contributors: ["Ben"], songWinner: null, albumWinner: null, sourceWinner: null },
+    ]);
+    expect(award).toEqual({
+      playerName: "Ben",
+      correctAttributions: 0,
+      totalTracks: 3,
+      rate: 0,
+    });
+  });
+
+  it("still prefers the lower rate over the larger sample", () => {
+    // The tiebreak must only apply on an exact tie. Ana at 0/1 is more obscure
+    // than Ben at 5/10 however many tracks Ben brought.
+    const history = [
+      { trackId: "a1", contributors: ["Ana"], songWinner: null, albumWinner: null, sourceWinner: null },
+      ...Array.from({ length: 10 }, (_, i) => ({
+        trackId: `b${i}`,
+        contributors: ["Ben"],
+        songWinner: null,
+        albumWinner: null,
+        sourceWinner: i < 5 ? "Ana" : null,
+      })),
+    ];
+    expect(computeMostObscure(history)?.playerName).toBe("Ana");
+  });
+
+  it("is stable when the rate and the track count both tie", () => {
+    const history = [
+      { trackId: "a1", contributors: ["Ana"], songWinner: null, albumWinner: null, sourceWinner: null },
+      { trackId: "b1", contributors: ["Ben"], songWinner: null, albumWinner: null, sourceWinner: null },
+    ];
+    const first = computeMostObscure(history);
+    expect(first).not.toBeNull();
+    expect(computeMostObscure(history)).toEqual(first);
+  });
+
   it("returns null with no history", () => {
     expect(computeMostObscure([])).toBeNull();
   });


### PR DESCRIPTION
Mixed Playlist Mode was invisible to `npm run stats`, and `npm run stats` was about to stop working entirely. Both are fixed here, plus two taste-card defects that fire precisely in a mixed-nationality room and the artifact a group event actually wants.

Design doc: `~/.gstack/projects/Waynting-GuessSong/waynliu-main-design-20260813-231427.md` (APPROVED, 2 rounds adversarial review 6/10 → 8/10). Eng review reduced the scope: `game_over` impression dedupe and `contributorCount` were both cut.

## The reader was broken, and had been wrong before it broke

Running `npm run stats` mid-release returned nothing but:

```
ERR KEYS command is disabled because total number of keys is too large, please use SCAN
```

`KEYS` matches against **every key in the instance**, not every key under the prefix — so this namespace's few hundred keys were never the deciding number. `lib/preview-cache.ts` writes one key per track and holds positive entries for a year, and that set crossing Upstash's ceiling took the whole report down for a reason with no connection to the loop.

**It had been silently truncating first.** The same seven-day window, read minutes apart:

| | `KEYS` | `SCAN` |
|---|---|---|
| Days with any activity | 5/7 | 7/7 |
| Games started | 4918 | 6740 |
| `join_submitted` | 42/19 — 45.2% | 92/30 — 32.6% |
| `game_over` | 936/8 — 0.9% | 1274/10 — 0.8% |

Two whole days of liveness markers were missing, so the report printed "5/7" — which `docs/viral-loop.md` §7 says to read as a plumbing problem rather than a result. **Every figure quoted from a pre-fix run is a partial sum.** The relative ordering of the surfaces survived; the levels did not.

`MGET` is chunked at 256 for the neighbouring reason: the REST transport puts the whole command in one request body.

## Mixed games now reach KV

`join_submitted` is rendered only by `app/j/[code]/page.tsx`, and `roomJoinUrl` sends players to `/buzz/[code]?p=1` whenever the buzzer is on (`lib/room-client.ts:125-127`). So a QR room with a buzzer — the ordinary configuration — and the entire `phone` sub-mode wrote to no counter anywhere.

**One optional field, not a new event.** `recordHostedStart` (`app/page.tsx`) already beacons `game_started` from all three start paths, so a mixed game was already reaching KV; only the discriminator was missing. A separate `mixed_pool_built` event was designed and rejected: it would have described one occurrence twice and cost a mixed game eight KV commands where this costs five.

`MixedSubMode` and `MIXED_SUB_MODES` live in `lib/loop-stats.ts` beside `HOST_INDEX_CEILING`, because that module owns the `loop:stats:` key space and these two strings become the tail of a key. `parsePulse` drops an unrecognised value rather than rejecting the body — the game is real either way, and `mixed_pool:${anything}` from an unauthenticated endpoint is how a counter namespace becomes a bill. `app/page.tsx` had a local copy of the same union; it now imports the canonical one.

## New: a generic "Other counters" block

`KEYS`/`SCAN` discovery already found every metric, but every renderer was written against one key shape, so a newly added counter was read, summed and **silently dropped** — while the file header promised the opposite. The number then looks like a zero rather than like a missing renderer, and zero is a real answer here. Closing it generically means the next metric never hits this.

## New: the mix comes back, and the round tally goes up

- **`lib/round-summary.ts`** — the per-round line under the final scores. Counts, never a rate: the denominator is rounds *played*, not rounds possible.
- **`lib/mix-export.ts`** — the merged tracklist as copyable text. **The roster is passed in rather than derived from the tracks**, so a contributor sampled to zero tracks is still named. `poolContributions` fills to a target and stops, so with enough contributors somebody gets zero — and they queued, scanned, and handed over their music. Text rather than a Spotify playlist because creating one needs user OAuth, and having no accounts is the product's premise.

Both in `lib/` because the suite only reaches `lib/`, the same reason `lib/song-count.ts` and `lib/room-poll.ts` live there.

## Fixed

- **The taste card drew an `AWARDS` heading over nothing.** `sharedSectionH` was guarded, the awards section was not — so a group with no shared songs and no popularity data got a heading and blank space, which is precisely the cross-culture case the card is most likely to be saved from.
- **`computeMostObscure` crowned whoever the Map saw first on an all-zero tie.** Every rate is 0 when nobody places anybody's music, so `rate < best.rate` never fired and the award went to whoever submitted earliest. Now breaks the tie on contributed-track count, using the `totals` map the function already builds.
- **`mixedPlaylistMeta` had no reader** since 1.2, so a contributor sampled to zero tracks was invisible to everyone including themselves. `formatMixList` is its first.
- **Five files documented a weekly digest that was never built.** `lib/kv.ts:74` named `lib/digest.ts` specifically. This cost two wrong conclusions during the review that produced this PR.

## Verification

- `npm test` — 459 passing (+31), including a regression test for `parsePulse` still stripping unknown fields now that one optional field is legitimate
- `npx tsc --noEmit` clean, `npm run lint` clean
- `npm run build` route table unchanged: `/icon` and `/opengraph-image` are `○`, `/icons/[size]` is `●` with all three sizes
- `npm run stats` verified against production KV — it prints again

## Known gaps

- **A room is still single-use.** `consumeRoomPool` claims `consumed` and the room dies (`lib/room.ts:427`); TTL counts from creation. A second game at the same party needs everyone to re-scan.
- **`game_over` impressions are undercounted**, so its 0.8% is *overstated*. Deferred deliberately: the fix collides with the documented `share`/`game_over` dedupe parity at `app/game/page.tsx:83-85` and no decision turns on it.
- **The `+2` source guess still has no buzzer affordance** — the most distinctive mechanic is the one part the host referees by hand.
- **`ROOM_MAX_SUBMISSIONS` and `BUZZER_MAX_PLAYERS` are both 12** and unverified against the actual retreat headcount. Raising the latter is a Worker deploy: the constant is shared verbatim with `worker/src/buzzer-room.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)