### PR TITLE
v1.7.0 feat: guides section and policy pages for AdSense compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,104 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2026-08-21
+
+AdSense refused the site under "Low value content" (缺乏價值的內容). This release
+is the response: the policy pages the review looks for, and enough editorial
+content that the site is something other than a form.
+
+The diagnosis was not subtle. `app/robots.ts` disallows `/game`, `/api`,
+`/share`, `/buzz`, `/j` and `/r`, which leaves exactly three indexable URLs —
+`/`, `/about`, `/zh`. `/zh` is `/` in another language and `/about` repeats
+`/`'s FAQ almost verbatim, so the site's unique indexable surface was closer to
+one and a half pages. The homepage's entire prose was the two paragraphs under
+"What is GuessSong?" plus six FAQ answers; everything else on it is form
+controls. And there was no privacy policy at all, on a site whose
+`app/layout.tsx` loads both AdSense and GA4 — that alone is disqualifying, and
+it is the item most likely to have triggered the category.
+
+Eight guides is a judgement, not a target: enough that `/guides` reads as a
+section rather than a gesture, and few enough that every one of them could be
+written from something this project actually knows. Two of them
+(`spotify-playlist-not-working`, `why-spotify-previews-disappeared`) are the
+measured findings already recorded in this file and in CLAUDE.md — the 0/20
+preview result across four markets, the `37i9` 404, the `403`-not-`429`
+throttling signal, the `absent`/`unavailable` distinction. That content exists
+nowhere else, which is the actual bar the policy is asking about.
+
+### Added
+
+- **`/guides` and eight articles under it.** `app/guides/page.tsx` is the index;
+  each article is a real static route at `app/guides/<slug>/page.tsx`. Metadata
+  is declared once in `lib/guides.ts` and derived from there by the route, the
+  index, `app/sitemap.ts` and the "read next" links — the four-copy hand-sync
+  that `lib/loop-links.ts` exists to avoid, and it fails the same silent way
+  here (a guide missing from the sitemap is a page Google never returns for).
+- **`app/guides/guide-shell.tsx`** — wraps every article: title, canonical,
+  dateline, `Article` JSON-LD, related links and closing CTA, all from the slug.
+  `requireGuide` *throws* on an unknown slug rather than rendering a page with
+  holes in it. The slug is written by us in the same file as the prose, so a bad
+  one is a typo that should fail the build, never a visitor's 404. That half —
+  `requireGuide`, `guideMetadata`, `formatGuideDate` — lives in `lib/guides.ts`
+  rather than beside the component, for the reason `lib/song-count.ts` gives:
+  the suite only reaches `lib/`, and a `.tsx` module cannot be imported from it.
+  What stayed in the shell is the part that is actually JSX.
+- **`/privacy`, `/terms`, `/contact`, `/zh/privacy`, `/zh/terms`.** Written
+  against what the code actually does — Client Credentials meaning Spotify is
+  never told who is asking, title-and-artist being all that reaches iTunes and
+  Deezer, room records carrying an expiry from creation, rate-limit counters
+  living for the length of one window. A template would have been faster and
+  wrong in ways a reviewer can check.
+- **`components/site-footer.tsx`** — one footer for the whole site, and the only
+  place the policy pages are linked from. Replaces three hand-rolled `<footer>`
+  blocks in `app/page.tsx`, `app/about/page.tsx` and `app/zh/page.tsx`.
+- **`components/article-shell.tsx`** — shared prose chrome. Server component
+  with no client boundary; these pages are static text and a React state import
+  would cost a bundle for nothing.
+- **`lib/legal.ts`** — the one "last updated" date the four policy pages print.
+  A literal, not a build timestamp: it has to mean "the day the wording changed",
+  not "the day this deployed".
+- **`tests/guides.test.ts`, `tests/site-policy.test.ts`** — 38 assertions over
+  the joins that fail silently. Every slug has a directory and vice versa; every
+  article's `SLUG` constant matches its own path (a copy-pasted article that kept
+  the source's constant renders the wrong canonical under the right URL); every
+  guide has at least one inbound sibling link; the sitemap lists all of them;
+  both privacy pages name AdSense, Analytics and cookies and carry the opt-out
+  link; the `/zh` footer contains no English label; `robots.ts` does not
+  disallow any of the new paths.
+
+### Changed
+
+- `app/sitemap.ts` derives the guide entries from `lib/guides.ts` and adds the
+  five policy URLs, with `hreflang` declared on both sides of each language pair.
+- `app/page.tsx` gains a three-card guides teaser under the FAQ, resolved through
+  `getGuide` rather than retyped, and filtered so a retired slug costs a card
+  instead of crashing the homepage.
+- `app/about/page.tsx` gains a section listing all eight.
+
+### Not done
+
+- **The guides are English only.** `/zh` is written natively rather than
+  translated, so eight translated articles under it would be the one seam in the
+  thing that page is for. The policy pages are bilingual because those have to
+  be readable by the person they bind; the guides can wait for someone to write
+  them in Chinese rather than render them in it.
+- **No `dateModified` maintenance.** `guide-shell.tsx` emits `dateModified`
+  equal to `datePublished`. Correct today, quietly wrong the first time an
+  article is edited. It wants a second field in `lib/guides.ts`, not a build
+  timestamp.
+
+### Known gaps
+
+- Nothing verifies that a guide's prose is still about what its `description`
+  claims. The tests pin the plumbing, not the writing.
+- `GUIDE_CATEGORIES` is ordered by hand. A category added to the union but not
+  to that array makes its guides unreachable from `/guides`; the partition test
+  in `tests/guides.test.ts` is what catches it, not the compiler.
+- The `/zh` footer links to `/guides`, which is English. Labelled in Chinese,
+  lands in English. Better than hiding the section from Chinese readers, but it
+  is a seam.
+
 ## [1.6.0] - 2026-08-15
 
 Mixed Playlist Mode gets an artifact and an instrument, and the loop counters

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,21 @@ Production domain is `https://www.guessong.app` (fallback in `app/layout.tsx`, `
 
 After touching any of them, check `npm run build`'s route table: `/icon` and `/opengraph-image` must be `○`, `/icons/[size]` must be `●` with all three sizes listed under it. An `ƒ` there is the regression.
 
+### Content pages — the guides, and the policy pages AdSense looks for
+
+`/guides` and its articles, plus `/privacy`, `/terms`, `/contact` and the `/zh` half of the first two, exist because AdSense refused the site under "Low value content" in August 2026. Before them the site had three indexable URLs, two of which were near-duplicates of the first, and no privacy policy at all on a page loading both AdSense and GA4. `CHANGELOG.md` 1.7.0 has the full diagnosis.
+
+Four rules hold this together, and each replaces something that fails silently:
+
+- **`lib/guides.ts` declares a guide once, and four things derive from it** — the route, the `/guides` index, `app/sitemap.ts`, and the "read next" links on its siblings. Hand-syncing those fails the same way `lib/loop-links.ts` does: a guide missing from the sitemap is a page Google never comes back for, and nothing on screen says so. `tests/guides.test.ts` asserts every slug has a directory and vice versa, that each article's own `SLUG` constant matches its path (a copy-pasted article that kept the source's constant renders the wrong canonical under the right URL), and that every guide has at least one inbound sibling link.
+- **`requireGuide`, `guideMetadata` and `formatGuideDate` live in `lib/guides.ts`, not beside the component that calls them.** Same reason `lib/song-count.ts` gives: the suite only reaches `lib/`, and vitest cannot import a `.tsx` module here. `app/guides/guide-shell.tsx` re-exports `guideMetadata` and keeps only the JSX. Moving that logic back into the shell silently drops it out of test range.
+- **`components/site-footer.tsx` is the only place the policy pages are linked from.** It replaced three hand-rolled `<footer>` blocks. A reviewer — Google's or a player's — looks for the privacy policy in the footer, and a page that omits it reads as a page that does not have one; three copies is three chances for one page to lose the link by being edited alone. `tests/site-policy.test.ts` pins that all three landing pages render it, that both privacy pages name AdSense, Analytics and cookies and carry the opt-out link, and that the `/zh` footer contains no English label.
+- **`CATEGORY_BLURB` in `app/guides/page.tsx` is keyed by `GuideCategory`, not `string`.** A new category with no blurb has to be a compile error, not an `undefined` rendered under the heading — the same rule `lib/error-messages.ts` follows for its translation table. `GUIDE_CATEGORIES` is still ordered by hand, and a category added to the union but not to that array makes its guides unreachable from `/guides`; the partition test is what catches that, not the compiler.
+
+**The guides are English only, deliberately.** `/zh` is written natively rather than translated, so eight translated articles under it would be the one seam in the thing that page is for. The policy pages are bilingual because those have to be readable by the person they bind. `/zh`'s footer links to `/guides` under a Chinese label and lands in English — a known seam, kept because hiding the section from Chinese readers is worse.
+
+`/guides`, `/privacy`, `/terms` and `/contact` must stay out of `app/robots.ts`'s disallow list. That list is for ephemeral room codes and the counting redirect; a content page landing in it would be invisible to exactly the crawler it was written for. `tests/site-policy.test.ts` asserts this.
+
 ## Environment Variables
 
 ```

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ app/
   game/page.tsx              The game — phase machine, playback, scoring, result images
   about/                     "How to play" page
   zh/                        Traditional-Chinese landing page (written natively, not translated)
+  guides/                    Guides index + eight articles (metadata declared in lib/guides.ts)
+  privacy/, terms/, contact/ Policy pages; zh/privacy and zh/terms are the Chinese halves
   j/[code]/                  Mixed Playlist Mode join page
   buzz/[code]/               Buzzer Mode player page (holds the live WebSocket)
   share/                     Web Share Target handler + /share/unsupported explainer

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { REPORT_PROBLEM_MAILTO } from "@/lib/contact";
-import { ChangelogModal } from "@/components/changelog-modal";
+import { SiteFooter } from "@/components/site-footer";
+import { GUIDES } from "@/lib/guides";
 
 export const metadata: Metadata = {
   title: "How to Play the Guess the Song Game",
@@ -572,6 +572,25 @@ export default function AboutPage() {
             </div>
           </section>
 
+          {/* Guides */}
+          <section className="fade-in fade-in-6">
+            <p className="eyebrow" style={{ marginBottom: "8px" }}>Guides</p>
+            <h2 className="section-title" style={{ marginBottom: "12px" }}>Go deeper</h2>
+            <p style={{ color: "#999", fontSize: "14px", fontWeight: 300, lineHeight: 1.6, marginBottom: "20px", maxWidth: "560px" }}>
+              This page covers the rules. These cover the evening — what to put on, how hard
+              to set it, how to score it so the last round still matters, and what to do when
+              a playlist refuses to load.
+            </p>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: "12px" }}>
+              {GUIDES.map((guide) => (
+                <Link key={guide.slug} href={`/guides/${guide.slug}`} className="card feature-card" style={{ textDecoration: "none" }}>
+                  <p className="feature-title">{guide.navTitle}</p>
+                  <p className="feature-desc">{guide.description}</p>
+                </Link>
+              ))}
+            </div>
+          </section>
+
           {/* Star CTA */}
           <section className="fade-in fade-in-6">
             <div className="star-banner">
@@ -598,23 +617,7 @@ export default function AboutPage() {
             </div>
           </section>
 
-          {/* Footer */}
-          <footer style={{ textAlign: "center", paddingTop: "8px", borderTop: "1px solid var(--border)" }}>
-            <div
-              style={{
-                padding: "20px 0 4px",
-                display: "flex",
-                gap: "10px",
-                justifyContent: "center",
-                alignItems: "center",
-                flexWrap: "wrap",
-              }}
-            >
-              <a href={REPORT_PROBLEM_MAILTO} className="link-btn">Report a problem</a>
-              <span aria-hidden style={{ color: "#333" }}>·</span>
-              <ChangelogModal />
-            </div>
-          </footer>
+          <SiteFooter />
         </div>
       </main>
     </>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArticleShell } from "@/components/article-shell";
+import { CONTACT_EMAIL, REPORT_PROBLEM_MAILTO } from "@/lib/contact";
+
+export const metadata: Metadata = {
+  title: "Contact",
+  description:
+    "How to reach the person who maintains GuessSong — bug reports, playlists that will not load, rights complaints, privacy requests and press.",
+  alternates: { canonical: "/contact" },
+};
+
+const GITHUB_URL = "https://github.com/Waynting/GuessSong";
+
+export default function ContactPage() {
+  return (
+    <ArticleShell
+      eyebrow="Contact"
+      title="Get in touch"
+      lede="GuessSong is maintained by one person. Mail reaches them directly — there is no ticket queue and no bot in between."
+      meta={`Email ${CONTACT_EMAIL} · Usually answered within a few days`}
+      backHref="/"
+    >
+      <div className="callout">
+        <p className="callout-title">Email</p>
+        <p>
+          <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a> — the address for
+          everything below. Please write in English or Chinese.
+        </p>
+      </div>
+
+      <h2>A playlist will not load</h2>
+      <p>
+        Check the <Link href="/guides/spotify-playlist-not-working">troubleshooting guide</Link>{" "}
+        first — it covers the four causes behind almost every report, and three of them you
+        can fix in ten seconds. If none of those is it, send us the playlist link and the
+        exact message the site showed you.
+      </p>
+
+      <h2>A song played the wrong audio</h2>
+      <p>
+        The game finds clips on iTunes and Deezer by title and artist, and once in a while
+        a cover version or a same-titled song wins. Tell us the song and the playlist and
+        we will look at why the match went wrong. Include what you actually heard — that
+        is the part that identifies the bad match.
+      </p>
+
+      <h2>Bugs and feature requests</h2>
+      <p>
+        Use{" "}
+        <a href={REPORT_PROBLEM_MAILTO}>the problem report link</a>, or open an issue on{" "}
+        <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
+          GitHub
+        </a>
+        . Issues are public and get looked at faster, because the discussion stays with the
+        code. Helpful things to include: what device and browser, how many players, whether
+        it was a single playlist or Mixed Playlist Mode, and what you expected instead.
+      </p>
+
+      <h2>Privacy requests</h2>
+      <p>
+        Access, correction, deletion or objection requests go to the same address. Worth
+        knowing before you write: there are no accounts here, so in almost every case there
+        is nothing on file about you to return or delete. The{" "}
+        <Link href="/privacy">Privacy Policy</Link> sets out the few exceptions and how
+        long each one lives.
+      </p>
+
+      <h2>Rights holders and takedown requests</h2>
+      <p>
+        GuessSong does not host, store or distribute any audio. It links to preview clips
+        published by iTunes and Deezer and plays them in the browser, and it reads public
+        playlist metadata from Spotify. If you believe something on this site infringes
+        your rights, write to <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a> with:
+      </p>
+      <ul>
+        <li>identification of the work concerned;</li>
+        <li>the exact URL on this site where it appears;</li>
+        <li>your contact details and the basis of your claim;</li>
+        <li>a statement that you are the rights holder or authorised to act for them.</li>
+      </ul>
+      <p>We act on well-founded requests promptly.</p>
+
+      <h2>Press, and using GuessSong somewhere</h2>
+      <p>
+        Happy to answer questions from writers, and happy for teachers, event hosts and
+        team leads to use the game — no permission needed, no licence to ask for. If you
+        are running it at something larger than a living room, read section 3 of the{" "}
+        <Link href="/terms">Terms</Link> on public performance first; that part is on you,
+        not on us.
+      </p>
+
+      <h2>Contributing</h2>
+      <p>
+        The whole project is MIT-licensed and open at{" "}
+        <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
+          github.com/Waynting/GuessSong
+        </a>
+        . Pull requests are welcome, and so is a star if the game earned one.
+      </p>
+
+      <div className="article-cta">
+        <p>Or skip the email and just play a round.</p>
+        <Link href="/" className="cta-primary">
+          Start a game →
+        </Link>
+      </div>
+    </ArticleShell>
+  );
+}

--- a/app/guides/best-playlists-for-a-guess-the-song-game/page.tsx
+++ b/app/guides/best-playlists-for-a-guess-the-song-game/page.tsx
@@ -1,0 +1,178 @@
+import type { Metadata } from "next";
+import { GuideShell, guideMetadata } from "@/app/guides/guide-shell";
+
+const SLUG = "best-playlists-for-a-guess-the-song-game";
+
+export const metadata: Metadata = guideMetadata(SLUG);
+
+export default function Page() {
+  return (
+    <GuideShell slug={SLUG}>
+      <p>
+        The playlist you would put on at a party and the playlist that makes a good
+        guessing game are usually different playlists. A party playlist wants flow — keys
+        that sit together, tempo that builds, no jarring transitions. A quiz playlist wants
+        the opposite: songs that have nothing to do with each other, arriving in an order
+        nobody can anticipate.
+      </p>
+      <p>
+        Here is how to tell, before the game starts, whether the one you picked will work.
+      </p>
+
+      <h2>The only property that really matters</h2>
+      <p>
+        A song is good in a quiz if <strong>most of the room can name it and some of the
+        room cannot</strong>. That is it. Both halves are load-bearing.
+      </p>
+      <p>
+        If nobody can name it, the round is dead air: fifteen seconds of a song, blank
+        faces, a reveal nobody reacts to. If <em>everybody</em> can name it, it is a race
+        rather than a quiz, and races reward whoever talks fastest rather than whoever
+        knows most.
+      </p>
+      <p>
+        Practically, aim for a playlist where you personally recognise something like{" "}
+        <strong>70 to 80 percent</strong> of the tracks. Below that you have picked
+        something too obscure for the room. Above 90 and you have picked a greatest-hits
+        list, which is fine for five minutes and boring for thirty.
+      </p>
+
+      <h2>Aim at the overlap, not at your taste</h2>
+      <p>
+        The mistake almost every first-time host makes is picking a playlist they love.
+        Your taste is a narrow, specific thing that took years to build. In a room of eight
+        people, it is a playlist that seven of them will lose at.
+      </p>
+      <p>
+        What you want is the <em>overlap</em> — the music this particular group has in
+        common. Two reliable ways to find it:
+      </p>
+      <ul>
+        <li>
+          <strong>Age, not genre.</strong> A group who were teenagers at roughly the same
+          time share far more than a group who all say they like indie. &ldquo;2008 to
+          2014&rdquo; is a better filter than any genre label.
+        </li>
+        <li>
+          <strong>Where the music was, not what it was.</strong> Songs that were
+          inescapable — on the radio, in adverts, in a film everyone saw — outperform
+          critically-loved songs by a mile. Ubiquity is the thing you are testing.
+        </li>
+      </ul>
+
+      <h2>Playlist shapes that reliably work</h2>
+      <h3>One decade, many genres</h3>
+      <p>
+        A wide slice of a single decade is the most robust format there is. Everyone in the
+        room has a foothold somewhere in it, and the genre-hopping keeps consecutive songs
+        from blurring together. &ldquo;90s&rdquo; beats &ldquo;90s rock&rdquo; every time.
+      </p>
+
+      <h3>Songs with a distinctive first five seconds</h3>
+      <p>
+        A playlist made of tracks with unmistakable openings — a specific riff, a drum
+        pattern, an instantly recognisable synth — supports much shorter clips, and short
+        clips are where the game gets exciting. If you are building a playlist by hand, this
+        is the single highest-value thing to select for.
+      </p>
+
+      <h3>Soundtracks</h3>
+      <p>
+        Film and TV soundtracks are quietly excellent. They cross generations, they carry
+        an extra layer of recognition (people who cannot name the song can name the scene),
+        and they generate the arguing that makes a good round.
+      </p>
+
+      <h3>A local charts playlist</h3>
+      <p>
+        If the room shares a country, a national chart playlist is a strong pick that
+        international lists will not match. It also sidesteps a subtler problem: songs
+        popular in one market are much better represented in the preview catalogues these
+        games draw clips from.
+      </p>
+
+      <h2>Shapes that disappoint</h2>
+      <ul>
+        <li>
+          <strong>Algorithmic mixes made for you.</strong> Anything generated from one
+          person&rsquo;s listening is, by construction, a list of things only that person
+          knows well.
+        </li>
+        <li>
+          <strong>Single-artist playlists.</strong> Deep cuts are invisible to everyone but
+          fans, and after eight songs by the same act, every clip sounds like the last one.
+        </li>
+        <li>
+          <strong>Ambient, lo-fi, classical, jazz standards.</strong> Wonderful music,
+          unguessable format. Most of it has no widely known title attached to it in the
+          first place.
+        </li>
+        <li>
+          <strong>Very new releases.</strong> A song needs six months of saturation before a
+          room can be expected to name it.
+        </li>
+        <li>
+          <strong>Live albums and remixes.</strong> The intro is the part people recognise,
+          and live versions and remixes replace it with something else.
+        </li>
+      </ul>
+
+      <h2>The technical constraints, briefly</h2>
+      <p>
+        Two of these will decide whether a playlist works before taste ever comes into it:
+      </p>
+      <ul>
+        <li>
+          <strong>It must be public, and it must be yours or someone&rsquo;s — not
+          Spotify&rsquo;s.</strong> Spotify&rsquo;s own editorial playlists (the ones it
+          curates, with ids beginning <code>37i9</code>) cannot be read by third-party apps
+          at all. This is the most common reason a playlist fails to load. Copy the tracks
+          into a playlist of your own and it works.{" "}
+          <a href="/guides/spotify-playlist-not-working">Full troubleshooting here.</a>
+        </li>
+        <li>
+          <strong>Mainstream tracks are more likely to have a playable clip.</strong> Games
+          like this find 30-second previews from public music catalogues, and coverage is
+          thinner for obscure releases, regional independents and anything with an unusual
+          title. A playlist of well-known songs is a playlist where almost every track
+          plays. <a href="/guides/why-spotify-previews-disappeared">Why that is</a> is a
+          story in itself.
+        </li>
+      </ul>
+
+      <h2>Size: fewer tracks than you think</h2>
+      <p>
+        You do not need a big playlist. A game plays 20 to 50 songs, drawn at random, so a
+        60-track playlist and a 600-track playlist produce a similarly varied night —
+        except the small one is one you have actually looked at, and the large one is full
+        of songs you forgot were in it.
+      </p>
+      <p>
+        <strong>Between 50 and 150 tracks</strong> is the sweet spot. Enough that the
+        random draw feels unpredictable, few enough that you can scan the list beforehand
+        and delete the four songs that will kill the room.
+      </p>
+
+      <h2>A two-minute check before you start</h2>
+      <ol>
+        <li>Open the playlist and scan the titles. Do you recognise roughly three in four?</li>
+        <li>Are there more than three songs by any one artist? Cut them down.</li>
+        <li>Are the tracks spread across at least two decades, or one decade and several genres?</li>
+        <li>Is it public, and did you make it — or did someone you know make it?</li>
+        <li>
+          Would the least musically confident person in the room get at least a few? If not,
+          widen it. That person is who decides whether the game is fun.
+        </li>
+      </ol>
+
+      <h2>Or let the room build it</h2>
+      <p>
+        The most reliable playlist for a specific group is the one that group made. If
+        everyone submits their own and the lists get merged, the result is by definition
+        centred on the room&rsquo;s overlap, and it comes with a better question attached —
+        not &ldquo;what is this song&rdquo; but{" "}
+        <a href="/guides/mixed-playlist-mode-guide">&ldquo;whose song is this&rdquo;</a>.
+      </p>
+    </GuideShell>
+  );
+}

--- a/app/guides/clip-length-and-difficulty/page.tsx
+++ b/app/guides/clip-length-and-difficulty/page.tsx
@@ -1,0 +1,154 @@
+import type { Metadata } from "next";
+import { GuideShell, guideMetadata } from "@/app/guides/guide-shell";
+
+const SLUG = "clip-length-and-difficulty";
+
+export const metadata: Metadata = guideMetadata(SLUG);
+
+export default function Page() {
+  return (
+    <GuideShell slug={SLUG}>
+      <p>
+        Most settings in a guessing game change the content: which songs, how many, who is
+        playing. Clip length changes the <em>game</em>. The same playlist at five seconds
+        and at thirty is two different evenings, and the gap between them is much wider
+        than the numbers suggest.
+      </p>
+
+      <h2>What is actually happening in those seconds</h2>
+      <p>
+        Song recognition is not gradual. It is a threshold: you have no idea, you have no
+        idea, and then you know — usually all at once, and usually a beat or two before you
+        can produce the title. Research on this has consistently found that listeners
+        identify familiar recordings from remarkably short fragments, often well under a
+        second, when the fragment happens to contain the right part of the song.
+      </p>
+      <p>
+        That last clause is the whole game. Clip length is not really measuring how well you
+        know the song. It is measuring <strong>whether the clip contains the identifying
+        moment</strong>, and whether the moment arrives early enough to beat the rest of the
+        room to it.
+      </p>
+      <p>
+        Which is why the same person can name a song in three seconds and completely miss a
+        song they know better — the second one just opens with eight bars of ambient pad.
+      </p>
+
+      <h2>Why the intro is the hard part</h2>
+      <p>
+        Clips typically start at or near the beginning of the preview, which means the game
+        is testing intros, and intros are the least distinctive part of most recordings.
+        Vocals have not started. The hook has not landed. A lot of songs open with the same
+        four chords at the same tempo with the same drum sound.
+      </p>
+      <p>This has two practical consequences:</p>
+      <ul>
+        <li>
+          <strong>Very short clips reward a specific kind of knowledge</strong> — production
+          detail, drum sounds, the exact timbre of a synth — rather than broad familiarity.
+          The person who wins at five seconds is not necessarily the person who knows the
+          most music.
+        </li>
+        <li>
+          <strong>Adding seconds does not add difficulty linearly.</strong> Going from five
+          to ten seconds is a huge change, because ten seconds usually reaches the first
+          vocal line. Going from twenty to thirty barely changes anything: if twenty seconds
+          did not do it, thirty will not either.
+        </li>
+      </ul>
+
+      <h2>What each setting actually feels like</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Length</th>
+            <th>The room</th>
+            <th>Use it when</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>5s</strong></td>
+            <td>Silence, then one person shouting. Long gaps between scores.</td>
+            <td>Tie-breakers, final rounds, groups who have played a lot.</td>
+          </tr>
+          <tr>
+            <td><strong>10s</strong></td>
+            <td>Two or three people close in at once. Loud, competitive, fast.</td>
+            <td>The default for a group that knows the playlist&rsquo;s era.</td>
+          </tr>
+          <tr>
+            <td><strong>15s</strong></td>
+            <td>Almost everyone gets there; the question is who first.</td>
+            <td>Mixed-confidence groups. The safest choice for a first game.</td>
+          </tr>
+          <tr>
+            <td><strong>20–30s</strong></td>
+            <td>People start singing along. Less quiz, more party.</td>
+            <td>Big groups, background play, drinking, families.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Longer clips are not just easier — they are a different activity</h2>
+      <p>
+        This is the part hosts underestimate. Somewhere around twenty seconds, a room stops
+        competing and starts singing. The clip outlasts the guess, so once the answer is
+        obvious there are fifteen seconds left with nothing to do but enjoy the song.
+      </p>
+      <p>
+        That is not a failure. For a family gathering, a big loud party, or a group who do
+        not all know each other yet, it is often the better outcome — the music is doing the
+        social work and the scoring is an excuse. But choose it deliberately. A host who
+        wants a tense quiz and sets 30 seconds has chosen a sing-along by accident.
+      </p>
+
+      <h2>Match the length to the playlist, not just the people</h2>
+      <p>
+        A playlist of songs with unmistakable openings — a distinctive riff, an instantly
+        placeable synth — supports five and ten second clips beautifully. A playlist of
+        songs that ease in needs fifteen or more before there is anything to grab.
+      </p>
+      <p>
+        If you are not sure which you have, look at the first few tracks and ask whether you
+        would know them from the first bar alone. If the answer is no more than once or
+        twice, do not run short clips.{" "}
+        <a href="/guides/best-playlists-for-a-guess-the-song-game">
+          More on building a playlist that supports short clips.
+        </a>
+      </p>
+
+      <h2>Change it mid-game</h2>
+      <p>
+        The best use of this setting is not choosing it once. It is moving it.
+      </p>
+      <ul>
+        <li>
+          <strong>Start long, finish short.</strong> Open at 15 or 20 seconds so everyone
+          scores something early, then drop to 10 once the room is warm and to 5 for the
+          last few. The night feels like it is tightening, which is a much better shape than
+          a flat difficulty.
+        </li>
+        <li>
+          <strong>Lengthen when the room goes quiet.</strong> Two or three songs in a row
+          with no guesses means the setting is wrong, not that the players are bad. Add five
+          seconds without commentary and carry on.
+        </li>
+        <li>
+          <strong>Shorten when one person is running away with it.</strong> Counter-intuitive
+          but effective: at very short clips, results get noisier, and noise favours whoever
+          is behind. It is a fairer handicap than any rule you could impose on a person.
+        </li>
+      </ul>
+
+      <h2>A rule of thumb</h2>
+      <p>
+        Pick the length at which the <strong>third-best</strong> player in the room gets
+        about half of them. Not the best player — tuning to them makes the game
+        unwinnable for everyone else. Not the least confident — tuning to them makes it
+        trivial. The third-best is close enough to the middle that the game stays live for
+        the whole room, which is the only thing difficulty settings are for.
+      </p>
+    </GuideShell>
+  );
+}

--- a/app/guides/guide-shell.tsx
+++ b/app/guides/guide-shell.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+import { ArticleShell } from "@/components/article-shell";
+import { formatGuideDate, requireGuide, relatedGuides } from "@/lib/guides";
+
+/**
+ * The wrapper every article under `/guides` renders inside.
+ *
+ * An article file is then a slug plus its prose — the title, description,
+ * canonical, dateline, Article JSON-LD, "read next" block and closing CTA are
+ * all derived from that one slug via `lib/guides.ts`. Eight articles each
+ * hand-rolling those is eight chances for the `<title>` and the `<h1>` to drift
+ * apart, or for one article to quietly ship without structured data.
+ *
+ * The metadata half of that derivation lives in `lib/guides.ts`, not here, for
+ * the reason `lib/song-count.ts` gives: the test suite only reaches `lib/`, and
+ * a `.tsx` module cannot be imported from it. What stays here is the part that
+ * is actually JSX.
+ */
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://www.guessong.app";
+
+export { guideMetadata } from "@/lib/guides";
+
+export function GuideShell({
+  slug,
+  children,
+}: {
+  slug: string;
+  children: React.ReactNode;
+}) {
+  const guide = requireGuide(slug);
+  const related = relatedGuides(slug);
+
+  const articleLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: guide.title,
+    description: guide.description,
+    datePublished: guide.published,
+    dateModified: guide.published,
+    inLanguage: "en",
+    author: { "@type": "Organization", name: "GuessSong", url: BASE_URL },
+    publisher: { "@type": "Organization", name: "GuessSong", url: BASE_URL },
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": `${BASE_URL}/guides/${guide.slug}`,
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }}
+      />
+      <ArticleShell
+        eyebrow={guide.category}
+        title={guide.title}
+        lede={guide.lede}
+        meta={`${formatGuideDate(guide.published)} · ${guide.minutes} min read`}
+        backHref="/guides"
+        backLabel="← All guides"
+      >
+        {children}
+
+        <div className="article-cta">
+          <p>
+            GuessSong turns any public Spotify playlist into this game. No login, no app,
+            no sign-up.
+          </p>
+          <Link href="/" className="cta-primary">
+            Start a game →
+          </Link>
+        </div>
+
+        {related.length > 0 && (
+          <section aria-labelledby="read-next">
+            <h2 id="read-next">Read next</h2>
+            <ul>
+              {related.map((r) => (
+                <li key={r.slug}>
+                  <Link href={`/guides/${r.slug}`}>{r.title}</Link> — {r.description}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </ArticleShell>
+    </>
+  );
+}

--- a/app/guides/how-to-host-a-music-quiz-night/page.tsx
+++ b/app/guides/how-to-host-a-music-quiz-night/page.tsx
@@ -1,0 +1,240 @@
+import type { Metadata } from "next";
+import { GuideShell, guideMetadata } from "@/app/guides/guide-shell";
+
+const SLUG = "how-to-host-a-music-quiz-night";
+
+export const metadata: Metadata = guideMetadata(SLUG);
+
+export default function Page() {
+  return (
+    <GuideShell slug={SLUG}>
+      <p>
+        The music is the easy part. Pick any decent playlist and the songs will be fine.
+        What decides whether a quiz night works is a set of much duller decisions — how
+        long a round runs, who controls the pause button, what happens when one person
+        turns out to know everything — and those get made badly by default, because most
+        hosts are thinking about the songs.
+      </p>
+      <p>
+        This is what we have learned watching these run, and what to do differently.
+      </p>
+
+      <h2>Decide the length before anyone arrives</h2>
+      <p>
+        A music quiz is not an evening&rsquo;s entertainment. It is a <strong>forty-minute
+        opener</strong> that people remember fondly, or a ninety-minute slog they remember
+        as the bit before the good part of the night. The difference is almost entirely
+        length.
+      </p>
+      <p>
+        A workable shape for a group of six to ten:
+      </p>
+      <ul>
+        <li>
+          <strong>20 songs</strong> for a first time with this group. About 25 minutes with
+          the talking.
+        </li>
+        <li>
+          <strong>30 songs</strong> if they have played before and asked for it again.
+        </li>
+        <li>
+          <strong>50 songs</strong> only if you are running actual rounds with breaks
+          between them, and someone else is handling drinks.
+        </li>
+      </ul>
+      <p>
+        Err short. A room that wanted three more songs will play again next month. A room
+        that got eight more than it wanted will not.
+      </p>
+
+      <h2>One screen, one host, and the host does not play</h2>
+      <p>
+        The strongest structural choice you can make is to have the host judge rather than
+        compete. It removes every argument about who said it first, it means somebody is
+        always watching the room rather than the scoreboard, and it lets you do the thing
+        that actually makes a quiz good: adjusting difficulty live.
+      </p>
+      <p>
+        Hosts resist this because it sounds like not getting to play. In practice the host
+        has the best seat. You see the exact moment recognition crosses someone&rsquo;s
+        face, three seconds before they can name what they are hearing, and you get to
+        decide whether to let it run.
+      </p>
+      <div className="callout">
+        <p className="callout-title">If the host wants to play</p>
+        <p>
+          Rotate. Host the first ten songs, hand the device to whoever is last on the
+          scoreboard, and let them host the next ten. It fixes two problems at once: the
+          host gets a turn, and the person doing worst gets a break from doing worst.
+        </p>
+      </div>
+
+      <h2>Verbal answers beat written ones at this size</h2>
+      <p>
+        Pub quizzes use answer sheets because forty people cannot shout at one host. Eight
+        people can. Below about a dozen players, shouted answers are strictly better:
+      </p>
+      <ul>
+        <li>
+          <strong>No dead time.</strong> Written rounds have a scoring gap after every ten
+          songs where nothing happens and the room checks their phones.
+        </li>
+        <li>
+          <strong>The near-misses are the fun.</strong> Someone yelling a wrong band name
+          with total confidence is most of what people remember. A sheet swallows that.
+        </li>
+        <li>
+          <strong>No spelling arguments.</strong> Nobody has to adjudicate whether
+          &ldquo;Chilli Peppers&rdquo; counts.
+        </li>
+      </ul>
+      <p>
+        The cost is that fast talkers dominate. That is a real cost, and the scoring
+        section below is where you fix it.
+      </p>
+
+      <h2>The person who knows everything</h2>
+      <p>
+        Every group has one. By song six the rest of the room has worked out they cannot
+        win and stops trying, which is the actual failure — not that someone is winning,
+        but that six other people have quietly stopped playing.
+      </p>
+      <p>Three fixes, in order of how little they feel like punishment:</p>
+      <ol>
+        <li>
+          <strong>Give them a job.</strong> Ask them to co-host the second half. Expertise
+          is more fun to display as commentary than as a score.
+        </li>
+        <li>
+          <strong>Change the question.</strong> Switch to a round where everyone submits
+          their own playlist and the question becomes &ldquo;whose song is this&rdquo;.
+          Encyclopaedic music knowledge does not help you guess that your colleague
+          secretly loves Enya.
+        </li>
+        <li>
+          <strong>Handicap the format, not the person.</strong> A comeback round where
+          points are doubled for everyone below the leader is fair, public and does not
+          single anyone out. More of these in{" "}
+          <a href="/guides/music-quiz-scoring-rules">the scoring guide</a>.
+        </li>
+      </ol>
+      <p>
+        What does not work is a private handicap. People notice, and it reads as pity.
+      </p>
+
+      <h2>Sound: the failure nobody plans for</h2>
+      <p>
+        Preview clips are mastered at wildly different volumes, and a laptop speaker in a
+        room of ten talking people is not enough. Two minutes of setup solves an evening
+        of &ldquo;can you turn it up&rdquo;:
+      </p>
+      <ul>
+        <li>
+          Use a real speaker. Any Bluetooth speaker beats any laptop. Pair it{" "}
+          <em>before</em> people arrive — pairing in front of an audience is the single
+          most common way a quiz night starts badly.
+        </li>
+        <li>
+          Set the volume on the loudest song you can find, not the first one. Then leave it
+          alone.
+        </li>
+        <li>
+          If you are on Bluetooth, expect a fraction of a second of delay when a clip
+          starts. Count it into your timing rather than fighting it.
+        </li>
+        <li>
+          Sit people so nobody is behind the speaker. Sounds obvious; is routinely wrong.
+        </li>
+      </ul>
+
+      <h2>Seat the room so everyone can see the host</h2>
+      <p>
+        The host&rsquo;s face is the interface. People need to see whether their answer
+        registered, and they need to see the moment the answer is revealed. A rough
+        semicircle facing the host, with the speaker behind or beside them, works. A long
+        table where four people are looking at the back of someone&rsquo;s head does not.
+      </p>
+
+      <h2>Five mistakes that flatten a good night</h2>
+      <ol>
+        <li>
+          <strong>Explaining the rules for four minutes.</strong> Explain the first round
+          only, in two sentences, and start. Rules learned by playing stick; rules
+          explained up front do not.
+        </li>
+        <li>
+          <strong>Letting a song run too long.</strong> If nobody has it in fifteen
+          seconds, nobody has it. Reveal, react, move on. The reveal is fast entertainment;
+          silence is not.
+        </li>
+        <li>
+          <strong>Announcing the scores after every song.</strong> Every three or four is
+          plenty. Constant scoreboard updates make it feel like admin.
+        </li>
+        <li>
+          <strong>Picking a playlist only you know.</strong> Your taste is not a difficulty
+          setting, it is an exclusion. See{" "}
+          <a href="/guides/best-playlists-for-a-guess-the-song-game">picking a playlist</a>.
+        </li>
+        <li>
+          <strong>Not knowing how it ends.</strong> Say the number of songs out loud at the
+          start. A game with a visible finish line has a last round people push for; one
+          without just stops when someone gets bored.
+        </li>
+      </ol>
+
+      <h2>A running order that works</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Stage</th>
+            <th>Songs</th>
+            <th>Clip length</th>
+            <th>What it does</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Warm-up</td>
+            <td>5</td>
+            <td>15–30s</td>
+            <td>Everyone scores something. Nobody is losing yet.</td>
+          </tr>
+          <tr>
+            <td>Main</td>
+            <td>10–15</td>
+            <td>10s</td>
+            <td>The real game. Fast, competitive.</td>
+          </tr>
+          <tr>
+            <td>Comeback</td>
+            <td>5</td>
+            <td>10s</td>
+            <td>Double points below the leader. Re-opens the night.</td>
+          </tr>
+          <tr>
+            <td>Finish</td>
+            <td>3–5</td>
+            <td>5s</td>
+            <td>Short and brutal. Ends on a spike, not a fade.</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        The shape matters more than the numbers: start generous, tighten in the middle,
+        re-open the scores, end fast. A night that gets harder as it goes feels like it is
+        building. A night at one difficulty feels like a list.
+      </p>
+
+      <h2>Have a plan for a song with no audio</h2>
+      <p>
+        Some tracks have no preview clip available anywhere — a real constraint of how
+        music previews work, explained in{" "}
+        <a href="/guides/why-spotify-previews-disappeared">this piece on what happened to Spotify&rsquo;s previews</a>.
+        Do not stop and debug it in front of the room. Skip it, say &ldquo;that one&rsquo;s
+        broken, next&rdquo;, and keep the tempo. The room will not care unless you make
+        them care.
+      </p>
+    </GuideShell>
+  );
+}

--- a/app/guides/mixed-playlist-mode-guide/page.tsx
+++ b/app/guides/mixed-playlist-mode-guide/page.tsx
@@ -1,0 +1,174 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { GuideShell, guideMetadata } from "@/app/guides/guide-shell";
+
+const SLUG = "mixed-playlist-mode-guide";
+
+export const metadata: Metadata = guideMetadata(SLUG);
+
+export default function Page() {
+  return (
+    <GuideShell slug={SLUG}>
+      <p>
+        A standard music quiz asks one question: what is this song. It is a good question,
+        but it has a ceiling — the person who knows the most music wins, and after two
+        rounds everyone in the room knows who that is.
+      </p>
+      <p>
+        Mixed Playlist Mode asks a different question. Everyone submits their own playlist,
+        the lists get merged into one pool, and the round becomes: <strong>whose playlist
+        did this come from?</strong> That question has no expert. Your friend who can name
+        any b-side from 1997 has no idea that the person across the table has been quietly
+        listening to Enya for a decade.
+      </p>
+
+      <h2>Why the question is better</h2>
+      <ul>
+        <li>
+          <strong>Nobody can study for it.</strong> The answer is not in the music, it is in
+          the people, and everyone in the room has roughly equal access to that.
+        </li>
+        <li>
+          <strong>Every song is somebody&rsquo;s.</strong> In a normal quiz, a track nobody
+          knows is dead air. Here it is the most interesting round of the night, because
+          someone has to own it.
+        </li>
+        <li>
+          <strong>It produces the reveal.</strong> The moment where a name appears next to a
+          song and the room turns to look at that person is the thing people talk about
+          afterwards. A title reveal has never once done that.
+        </li>
+        <li>
+          <strong>It scales down.</strong> Four people is enough. A conventional quiz needs
+          six or more to feel like an event.
+        </li>
+      </ul>
+
+      <h2>Two ways to collect the playlists</h2>
+
+      <h3>Pass this phone</h3>
+      <p>
+        The host&rsquo;s device goes round the room. Each person types their name and pastes
+        their playlist link, then hands it on. A masked confirmation shows that a playlist
+        was added without revealing what is in it, so the next person cannot peek.
+      </p>
+      <p>
+        Best for: a table of four to six, everyone in one place, no faffing with codes. It
+        needs nothing beyond the one device already running the game.
+      </p>
+
+      <h3>QR code room</h3>
+      <p>
+        The host creates a room and gets a short code and a QR code. Everyone scans it on
+        their own phone, submits their own playlist, and appears on the host&rsquo;s screen
+        as they arrive. Nobody installs anything — it is a web page.
+      </p>
+      <p>
+        Best for: more than six people, groups spread around a room, and anyone who does not
+        want to hand their unlocked phone to seven people. It is also much faster: everyone
+        submits at once rather than in sequence.
+      </p>
+      <div className="callout">
+        <p className="callout-title">Rooms expire on purpose</p>
+        <p>
+          A room lives for a few hours and is designed to be consumed once, when the host
+          starts the game. That is deliberate — nothing about the evening should outlive the
+          evening. If you are setting up well in advance, create the room when people
+          actually arrive, not the night before.
+        </p>
+      </div>
+
+      <h2>What happens to the songs</h2>
+      <p>Once the playlists are in, three things happen before the first clip plays:</p>
+      <ol>
+        <li>
+          <strong>Sampling.</strong> Each playlist contributes a share of the pool, so the
+          person who submitted 800 tracks does not drown out the person who submitted 40.
+          Bringing a bigger playlist is not an advantage.
+        </li>
+        <li>
+          <strong>Deduplication.</strong> Tracks that appear on more than one playlist are
+          collapsed. This matters for fairness — a song three people picked would otherwise
+          make &ldquo;whose is it&rdquo; unanswerable — and the overlaps are kept, because
+          they turn out to be the interesting part at the end.
+        </li>
+        <li>
+          <strong>Shuffling.</strong> The pool is randomised, so contributions do not arrive
+          in blocks. If four songs in a row are obviously the same person&rsquo;s, the guess
+          stops being a guess.
+        </li>
+      </ol>
+
+      <h2>Scoring it</h2>
+      <p>
+        The usual 3 for the title and 1 for the album still apply, with{" "}
+        <strong>2 points for correctly naming whose playlist the track came from</strong>.
+      </p>
+      <p>
+        Two is the right weight. Lower and nobody bothers; higher and the actual music
+        becomes a sideshow. It also has a useful property as a comeback mechanic: it is
+        available on every single round, including the ones where nobody has any idea what
+        the song is, so a player who is behind on titles always has a way back in.{" "}
+        <Link href="/guides/music-quiz-scoring-rules">More scoring variants here.</Link>
+      </p>
+
+      <h2>Getting a good pool</h2>
+      <ul>
+        <li>
+          <strong>Ask for an honest playlist, not a curated one.</strong> The instruction
+          that works is &ldquo;send the one you actually listen to&rdquo;. People who build a
+          playlist for the game submit what they want to be seen listening to, and that is
+          both harder to guess and far less funny.
+        </li>
+        <li>
+          <strong>Fifty to a hundred tracks each is plenty.</strong> Sampling means a huge
+          playlist buys nothing.
+        </li>
+        <li>
+          <strong>Public playlists only, and not Spotify&rsquo;s own.</strong> Editorial
+          playlists cannot be read by third-party apps.{" "}
+          <Link href="/guides/spotify-playlist-not-working">Why, and what to do instead.</Link>
+        </li>
+        <li>
+          <strong>Nicknames are fine.</strong> Whatever someone types is what the room sees.
+        </li>
+      </ul>
+
+      <h2>Reading the Taste Card</h2>
+      <p>
+        At the end you can save a shareable card summarising what the merged pool revealed.
+        It carries three things worth understanding:
+      </p>
+      <ul>
+        <li>
+          <strong>Shared Bangers</strong> — the tracks that appeared on more than one
+          playlist. This is the room&rsquo;s common ground, computed rather than guessed,
+          and it is usually the part people screenshot.
+        </li>
+        <li>
+          <strong>Most Obscure Taste</strong> — whose contributions the room found hardest
+          to place. Worth reading as a compliment, whatever the recipient says.
+        </li>
+        <li>
+          <strong>Most Mainstream</strong> — the highest average popularity score across
+          submitted tracks. Also a compliment, and treated as one by nobody.
+        </li>
+      </ul>
+      <p>
+        You can also copy the whole merged tracklist at the end, with each song credited to
+        whoever brought it. It is a genuinely good playlist — it is the intersection of a
+        room of people who like each other — and it is the main reason groups run this mode
+        twice.
+      </p>
+
+      <h2>When not to use it</h2>
+      <p>
+        It needs a group who know each other at least a bit. &ldquo;Whose song is
+        this&rdquo; is not a question you can ask on the first evening of a work offsite
+        where nobody has met. For those, run a{" "}
+        <Link href="/guides/best-playlists-for-a-guess-the-song-game">shared-era playlist</Link>{" "}
+        first and save this for the second round, once people have names for each other.
+      </p>
+    </GuideShell>
+  );
+}

--- a/app/guides/music-quiz-scoring-rules/page.tsx
+++ b/app/guides/music-quiz-scoring-rules/page.tsx
@@ -1,0 +1,171 @@
+import type { Metadata } from "next";
+import { GuideShell, guideMetadata } from "@/app/guides/guide-shell";
+
+const SLUG = "music-quiz-scoring-rules";
+
+export const metadata: Metadata = guideMetadata(SLUG);
+
+export default function Page() {
+  return (
+    <GuideShell slug={SLUG}>
+      <p>
+        Scoring looks like bookkeeping. It is not. The scoring system is the thing that
+        decides whether people are still playing in the last third of the night, and almost
+        every music quiz that dies, dies because someone pulled ten points clear at song
+        twelve and five people quietly stopped trying.
+      </p>
+      <p>
+        Here is what the numbers are doing, and five variants that fix the specific problem
+        you have.
+      </p>
+
+      <h2>Why three points for the title and one for the album</h2>
+      <p>
+        The default in GuessSong is <strong>3 points for naming the song, 1 more for naming
+        the album it came from</strong>, awarded at most once each per round. That ratio is
+        doing three jobs.
+      </p>
+      <ul>
+        <li>
+          <strong>The primary answer stays primary.</strong> At 3:1, the bonus is worth
+          chasing but can never substitute for the main skill. A 1:1 split would turn the
+          game into an album-trivia contest with music attached.
+        </li>
+        <li>
+          <strong>It gives the room a second question.</strong> The moment after someone
+          shouts the title is normally dead. A live bonus keeps six other people leaning in
+          for another few seconds, and it is a different kind of knowledge, so it is usually
+          a different person who gets it.
+        </li>
+        <li>
+          <strong>It creates a comeback increment that is not a full round.</strong> Someone
+          four points down can close the gap over three or four songs by picking up bonuses.
+          That is enough to keep them in it without ever handing them a shortcut.
+        </li>
+      </ul>
+      <p>
+        The one-award-per-type rule matters as much as the numbers. Without it, a host who
+        is being generous accidentally inflates a single round to eight or nine points and
+        that round decides the night.
+      </p>
+
+      <h2>The runaway leader problem</h2>
+      <p>
+        This is the failure mode. It has a recognisable signature: the room gets quieter,
+        two people are still shouting, and the rest have moved to talking to each other.
+      </p>
+      <p>
+        The important insight is that <strong>the problem is not that someone is winning.
+        It is that the others have correctly calculated they cannot.</strong> Nobody minds
+        losing a close game. What kills a quiz night is a game that has been mathematically
+        over for twenty minutes and is still being played.
+      </p>
+      <p>
+        So the fix is not to slow the leader down. It is to keep the arithmetic open.
+      </p>
+
+      <h2>Five variants that keep it close</h2>
+
+      <h3>1. The comeback round</h3>
+      <p>
+        For a block of five songs near the end, <strong>everyone below the current leader
+        scores double</strong>. Announce it out loud, before the block starts.
+      </p>
+      <p>
+        This is the best of the five, because it is public, mechanical and impersonal. It is
+        not a favour to anyone and it does not single out the leader — it just re-opens the
+        scoreboard at exactly the point in the evening when it has usually closed. A leader
+        eight points clear is no longer safe, so they keep playing hard too.
+      </p>
+
+      <h3>2. The steal</h3>
+      <p>
+        If nobody names the song before the clip ends, the host plays it once more and{" "}
+        <strong>only the player in last place may answer</strong>, for double points.
+      </p>
+      <p>
+        Turns dead rounds — the ones where the clip ends in silence — into the most
+        interesting moments of the night. It costs nothing, because those rounds were
+        already wasted.
+      </p>
+
+      <h3>3. Wagers, before the clip</h3>
+      <p>
+        Once every five songs, players privately commit to a wager of 1, 2 or 3 points
+        before hearing anything. Get it right, gain the wager; get it wrong, lose it.
+      </p>
+      <p>
+        Adds a decision that is not about music knowledge at all, which is precisely why it
+        redistributes points. Keep it occasional — every round would turn the game into
+        arithmetic.
+      </p>
+
+      <h3>4. Teams, drawn after the first block</h3>
+      <p>
+        Play ten songs as individuals, then split into pairs, strongest with weakest, and
+        play the rest as teams. Two effects: the strongest players are no longer competing
+        with each other, and the least confident player now has someone confirming their
+        guesses out loud, which is usually all they needed.
+      </p>
+      <p>
+        This is the fix for a group where one or two people are genuinely far ahead of the
+        rest.
+      </p>
+
+      <h3>5. Change what is being scored</h3>
+      <p>
+        The most complete fix is to stop asking the question the expert is good at. In a
+        round built from everyone&rsquo;s own playlists, the scoring question becomes{" "}
+        <strong>whose playlist did this come from</strong> — and knowing every song ever
+        recorded does not help you guess that your quiet colleague listens to power ballads.
+        See <a href="/guides/mixed-playlist-mode-guide">Mixed Playlist Mode</a>, where that
+        guess is worth 2 points on top of the usual 3 and 1.
+      </p>
+
+      <h2>Rules worth settling before the first song</h2>
+      <ul>
+        <li>
+          <strong>Wrong answers cost nothing.</strong> Penalties make people stop guessing,
+          and a room that has stopped guessing is a room that has stopped playing. The
+          exception is a declared wager, which the player chose.
+        </li>
+        <li>
+          <strong>Artist alone is not the song.</strong> Otherwise half the room shouts the
+          band name on every clip. If you want to reward it, make it worth 1 point, like the
+          album.
+        </li>
+        <li>
+          <strong>Close enough is close enough.</strong> A missing &ldquo;the&rdquo;, an
+          accent, an approximate translation of a title — all fine. Adjudicating exact
+          wording is the fastest way to make a party feel like a test.
+        </li>
+        <li>
+          <strong>The host&rsquo;s call is final, and the host says so at the start.</strong>{" "}
+          One sentence up front prevents every argument later. Simultaneous shouts go to
+          whoever the host heard first; that is a judgement, not a measurement, and everyone
+          should know that going in.
+        </li>
+      </ul>
+
+      <h2>How often to read the scores out</h2>
+      <p>
+        Every three or four songs. Not every song — that turns the game into admin and makes
+        the gap the most salient thing in the room. Not never, either: people need to know
+        whether the last five minutes changed anything.
+      </p>
+      <p>
+        One refinement worth the effort: when you read them, read <em>up</em> from the
+        bottom, and read the gaps rather than the totals. &ldquo;Three points between fourth
+        and first&rdquo; is a live game. &ldquo;Sam has 22&rdquo; is a result.
+      </p>
+
+      <h2>Ending it</h2>
+      <p>
+        Say the number of songs at the start, and stop there even if the game is close —
+        especially if it is close. A quiz that ends while people still want another round is
+        a quiz that gets played again. Sudden-death tie-breaks are the one good reason to
+        add songs: same rules, five-second clips, first correct answer takes it.
+      </p>
+    </GuideShell>
+  );
+}

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -1,0 +1,243 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SiteFooter } from "@/components/site-footer";
+import {
+  GUIDES,
+  GUIDE_CATEGORIES,
+  guidesByCategory,
+  type GuideCategory,
+} from "@/lib/guides";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://www.guessong.app";
+
+export const metadata: Metadata = {
+  title: "Guides — Music Quiz Hosting, Playlists and Troubleshooting",
+  description:
+    "How to host a music quiz night, pick a playlist that plays well, set the right clip length, score a game so it stays close, and fix a Spotify playlist that will not load.",
+  alternates: { canonical: "/guides" },
+  openGraph: {
+    type: "website",
+    url: `${BASE_URL}/guides`,
+    title: "GuessSong Guides",
+    description:
+      "Everything we have learned about running a music guessing game — hosting, playlists, scoring, and the technical bits that break.",
+  },
+};
+
+// Keyed by the union, not by string: a new GuideCategory with no blurb here
+// must be a compile error, not an `undefined` rendered under the heading.
+// Same rule lib/error-messages.ts follows for its translation table.
+const CATEGORY_BLURB: Record<GuideCategory, string> = {
+  Playing: "The game itself — playlists, difficulty, scoring, and the modes worth knowing.",
+  Hosting: "Running the evening: length, seating, sound, and the mistakes that flatten a good night.",
+  Troubleshooting: "When something does not work, and why. Mostly Spotify's fault, honestly.",
+};
+
+export default function GuidesIndexPage() {
+  const itemListLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "GuessSong Guides",
+    itemListElement: GUIDES.map((g, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      url: `${BASE_URL}/guides/${g.slug}`,
+      name: g.title,
+    })),
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListLd) }}
+      />
+      <style>{`
+        @import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Outfit:wght@300;400;500;600;700&display=swap');
+
+        :root {
+          --green: #1DB954;
+          --bg: #111111;
+          --surface: #1a1a1a;
+          --border: #2a2a2a;
+          --text: #f0f0f0;
+          --muted: #999;
+        }
+        body { background: var(--bg); color: var(--text); font-family: 'Outfit', sans-serif; }
+
+        .guides-main {
+          min-height: 100vh;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          padding: 40px 20px 0;
+        }
+        .guides-col { width: 100%; max-width: 760px; }
+
+        .guides-back {
+          display: inline-block;
+          color: var(--muted);
+          font-size: 13px;
+          text-decoration: none;
+          margin-bottom: 32px;
+        }
+        .guides-back:hover { color: var(--green); }
+
+        .guides-eyebrow {
+          color: var(--green);
+          font-size: 12px;
+          font-weight: 500;
+          letter-spacing: 0.1em;
+          text-transform: uppercase;
+          margin-bottom: 10px;
+        }
+        .guides-h1 {
+          font-family: 'Bebas Neue', sans-serif;
+          font-size: clamp(2.4rem, 7vw, 4rem);
+          line-height: 1;
+          letter-spacing: 0.02em;
+          margin-bottom: 16px;
+        }
+        .guides-lede {
+          color: var(--muted);
+          font-size: 17px;
+          font-weight: 300;
+          line-height: 1.65;
+          max-width: 580px;
+          padding-bottom: 28px;
+          border-bottom: 1px solid var(--border);
+          margin-bottom: 8px;
+        }
+
+        .guides-section { margin-top: 48px; }
+        .guides-section-title {
+          font-family: 'Bebas Neue', sans-serif;
+          font-size: clamp(1.5rem, 3.5vw, 2rem);
+          letter-spacing: 0.03em;
+          line-height: 1;
+          margin-bottom: 6px;
+        }
+        .guides-section-blurb {
+          color: #777;
+          font-size: 14px;
+          font-weight: 300;
+          margin-bottom: 18px;
+        }
+
+        .guide-card {
+          display: block;
+          background: var(--surface);
+          border: 1px solid var(--border);
+          border-radius: 12px;
+          padding: 20px 22px;
+          margin-bottom: 12px;
+          text-decoration: none;
+          transition: border-color 0.15s ease, transform 0.15s ease;
+        }
+        .guide-card:hover { border-color: var(--green); transform: translateY(-2px); }
+        .guide-card-title {
+          color: var(--text);
+          font-size: 17px;
+          font-weight: 600;
+          line-height: 1.35;
+          margin-bottom: 7px;
+        }
+        .guide-card-desc {
+          color: #a0a0a0;
+          font-size: 14px;
+          font-weight: 300;
+          line-height: 1.6;
+          margin-bottom: 10px;
+        }
+        .guide-card-meta {
+          color: #666;
+          font-size: 12px;
+          font-weight: 400;
+          letter-spacing: 0.04em;
+        }
+
+        .guides-cta {
+          background: var(--surface);
+          border: 1px solid var(--border);
+          border-radius: 14px;
+          padding: 28px 24px;
+          text-align: center;
+          margin-top: 52px;
+        }
+        .guides-cta p {
+          color: #a0a0a0;
+          font-size: 15px;
+          font-weight: 300;
+          line-height: 1.6;
+          margin-bottom: 18px;
+          max-width: 420px;
+          margin-left: auto;
+          margin-right: auto;
+        }
+        .cta-primary {
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+          background: var(--green);
+          color: #000;
+          font-weight: 600;
+          font-size: 14.5px;
+          padding: 11px 24px;
+          border-radius: 999px;
+          text-decoration: none;
+        }
+        .cta-primary:hover { background: #1ed760; }
+        .link-btn { color: var(--muted); font-size: 13px; text-decoration: none; }
+        .link-btn:hover { color: var(--green); }
+      `}</style>
+
+      <main className="guides-main">
+        <div className="guides-col">
+          <Link href="/" className="guides-back">← GuessSong</Link>
+
+          <header>
+            <p className="guides-eyebrow">Guides</p>
+            <h1 className="guides-h1">How to run a music guessing game</h1>
+            <p className="guides-lede">
+              Everything we have worked out about making one of these evenings good — how to
+              pick a playlist, how long a clip should be, how to score it so the last round
+              still matters, and why Spotify keeps refusing your link.
+            </p>
+          </header>
+
+          {GUIDE_CATEGORIES.map((category) => {
+            const guides = guidesByCategory(category);
+            if (guides.length === 0) return null;
+            return (
+              <section key={category} className="guides-section">
+                <h2 className="guides-section-title">{category}</h2>
+                <p className="guides-section-blurb">{CATEGORY_BLURB[category]}</p>
+                {guides.map((guide) => (
+                  <Link
+                    key={guide.slug}
+                    href={`/guides/${guide.slug}`}
+                    className="guide-card"
+                  >
+                    <p className="guide-card-title">{guide.title}</p>
+                    <p className="guide-card-desc">{guide.description}</p>
+                    <p className="guide-card-meta">{guide.minutes} MIN READ</p>
+                  </Link>
+                ))}
+              </section>
+            );
+          })}
+
+          <section className="guides-cta">
+            <p>
+              All of this applies to any music quiz. If you want one that runs off a Spotify
+              playlist with no login and nothing to install, that is what GuessSong is.
+            </p>
+            <Link href="/" className="cta-primary">Start a game →</Link>
+          </section>
+
+          <SiteFooter />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/app/guides/party-games-for-small-groups/page.tsx
+++ b/app/guides/party-games-for-small-groups/page.tsx
@@ -1,0 +1,195 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { GuideShell, guideMetadata } from "@/app/guides/guide-shell";
+
+const SLUG = "party-games-for-small-groups";
+
+export const metadata: Metadata = guideMetadata(SLUG);
+
+export default function Page() {
+  return (
+    <GuideShell slug={SLUG}>
+      <p>
+        Party games are mostly designed for one of two sizes: two or three people at a
+        table, or a crowd. The awkward middle — four to twelve, one room, everyone can hear
+        each other — has a specific failure mode that most games walk straight into.
+      </p>
+      <p>
+        It is not boredom. It is <strong>elimination</strong>. The person knocked out in the
+        first five minutes now has thirty-five minutes of watching. At a party of forty
+        that is fine, because they can go and talk to someone else. At a party of eight,
+        they are a quarter of the room and there is nowhere to go.
+      </p>
+      <p>
+        So the property to select for at this size is simple: <em>can everyone stay in every
+        round?</em> Here are games that pass, and what each is actually good at.
+      </p>
+
+      <h2>Music guessing</h2>
+      <p>
+        <strong>Best for: 4–12 · Needs: a speaker · Setup: about a minute</strong>
+      </p>
+      <p>
+        Play a short clip, everyone shouts the title, fastest correct answer scores. It
+        passes the test structurally — every player is live on every clip, and being behind
+        does not reduce your chances on the next song.
+      </p>
+      <p>
+        What makes it unusually good at this size is that it needs no reading, no writing and
+        no turn order, so the conversation never stops. People talk over it, argue about
+        whether that was the same song as the last one, and sing along. It is one of the few
+        games that improves rather than collapses when people are not fully concentrating.
+      </p>
+      <p>
+        The variant worth knowing about: instead of everyone guessing the same playlist, have
+        everyone submit their own, merge them, and guess{" "}
+        <Link href="/guides/mixed-playlist-mode-guide">whose playlist each song came from</Link>.
+        That version works with as few as four people and gets better the less alike the
+        group&rsquo;s taste is.
+      </p>
+      <p>
+        <strong>Weakness:</strong> one person who knows every song can flatten it. Fixable —{" "}
+        <Link href="/guides/music-quiz-scoring-rules">the scoring guide covers five ways</Link>.
+      </p>
+
+      <h2>Two Truths and a Lie</h2>
+      <p>
+        <strong>Best for: 5–10 · Needs: nothing · Setup: none</strong>
+      </p>
+      <p>
+        Everyone states three things about themselves; the room votes on which is invented.
+        The reason it endures is that it does double duty — it is a game and it is the
+        fastest way for a group who half-know each other to actually learn something.
+      </p>
+      <p>
+        <strong>Weakness:</strong> it is turn-based, so at ten people each player is active
+        for two minutes and passive for eighteen. Keep it to one round.
+      </p>
+
+      <h2>Fishbowl</h2>
+      <p>
+        <strong>Best for: 6–12 · Needs: paper, a bowl · Setup: five minutes</strong>
+      </p>
+      <p>
+        Everyone writes several names or phrases onto slips. Three rounds with the same
+        slips: describe them freely, then in one word, then mime them. The joke is that by
+        round three everyone remembers the slips, so the constraint gets funnier as the
+        information gets easier.
+      </p>
+      <p>
+        The best structural game on this list — genuinely team-based, no elimination, and the
+        escalating format means it peaks rather than fades.
+      </p>
+      <p>
+        <strong>Weakness:</strong> the setup is real, and it needs an even split into teams.
+      </p>
+
+      <h2>Werewolf and its relatives</h2>
+      <p>
+        <strong>Best for: 7–12 · Needs: a moderator · Setup: ten minutes</strong>
+      </p>
+      <p>
+        Superb when it works, and it is the clearest example of the failure this page is
+        about: it eliminates players by design, and the ones eliminated first are eliminated
+        for the whole game. Under about eight players it also stops functioning as a
+        deduction game.
+      </p>
+      <p>
+        Play it when the group is at the top of this size range, has played before, and
+        someone is genuinely willing to moderate rather than play. Otherwise it is a long
+        setup for a game some people stop being in.
+      </p>
+
+      <h2>Drawing games</h2>
+      <p>
+        <strong>Best for: 4–12 · Needs: paper or phones · Setup: minimal</strong>
+      </p>
+      <p>
+        The write-a-phrase, draw-it, guess-it, draw-that chain. Everyone is active
+        simultaneously, artistic ability is irrelevant and arguably a handicap, and the
+        output is the point — the reveal at the end is what people photograph.
+      </p>
+      <p>
+        <strong>Weakness:</strong> it goes quiet. Everyone is looking down at their own paper
+        or phone for most of it, so it is a poor choice if the room has not warmed up yet.
+      </p>
+
+      <h2>Choosing between them</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>If the group is…</th>
+            <th>Play</th>
+            <th>Because</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Strangers, just arrived</td>
+            <td>Two Truths, then music</td>
+            <td>Names first, competition second</td>
+          </tr>
+          <tr>
+            <td>Old friends</td>
+            <td>Mixed-playlist music, Fishbowl</td>
+            <td>Both reward shared history</td>
+          </tr>
+          <tr>
+            <td>Loud and half-distracted</td>
+            <td>Music guessing</td>
+            <td>The only one that survives inattention</td>
+          </tr>
+          <tr>
+            <td>Wide age range</td>
+            <td>Music guessing, drawing</td>
+            <td>No reading speed, no cultural gatekeeping</td>
+          </tr>
+          <tr>
+            <td>Only four people</td>
+            <td>Music guessing</td>
+            <td>Most of the others need six-plus</td>
+          </tr>
+          <tr>
+            <td>Twelve, and up for a project</td>
+            <td>Fishbowl or Werewolf</td>
+            <td>Both need the numbers to work</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Three rules that apply to all of them</h2>
+      <ol>
+        <li>
+          <strong>Start before everyone has arrived.</strong> Waiting for the last two people
+          costs more energy than starting without them. A game already running is easier to
+          join than a game being explained.
+        </li>
+        <li>
+          <strong>Stop while people still want more.</strong> The single highest-value rule
+          in this entire subject. Ending one round early is what makes a group ask to play
+          again; ending one round late is what makes them remember it as long.
+        </li>
+        <li>
+          <strong>Have exactly one person deciding.</strong> Not a committee. Groups of this
+          size are notoriously bad at choosing a game — twenty minutes of &ldquo;I don&rsquo;t
+          mind, what do you want to do&rdquo; kills more evenings than any bad game ever has.
+          Pick one, announce it, start it.
+        </li>
+      </ol>
+
+      <h2>The two-minute default</h2>
+      <p>
+        If you want a game that needs no equipment, no explanation and no minimum group size,
+        put on a playlist everyone half-knows, play ten seconds of a random track, and let
+        the room shout. It is the lowest-setup thing on this page and it works from four
+        people to twenty.
+      </p>
+      <p>
+        <Link href="/guides/how-to-host-a-music-quiz-night">
+          How to run it so it holds up for a full evening
+        </Link>{" "}
+        is the longer version.
+      </p>
+    </GuideShell>
+  );
+}

--- a/app/guides/spotify-playlist-not-working/page.tsx
+++ b/app/guides/spotify-playlist-not-working/page.tsx
@@ -1,0 +1,215 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { GuideShell, guideMetadata } from "@/app/guides/guide-shell";
+
+const SLUG = "spotify-playlist-not-working";
+
+export const metadata: Metadata = guideMetadata(SLUG);
+
+export default function Page() {
+  return (
+    <GuideShell slug={SLUG}>
+      <p>
+        A playlist that will not load is the most common thing that goes wrong in a
+        Spotify-based game, and it almost always happens at the worst possible moment —
+        eight people sitting down, host pasting a link, nothing happening.
+      </p>
+      <p>
+        The good news is that the causes are few and distinguishable. In our experience four
+        of them account for nearly everything, and three can be fixed in under a minute.
+        Work down this list in order.
+      </p>
+
+      <h2>1. It is one of Spotify&rsquo;s own playlists</h2>
+      <p>
+        This is the single biggest cause, and it surprises everyone, because these playlists
+        are the most visible ones in the app.
+      </p>
+      <p>
+        Playlists curated by Spotify itself — Today&rsquo;s Top Hits, Discover Weekly,
+        RapCaviar, All Out 2000s, every &ldquo;This Is&rdquo; playlist, most mood and genre
+        mixes on the browse page — <strong>cannot be read by third-party applications at
+        all</strong>. In late 2024 Spotify restricted access to its editorial catalogue for
+        newly registered applications, and requests for those playlists now come back as
+        &ldquo;not found&rdquo;, even though the playlist very obviously exists and you are
+        looking at it.
+      </p>
+      <div className="callout">
+        <p className="callout-title">How to spot one in two seconds</p>
+        <p>
+          Look at the playlist id in the link. If it begins <code>37i9</code>, it is a
+          Spotify editorial playlist and no third-party app can load it:
+          <br />
+          <code>open.spotify.com/playlist/<strong>37i9</strong>dQZF1DXcBWIGoYBM5M</code>
+        </p>
+      </div>
+      <p>
+        <strong>The fix, and it takes about thirty seconds:</strong> open the playlist in
+        Spotify, select all the tracks, add them to a new playlist of your own, make that
+        playlist public, and use its link instead. A copy owned by a normal user account
+        reads perfectly. The tracks are identical.
+      </p>
+      <p>
+        This is also a good excuse to trim it. A copied chart playlist is usually better for
+        a quiz after you delete the ten songs nobody in your room will know —{" "}
+        <Link href="/guides/best-playlists-for-a-guess-the-song-game">more on that here</Link>.
+      </p>
+
+      <h2>2. The playlist is private, or collaborative-only</h2>
+      <p>
+        A playlist has to be public for an app that is not logged in as you to see it. This
+        catches people out because a private playlist still produces a perfectly normal
+        share link — the link works for you, because you are signed in as its owner, and
+        fails for everyone and everything else.
+      </p>
+      <p>
+        <strong>The fix:</strong> in Spotify, open the playlist, use the three-dot menu, and
+        choose the option to make it public. On mobile the wording differs slightly by
+        version but it is always in that menu. Then re-copy the link — and give it a few
+        seconds, since the change is not always instantaneous.
+      </p>
+      <p>
+        Note that &ldquo;collaborative&rdquo; is not the same as &ldquo;public&rdquo;. A
+        collaborative playlist that is not also public still cannot be read.
+      </p>
+
+      <h2>3. It is the wrong kind of link</h2>
+      <p>
+        Spotify has several share surfaces and they do not all produce a playlist URL. The
+        ones that fail:
+      </p>
+      <ul>
+        <li>
+          <strong>An album link.</strong> <code>/album/…</code> is not <code>/playlist/…</code>.
+          Easy to do from the Now Playing screen.
+        </li>
+        <li>
+          <strong>An artist or track link.</strong> Same problem — check the path segment.
+        </li>
+        <li>
+          <strong>A short <code>spotify.link</code> URL.</strong> Some share sheets produce
+          a redirect link rather than the real one. Open it in a browser first and copy the
+          address it lands on.
+        </li>
+        <li>
+          <strong>A Spotify URI.</strong> <code>spotify:playlist:…</code> is the desktop
+          app&rsquo;s internal format, not a web address.
+        </li>
+        <li>
+          <strong>A folder.</strong> Folders group playlists in the desktop app and are not
+          playlists themselves. There is nothing to share.
+        </li>
+      </ul>
+      <p>
+        <strong>What a working link looks like:</strong>
+        <br />
+        <code>https://open.spotify.com/playlist/3cEYpjA9oz9GiPac4AsH4n</code>
+      </p>
+      <p>
+        Anything after a <code>?</code> is tracking parameters and can be left on or
+        removed; it makes no difference.
+      </p>
+
+      <h2>4. Rate limiting — and how to tell it apart</h2>
+      <p>
+        This one is different in kind from the first three, and confusing it with them wastes
+        the most time.
+      </p>
+      <p>
+        Spotify limits how often an application may call its API, and the limit applies to{" "}
+        <strong>the application as a whole, not to you</strong>. So if a lot of people are
+        starting games at the same moment, a playlist that is perfectly fine can be refused
+        for a while. Your link is not the problem, and re-pasting it will not help.
+      </p>
+      <p>
+        A well-built app will tell you the difference explicitly rather than showing a
+        generic error — being told to check that your playlist is public when the playlist
+        was always public is how a host ends up spending ten minutes changing settings that
+        were never wrong. If you see a message about the service being busy or a wait time,
+        that is this.
+      </p>
+      <p>
+        <strong>The fix:</strong> wait a minute or two and try again. Nothing on your side
+        needs changing. Playlists that have already been loaded recently usually keep
+        working throughout, so if you have a backup playlist you used earlier, it will
+        probably still start.
+      </p>
+
+      <h2>Rarer causes worth knowing</h2>
+      <ul>
+        <li>
+          <strong>The playlist is empty, or has fewer tracks than the game needs.</strong>{" "}
+          Local files in a playlist do not count — they are not on Spotify&rsquo;s servers
+          and are invisible to any API.
+        </li>
+        <li>
+          <strong>Region restrictions.</strong> A playlist built entirely of tracks
+          unavailable in the market the app queries can come back looking empty.
+        </li>
+        <li>
+          <strong>Very large playlists get sampled.</strong> Playlists in the thousands are
+          usually read only up to a cap — a few hundred tracks, drawn from across the list.
+          For a game that plays 30 songs this changes nothing, but it is why a 4,000-track
+          playlist does not take a minute to load.
+        </li>
+        <li>
+          <strong>The playlist was deleted, or the owner made it private after sharing.</strong>{" "}
+          The link survives; the playlist does not.
+        </li>
+      </ul>
+
+      <h2>A different problem: it loaded, but songs have no audio</h2>
+      <p>
+        If the playlist loaded fine and the game runs but some tracks are silent or skipped,
+        nothing above applies. That is the preview-clip problem, and it has an unrelated
+        cause: Spotify stopped supplying 30-second preview URLs to new applications, so
+        games now find clips elsewhere and coverage is not total.
+      </p>
+      <p>
+        <Link href="/guides/why-spotify-previews-disappeared">
+          What actually happened, and what we measured
+        </Link>{" "}
+        is the full story. The short version: pick mainstream tracks and the hit rate is very
+        high.
+      </p>
+
+      <h2>Quick reference</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Symptom</th>
+            <th>Most likely cause</th>
+            <th>Fix</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Not found, but the playlist clearly exists</td>
+            <td>Editorial playlist (<code>37i9…</code>)</td>
+            <td>Copy the tracks to your own public playlist</td>
+          </tr>
+          <tr>
+            <td>Not found, and it is your own playlist</td>
+            <td>Private</td>
+            <td>Make it public, re-copy the link</td>
+          </tr>
+          <tr>
+            <td>Rejected immediately as invalid</td>
+            <td>Album, track, folder or short link</td>
+            <td>Use a <code>/playlist/</code> URL</td>
+          </tr>
+          <tr>
+            <td>Worked earlier, fails now</td>
+            <td>Rate limiting</td>
+            <td>Wait a minute; change nothing</td>
+          </tr>
+          <tr>
+            <td>Loads, but tracks are silent</td>
+            <td>No preview clip available</td>
+            <td>Prefer mainstream tracks</td>
+          </tr>
+        </tbody>
+      </table>
+    </GuideShell>
+  );
+}

--- a/app/guides/why-spotify-previews-disappeared/page.tsx
+++ b/app/guides/why-spotify-previews-disappeared/page.tsx
@@ -1,0 +1,196 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { GuideShell, guideMetadata } from "@/app/guides/guide-shell";
+
+const SLUG = "why-spotify-previews-disappeared";
+
+export const metadata: Metadata = guideMetadata(SLUG);
+
+export default function Page() {
+  return (
+    <GuideShell slug={SLUG}>
+      <p>
+        For most of the last decade, if you wanted to play a short snippet of a song in a
+        web app, the answer was easy. Spotify&rsquo;s API returned a field called{" "}
+        <code>preview_url</code> on every track: a link to a 30-second MP3, no
+        authentication needed to play it, free to use. An enormous number of small music
+        tools were built on that one field.
+      </p>
+      <p>
+        In late 2024 it stopped coming back. This is what we measured when we went looking,
+        and what a music game has to do instead.
+      </p>
+
+      <h2>What changed</h2>
+      <p>
+        In November 2024 Spotify restricted a group of Web API capabilities for{" "}
+        <strong>newly registered applications</strong>. The list included recommendations,
+        audio-features data, related-artists lookups, access to Spotify&rsquo;s own editorial
+        playlists — and 30-second preview URLs.
+      </p>
+      <p>
+        The change was not retroactive for applications that already existed, which is the
+        detail that made it so confusing to diagnose. Existing integrations carried on
+        working. Documentation still described the field. Tutorials still used it. Answers on
+        forums still recommended it. But any application registered after the cutoff got{" "}
+        <code>null</code> where the URL used to be, with no error and no explanation — the
+        field is still there in the response, it is simply empty.
+      </p>
+      <p>
+        A silent null is about the worst way for a dependency to break. There is nothing to
+        catch, nothing logged, no status code to check. The song list loads perfectly and
+        then nothing plays.
+      </p>
+
+      <h2>What we measured</h2>
+      <p>
+        When we hit this, the first hypothesis was the obvious one: a licensing gap, some
+        tracks in some regions. Preview availability had always been patchy, so partial
+        coverage seemed plausible. We checked it properly before building around it.
+      </p>
+      <p>
+        We pulled twenty well-known, mainstream tracks and requested them through the
+        Client Credentials flow — the server-to-server mode an app uses when it is acting as
+        itself rather than on behalf of a logged-in user — across four different market
+        codes, on an application registered after the cutoff.
+      </p>
+      <div className="callout">
+        <p className="callout-title">The result</p>
+        <p>
+          <strong>0 of 20 tracks returned a preview URL. In all four markets.</strong> Not a
+          coverage gap. Not region-dependent. The field is simply never populated for this
+          class of application.
+        </p>
+      </div>
+      <p>
+        That number settled the design question immediately. A partial result would have
+        meant building a fallback for the gaps. A clean zero means the field cannot be a
+        source at all — which is why the track type in this project carries no{" "}
+        <code>previewUrl</code> field whatsoever. Leaving it in as an optional would have
+        invited someone to reach for it later and rediscover the null the hard way.
+      </p>
+
+      <h2>Where clips come from now</h2>
+      <p>
+        The workaround the ecosystem converged on is to look the song up somewhere else
+        entirely, by name.
+      </p>
+      <p>
+        Two public catalogues still publish 30-second previews without authentication:{" "}
+        <strong>the iTunes Search API</strong> and <strong>Deezer</strong>. Given a track&rsquo;s
+        title and artist from Spotify, you search one, and if that fails, the other. It works.
+        It is also considerably more fragile than reading a field, in three specific ways.
+      </p>
+
+      <h3>The volume is per-track, not per-playlist</h3>
+      <p>
+        Spotify is asked about a playlist once. iTunes and Deezer have to be asked about
+        every single song. A cold 50-song game is 50 separate lookups, each of which may
+        need several queries before something matches — the difference between one upstream
+        request and a couple of hundred. Both services rate-limit, so any app doing this at
+        scale needs aggressive caching just to stay under their ceilings.
+      </p>
+
+      <h3>Matching by name is genuinely hard</h3>
+      <p>
+        This is the interesting part. Searching a catalogue by title and artist sounds
+        trivial and is full of traps:
+      </p>
+      <ul>
+        <li>
+          <strong>Common titles return the most popular song with that name.</strong> Ask
+          iTunes for &ldquo;Hello&rdquo; without an artist and you can get a children&rsquo;s
+          nursery-rhyme version. Ask for &ldquo;Alone&rdquo; and you get Heart. If a game
+          accepted those, it would play one song and reveal a different one — a bug that
+          looks, to the player, like the game simply being wrong.
+        </li>
+        <li>
+          <strong>The same recording is credited differently in different catalogues.</strong>{" "}
+          Non-Latin-script artists are the sharp edge here. A track Spotify lists under the
+          artist 田馥甄 may be listed by iTunes as &ldquo;Hebe Tien&rdquo;, with the title
+          translated too. A strict artist-name comparison rejects the correct result and
+          finds nothing for an entire catalogue of music.
+        </li>
+        <li>
+          <strong>Remasters, live versions, radio edits and karaoke covers</strong> all
+          match the title closely and are all the wrong recording.
+        </li>
+      </ul>
+      <p>
+        The approach that holds up is to ask progressively looser questions, and to raise
+        the standard of proof as the question gets looser. A query that includes the artist
+        can trust the result, because the catalogue already used that signal. A query that
+        drops the artist — the last resort, where the catalogue is ranking purely by
+        popularity — has to verify the candidate some other way, by a matching credit or a
+        matching running time, before accepting it.
+      </p>
+
+      <h3>&ldquo;No preview exists&rdquo; and &ldquo;we could not check&rdquo; are different answers</h3>
+      <p>
+        The subtlest problem, and the one most likely to be got wrong, is what to do with a
+        failure.
+      </p>
+      <p>
+        If a catalogue answers cleanly and has nothing, that is a durable fact about the
+        recording: no clip exists, and it will not exist tomorrow either. Worth remembering
+        for a long time.
+      </p>
+      <p>
+        If the request was rate-limited, timed out, or never arrived, that is a fact about{" "}
+        <em>the requester</em>, and it is true for about a minute. Treating the second like
+        the first is how one busy moment marks a slice of the catalogue permanently silent —
+        a bug that never reproduces in testing, because a developer&rsquo;s own machine is
+        never the one being throttled.
+      </p>
+      <p>
+        There are traps in reading the failures too. iTunes signals throttling with a{" "}
+        <code>403</code> rather than the <code>429</code> you would expect, and Deezer can
+        return a quota error inside the body of an otherwise successful{" "}
+        <code>200</code> response. Reading only the status code classifies both as
+        &ldquo;no result found&rdquo;.
+      </p>
+
+      <h2>What this means when you are playing</h2>
+      <ul>
+        <li>
+          <strong>Some tracks have no clip anywhere and will be skipped.</strong> This is not
+          a bug and there is no setting that fixes it.
+        </li>
+        <li>
+          <strong>Mainstream music has near-total coverage.</strong> Well-known releases are
+          in every catalogue. Obscure independents, regional releases and very new tracks are
+          where the gaps are.{" "}
+          <Link href="/guides/best-playlists-for-a-guess-the-song-game">
+            Choosing a playlist with this in mind
+          </Link>{" "}
+          costs nothing and removes almost all of it.
+        </li>
+        <li>
+          <strong>Clip URLs go stale.</strong> The files sit on content-delivery networks
+          that rotate them, so a link that worked six months ago may not today. A clip that
+          fails to start is usually this, and re-resolving it fixes it.
+        </li>
+        <li>
+          <strong>Occasionally a clip is the wrong recording.</strong> A cover, a live
+          version, or a different song with the same title. Given the matching problem above,
+          this is the residual error rate rather than a mistake — if you hit one,{" "}
+          <Link href="/contact">tell us which song</Link>, because each report is a concrete
+          case to fix.
+        </li>
+      </ul>
+
+      <h2>The wider point</h2>
+      <p>
+        A whole category of small music tools was built on one convenient field in one
+        company&rsquo;s API, and that field went away with a documentation note and no
+        error message. What replaced it is not one lookup but a search problem, a matching
+        problem, a caching problem and a failure-classification problem.
+      </p>
+      <p>
+        Everything above is visible in this project&rsquo;s source, which is public. If you
+        are building something similar, that is probably a faster read than rediscovering
+        the <code>403</code>.
+      </p>
+    </GuideShell>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,6 @@ import { arrivedFrom } from "@/lib/loop-links";
 import { bumpHostGameCount, recallLoopRef, rememberLoopRef } from "@/lib/host-session";
 import { reportGameStart } from "@/lib/loop-client";
 import type { MixedSubMode } from "@/lib/loop-stats";
-import { REPORT_PROBLEM_MAILTO } from "@/lib/contact";
 import {
   AppError,
   apiError,
@@ -23,7 +22,8 @@ import { buildGamePayload, GAME_STORAGE_KEY } from "@/lib/game-session";
 import { isBuzzerConfigured } from "@/lib/buzzer-client";
 import type { OpenRoom } from "@/lib/room-client";
 import { RoomPanel } from "@/components/room-panel";
-import { ChangelogModal } from "@/components/changelog-modal";
+import { SiteFooter } from "@/components/site-footer";
+import { getGuide } from "@/lib/guides";
 import { InstallBanner } from "@/components/install-banner";
 import {
   MixedPlaylistCollector,
@@ -88,6 +88,17 @@ async function settleWithConcurrency<T, R>(
 
 // Rendered on the page *and* emitted as FAQPage JSON-LD below — keep the two
 // in sync, Google penalises schema that doesn't match visible content.
+// The three guides linked from the homepage. Resolved through getGuide rather
+// than retyped so the titles here cannot drift from the articles themselves;
+// filtered so a retired slug costs a card instead of crashing the homepage.
+const HOME_GUIDES = [
+  "how-to-host-a-music-quiz-night",
+  "best-playlists-for-a-guess-the-song-game",
+  "spotify-playlist-not-working",
+]
+  .map((slug) => getGuide(slug))
+  .filter((guide): guide is NonNullable<typeof guide> => Boolean(guide));
+
 const FAQS: { q: string; a: string }[] = [
   {
     q: "How do you play the guess the song game?",
@@ -816,6 +827,35 @@ export default function SetupPage() {
           color: #666;
         }
         .seo-p + .seo-p { margin-top: 10px; }
+        .guide-links {
+          margin-top: 14px;
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+          gap: 10px;
+        }
+        .guide-link {
+          display: block;
+          background: #1a1a1a;
+          border: 1px solid #2a2a2a;
+          border-radius: 10px;
+          padding: 14px 16px;
+          text-decoration: none;
+          transition: border-color 0.15s ease;
+        }
+        .guide-link:hover { border-color: #1DB954; }
+        .guide-link-title {
+          color: #f0f0f0;
+          font-size: 14.5px;
+          font-weight: 600;
+          line-height: 1.4;
+          margin-bottom: 4px;
+        }
+        .guide-link-desc {
+          color: #888;
+          font-size: 12.5px;
+          font-weight: 300;
+          line-height: 1.5;
+        }
         .faq-list { margin-top: 12px; display: flex; flex-direction: column; gap: 14px; }
         .faq-q {
           font-size: 13px;
@@ -1363,22 +1403,29 @@ export default function SetupPage() {
             </div>
           </section>
 
-          {/* Footer */}
-          <footer style={{ textAlign: "center", marginTop: "32px", paddingTop: "20px", borderTop: "1px solid var(--border)" }}>
-            <div
-              style={{
-                display: "flex",
-                gap: "10px",
-                justifyContent: "center",
-                alignItems: "center",
-                flexWrap: "wrap",
-              }}
-            >
-              <a href={REPORT_PROBLEM_MAILTO} className="link-btn">Report a problem</a>
-              <span aria-hidden style={{ color: "#333" }}>·</span>
-              <ChangelogModal />
+          {/* Three of the guides, not all eight — this is a teaser under a form,
+              not a second index. HOME_GUIDES names which three; the copy comes
+              from lib/guides.ts so a retitled guide is retitled here too. */}
+          <section className="seo-section">
+            <h2 className="seo-h2">Guides</h2>
+            <p className="seo-p">
+              Longer pieces on running one of these evenings — what to put on, how hard to
+              make it, and what to do when Spotify refuses your link.
+            </p>
+            <div className="guide-links">
+              {HOME_GUIDES.map((guide) => (
+                <a key={guide.slug} href={`/guides/${guide.slug}`} className="guide-link">
+                  <span className="guide-link-title">{guide.navTitle}</span>
+                  <span className="guide-link-desc">{guide.description}</span>
+                </a>
+              ))}
             </div>
-          </footer>
+            <p style={{ marginTop: "14px" }}>
+              <a href="/guides" className="link-btn">All guides →</a>
+            </p>
+          </section>
+
+          <SiteFooter />
 
         </div>
       </main>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,226 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArticleShell } from "@/components/article-shell";
+import { CONTACT_EMAIL } from "@/lib/contact";
+import { POLICY_LAST_UPDATED } from "@/lib/legal";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description:
+    "What GuessSong stores, what it does not, and which third parties are involved. GuessSong has no accounts and no login: game state lives in your own browser.",
+  alternates: {
+    canonical: "/privacy",
+    languages: { en: "/privacy", "zh-TW": "/zh/privacy" },
+  },
+};
+
+export default function PrivacyPage() {
+  return (
+    <ArticleShell
+      eyebrow="Legal"
+      title="Privacy Policy"
+      lede="GuessSong has no accounts, no login and no user profiles. This page describes exactly what does get stored, for how long, and who else is involved."
+      meta={`Last updated ${POLICY_LAST_UPDATED} · Operated by GuessSong · ${CONTACT_EMAIL}`}
+      backHref="/"
+    >
+      <div className="callout">
+        <p className="callout-title">The short version</p>
+        <p>
+          We never ask who you are. Your game — playlist, player names, scores — is held
+          by your own browser and disappears when you close the tab. The only things that
+          reach a server are a playlist link (to read its track list), a song title and
+          artist (to find an audio clip), and, if you use Mixed Playlist Mode, a room that
+          deletes itself within hours. Google AdSense and Google Analytics run on this
+          site and set their own cookies.
+        </p>
+      </div>
+
+      <h2>Who we are</h2>
+      <p>
+        GuessSong (&ldquo;we&rdquo;, &ldquo;the site&rdquo;) is a free, open-source party
+        game published at <code>www.guessong.app</code>. The source code is public at{" "}
+        <a href="https://github.com/Waynting/GuessSong" target="_blank" rel="noopener noreferrer">
+          github.com/Waynting/GuessSong
+        </a>
+        , so every claim on this page can be checked against the code that makes it. For
+        any privacy question, write to{" "}
+        <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>.
+      </p>
+
+      <h2>We do not have accounts</h2>
+      <p>
+        There is no sign-up, no login, no password and no Spotify authorisation step.
+        We do not know your name, email address or Spotify identity, because the site
+        never asks for them and has nowhere to put them. There is no user database.
+      </p>
+
+      <h2>What stays in your browser</h2>
+      <p>
+        A game in progress is held in your device&rsquo;s <strong>session storage</strong>
+        — a per-tab store the browser clears when you close the tab. It contains the
+        tracks drawn from the playlist you pasted, the player names you typed, the clip
+        length you chose and the running scores. It is never transmitted to us.
+      </p>
+      <p>
+        The site also uses <strong>local storage</strong> for small preferences, such as
+        whether you have already seen the current release notes. Clearing your browser
+        data for this site removes both.
+      </p>
+
+      <h2>What reaches our servers</h2>
+      <h3>Playlist lookups</h3>
+      <p>
+        When you paste a Spotify playlist link, that link is sent to our server, which
+        asks Spotify&rsquo;s public Web API for the playlist&rsquo;s name and track list.
+        We use Spotify&rsquo;s <em>Client Credentials</em> flow, which authenticates{" "}
+        <em>this application</em> and not you: Spotify is never told who is asking, and
+        we never gain access to your Spotify account, library or listening history. The
+        resulting track list is cached on our side for a few hours, keyed by the playlist
+        id, so that a popular playlist is not fetched repeatedly.
+      </p>
+
+      <h3>Audio clip lookups</h3>
+      <p>
+        Spotify stopped supplying preview clips for most tracks in late 2024, so for each
+        song the site sends the <strong>song title and artist name</strong> to the iTunes
+        Search API and, if that finds nothing, to Deezer, in order to locate a 30-second
+        preview. Only the title and artist are sent. The result is cached by track id,
+        including &ldquo;no preview exists&rdquo; results.
+      </p>
+
+      <h3>Mixed Playlist Mode rooms</h3>
+      <p>
+        If you create a room so that other people can submit playlists from their phones,
+        we store — in a temporary key-value store — the room code, the display names
+        players type in, and the track lists drawn from the playlists they submit. This
+        record carries an expiry from the moment it is created and is deleted
+        automatically when that expiry passes; it is also intended to be consumed once,
+        when the host starts the game. Type a nickname rather than your legal name if you
+        would rather not appear in it.
+      </p>
+
+      <h3>Buzzer rooms</h3>
+      <p>
+        Buzzer Mode runs on Cloudflare Durable Objects and holds, for the life of the
+        room only, the player names in it and who pressed first. Nothing survives the room.
+      </p>
+
+      <h3>Rate limiting and abuse prevention</h3>
+      <p>
+        To stop one visitor from exhausting the shared quotas we have with Spotify and
+        iTunes, our server counts requests per <strong>IP address</strong> in a short
+        fixed window. What is stored is a counter against a key derived from the address,
+        held for the length of that window (minutes) and then gone. We do not build
+        profiles from it and do not use it to identify anyone.
+      </p>
+
+      <h3>Server logs</h3>
+      <p>
+        Our hosting provider, Vercel, records standard request logs (timestamp, path,
+        response status, IP address, user agent) as part of operating the service. These
+        are retained by Vercel under their own policy and are used only for debugging and
+        security.
+      </p>
+
+      <h2>Counting, not tracking</h2>
+      <p>
+        We keep a small set of aggregate counters — how many games were started, how many
+        people arrived from a shared link — as plain numbers per day. They are totals with
+        no identifier attached and cannot be traced back to a person or a device.
+      </p>
+
+      <h2>Third parties, cookies and advertising</h2>
+      <p>
+        Three Google services run on this site, and each sets its own cookies or similar
+        identifiers under its own policy:
+      </p>
+      <ul>
+        <li>
+          <strong>Google AdSense</strong> serves the advertising on this site. Google and
+          its partners may use cookies to serve ads based on your prior visits to this and
+          other websites.
+        </li>
+        <li>
+          <strong>Google Analytics 4</strong> gives us aggregate usage statistics — page
+          views, which features are used, which errors occur. Failure reasons are recorded
+          as fixed categories, never as raw text, so nothing you paste or type is
+          forwarded to Analytics.
+        </li>
+        <li>
+          <strong>Google Fonts</strong> serves the two typefaces the site uses.
+        </li>
+      </ul>
+      <p>
+        Google&rsquo;s use of advertising cookies enables it and its partners to serve ads
+        to you based on your visit to this site and other sites on the internet. You can
+        opt out of personalised advertising at{" "}
+        <a href="https://www.google.com/settings/ads" target="_blank" rel="noopener noreferrer">
+          Google Ads Settings
+        </a>
+        , or opt out of third-party vendors&rsquo; use of cookies for personalised
+        advertising at{" "}
+        <a href="https://www.aboutads.info/choices/" target="_blank" rel="noopener noreferrer">
+          aboutads.info/choices
+        </a>
+        . Google&rsquo;s own handling of data is described in its{" "}
+        <a href="https://policies.google.com/technologies/partner-sites" target="_blank" rel="noopener noreferrer">
+          privacy and terms
+        </a>
+        .
+      </p>
+      <p>
+        We also depend on Spotify, Apple (iTunes Search), Deezer, Vercel, Upstash and
+        Cloudflare as described above. We do not sell or share personal information, and
+        there is no personal information here to sell.
+      </p>
+
+      <h2>Visitors in the EEA, UK and Switzerland</h2>
+      <p>
+        Where a lawful basis is required, we rely on <strong>legitimate interests</strong>
+        for the technical processing that makes the game work (playlist and clip lookups,
+        rate limiting, server logs), and on <strong>consent</strong> for advertising and
+        analytics cookies, collected through Google&rsquo;s consent mechanism where it
+        applies. You have the right to access, correct, delete, restrict or object to
+        processing of your personal data, and to complain to your local supervisory
+        authority. Because we hold no accounts, in most cases we have nothing on file to
+        return — but write to us and we will tell you exactly that.
+      </p>
+
+      <h2>Visitors in California</h2>
+      <p>
+        We do not sell personal information and do not share it for cross-context
+        behavioural advertising as those terms are defined by the CCPA/CPRA. To exercise
+        any CCPA right, contact us at the address below.
+      </p>
+
+      <h2>Children</h2>
+      <p>
+        GuessSong is a general-audience game and is not directed at children under 13. We
+        do not knowingly collect personal information from children. If you believe a
+        child has submitted personal information through a Mixed Playlist room, tell us
+        and we will remove it — and note that these rooms expire on their own within hours
+        regardless.
+      </p>
+
+      <h2>Changes to this policy</h2>
+      <p>
+        If this policy changes materially, the date at the top of the page changes with it.
+        The site&rsquo;s release notes, linked in the footer, record when.
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        Questions, requests and complaints:{" "}
+        <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>. There is more on how to
+        reach us on the <Link href="/contact">contact page</Link>.
+      </p>
+
+      <div className="article-cta">
+        <p>Nothing to sign up for. Paste a playlist and play.</p>
+        <Link href="/" className="cta-primary">
+          Start a game →
+        </Link>
+      </div>
+    </ArticleShell>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { GUIDES } from "@/lib/guides";
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://www.guessong.app";
 
@@ -11,26 +12,97 @@ const LANGUAGE_ALTERNATES = {
 };
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  return [
+  const now = new Date();
+
+  const core: MetadataRoute.Sitemap = [
     {
       url: BASE_URL,
-      lastModified: new Date(),
+      lastModified: now,
       changeFrequency: "monthly",
       priority: 1,
       alternates: { languages: LANGUAGE_ALTERNATES },
     },
     {
       url: `${BASE_URL}/about`,
-      lastModified: new Date(),
+      lastModified: now,
       changeFrequency: "monthly",
       priority: 0.8,
     },
     {
       url: `${BASE_URL}/zh`,
-      lastModified: new Date(),
+      lastModified: now,
       changeFrequency: "monthly",
       priority: 0.9,
       alternates: { languages: LANGUAGE_ALTERNATES },
     },
+    {
+      url: `${BASE_URL}/guides`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
   ];
+
+  // Derived from lib/guides.ts rather than listed again. A guide that shipped
+  // but never reached the sitemap is a page Google does not come back for, and
+  // nothing on screen would say so — same hand-sync failure lib/loop-links.ts
+  // is shaped to avoid.
+  const guides: MetadataRoute.Sitemap = GUIDES.map((guide) => ({
+    url: `${BASE_URL}/guides/${guide.slug}`,
+    lastModified: new Date(guide.published),
+    changeFrequency: "monthly" as const,
+    priority: 0.7,
+  }));
+
+  // Policy pages are low priority but must be crawlable and discoverable: an
+  // ad network's site review looks for them, and a page it cannot find reads
+  // exactly like a page that does not exist.
+  const policy: MetadataRoute.Sitemap = [
+    {
+      url: `${BASE_URL}/privacy`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.4,
+      alternates: {
+        languages: {
+          en: `${BASE_URL}/privacy`,
+          "zh-TW": `${BASE_URL}/zh/privacy`,
+          "x-default": `${BASE_URL}/privacy`,
+        },
+      },
+    },
+    {
+      url: `${BASE_URL}/terms`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.4,
+      alternates: {
+        languages: {
+          en: `${BASE_URL}/terms`,
+          "zh-TW": `${BASE_URL}/zh/terms`,
+          "x-default": `${BASE_URL}/terms`,
+        },
+      },
+    },
+    {
+      url: `${BASE_URL}/contact`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.5,
+    },
+    {
+      url: `${BASE_URL}/zh/privacy`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.4,
+    },
+    {
+      url: `${BASE_URL}/zh/terms`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.4,
+    },
+  ];
+
+  return [...core, ...guides, ...policy];
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,179 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArticleShell } from "@/components/article-shell";
+import { CONTACT_EMAIL } from "@/lib/contact";
+import { POLICY_LAST_UPDATED } from "@/lib/legal";
+
+export const metadata: Metadata = {
+  title: "Terms of Use",
+  description:
+    "The terms you accept by using GuessSong: what the game is, what it is not, how it relates to Spotify, iTunes and Deezer, and the limits of the service.",
+  alternates: {
+    canonical: "/terms",
+    languages: { en: "/terms", "zh-TW": "/zh/terms" },
+  },
+};
+
+export default function TermsPage() {
+  return (
+    <ArticleShell
+      eyebrow="Legal"
+      title="Terms of Use"
+      lede="GuessSong is a free, open-source party game offered as-is. These are the terms you accept by using it."
+      meta={`Last updated ${POLICY_LAST_UPDATED} · ${CONTACT_EMAIL}`}
+      backHref="/"
+    >
+      <h2>1. What this service is</h2>
+      <p>
+        GuessSong is a free browser-based party game. You give it a link to a public
+        Spotify playlist; it reads that playlist&rsquo;s track list, finds a short
+        publicly available preview clip for each song, and plays those clips so the people
+        in the room can guess the titles. There is nothing to install, no account to
+        create and no charge.
+      </p>
+      <p>
+        By using the site you agree to these terms. If you do not agree with them, do not
+        use the site.
+      </p>
+
+      <h2>2. We are not Spotify</h2>
+      <p>
+        <strong>
+          GuessSong is an independent project. It is not affiliated with, endorsed,
+          sponsored or certified by Spotify AB, Apple Inc. or Deezer S.A.
+        </strong>{" "}
+        Spotify, iTunes and Deezer are trademarks of their respective owners and are used
+        here only to describe what the game reads from.
+      </p>
+      <p>
+        The site reads public playlist metadata through Spotify&rsquo;s public Web API,
+        and preview clips through the public iTunes Search API and Deezer&rsquo;s public
+        API. It does not download, store, host or redistribute any music. Clips stream
+        directly from the provider that hosts them, and each provider&rsquo;s own terms
+        apply to that playback. We do not remove, bypass or interfere with any technical
+        protection measure.
+      </p>
+
+      <h2>3. Acceptable use</h2>
+      <p>You agree not to:</p>
+      <ul>
+        <li>
+          use the site for any unlawful purpose, or in any way that infringes someone
+          else&rsquo;s rights;
+        </li>
+        <li>
+          submit a playlist link you do not have the right to share, or submit content
+          that is unlawful, abusive or hateful — including in the display names typed into
+          a Mixed Playlist room, which other players will see;
+        </li>
+        <li>
+          automate, scrape or otherwise send requests at a volume that degrades the
+          service for other people, or attempt to circumvent the rate limits that exist to
+          prevent exactly that;
+        </li>
+        <li>
+          attempt to gain unauthorised access to the site, its infrastructure or the rooms
+          created by other hosts, including by guessing room codes;
+        </li>
+        <li>
+          use the site to reproduce, perform or distribute music in a way that requires a
+          licence you do not hold. A private game night among friends and a public
+          performance are not the same thing, and only you know which one you are running.
+        </li>
+      </ul>
+
+      <h2>4. Rooms and player-submitted content</h2>
+      <p>
+        Mixed Playlist Mode lets other people submit playlist links and display names into
+        a room you host. That content belongs to whoever submitted it; we do not claim
+        ownership of it and we do not moderate it. Rooms are temporary and expire
+        automatically. If something inappropriate appears in a room, the host can simply
+        stop the game — and the room will delete itself regardless.
+      </p>
+
+      <h2>5. Availability, and the things that break</h2>
+      <p>
+        The service is provided <strong>&ldquo;as is&rdquo; and &ldquo;as
+        available&rdquo;</strong>, without warranties of any kind, express or implied,
+        including merchantability, fitness for a particular purpose and non-infringement.
+        Specifically, and to be honest about the failure modes we already know:
+      </p>
+      <ul>
+        <li>
+          some tracks have no preview clip anywhere and will be skipped, so a playlist may
+          play fewer songs than it holds;
+        </li>
+        <li>
+          Spotify&rsquo;s editorial playlists cannot be read at all, and private or
+          region-restricted playlists will fail;
+        </li>
+        <li>
+          the upstream services this site depends on impose their own rate limits, and
+          when they refuse a request, the game will too;
+        </li>
+        <li>
+          we may change, suspend or discontinue any part of the service at any time,
+          without notice.
+        </li>
+      </ul>
+      <p>
+        We do not warrant that the service will be uninterrupted, timely, secure or
+        error-free.
+      </p>
+
+      <h2>6. Limitation of liability</h2>
+      <p>
+        To the fullest extent permitted by law, GuessSong and its maintainers are not
+        liable for any indirect, incidental, special, consequential or punitive damages,
+        or any loss of data, profits or goodwill, arising from your use of or inability to
+        use the service. Since the service is provided free of charge, our total aggregate
+        liability to you is limited to the amount you have paid for it, which is nothing.
+      </p>
+      <p>
+        Nothing in these terms excludes or limits liability that cannot lawfully be
+        excluded or limited, including liability for death or personal injury caused by
+        negligence, or for fraud.
+      </p>
+
+      <h2>7. The code, and its licence</h2>
+      <p>
+        GuessSong&rsquo;s source code is published under the MIT licence at{" "}
+        <a href="https://github.com/Waynting/GuessSong" target="_blank" rel="noopener noreferrer">
+          github.com/Waynting/GuessSong
+        </a>
+        . That licence governs the code. It does not grant any right in the GuessSong
+        name, in the music the game plays, or in any third-party service the code talks
+        to — and these terms, not the licence, govern your use of the hosted site.
+      </p>
+
+      <h2>8. Privacy and advertising</h2>
+      <p>
+        The <Link href="/privacy">Privacy Policy</Link> forms part of these terms and
+        describes what the site stores and which third parties are involved. This site
+        carries advertising served by Google AdSense.
+      </p>
+
+      <h2>9. Changes</h2>
+      <p>
+        We may update these terms. The date at the top of this page records when they last
+        changed, and continuing to use the site after a change means you accept the
+        updated terms.
+      </p>
+
+      <h2>10. Contact</h2>
+      <p>
+        Questions about these terms, or a rights complaint about anything on this site:{" "}
+        <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>. We respond to
+        well-founded takedown requests promptly — see the{" "}
+        <Link href="/contact">contact page</Link> for what to include.
+      </p>
+
+      <div className="article-cta">
+        <p>That&rsquo;s the paperwork. The game is more fun.</p>
+        <Link href="/" className="cta-primary">
+          Start a game →
+        </Link>
+      </div>
+    </ArticleShell>
+  );
+}

--- a/app/zh/page.tsx
+++ b/app/zh/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { REPORT_PROBLEM_MAILTO } from "@/lib/contact";
-import { ChangelogModal } from "@/components/changelog-modal";
+import { SiteFooter } from "@/components/site-footer";
 
 export const metadata: Metadata = {
   // Unlike the English pages, the H1 here IS the keyword — /zh is not the brand
@@ -428,24 +427,7 @@ export default function ZhPage() {
             </div>
           </section>
 
-          <footer style={{ textAlign: "center", paddingTop: "20px", borderTop: "1px solid var(--border)" }}>
-            <div
-              style={{
-                display: "flex",
-                gap: "10px",
-                justifyContent: "center",
-                alignItems: "center",
-                flexWrap: "wrap",
-              }}
-            >
-              <a href={REPORT_PROBLEM_MAILTO} className="link-btn">回報問題</a>
-              <span aria-hidden style={{ color: "#333" }}>·</span>
-              {/* Chinese notes, to match the page they open from — /zh is written
-                  natively rather than translated, and an English panel here would
-                  be the one seam in it. */}
-              <ChangelogModal locale="zh" />
-            </div>
-          </footer>
+          <SiteFooter locale="zh" />
         </div>
       </main>
     </>

--- a/app/zh/privacy/page.tsx
+++ b/app/zh/privacy/page.tsx
@@ -1,0 +1,196 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArticleShell } from "@/components/article-shell";
+import { CONTACT_EMAIL } from "@/lib/contact";
+import { POLICY_LAST_UPDATED_ZH } from "@/lib/legal";
+
+export const metadata: Metadata = {
+  title: "隱私權政策",
+  description:
+    "GuessSong 會存什麼、不存什麼，以及有哪些第三方服務參與。這個遊戲沒有帳號、不用登入，遊戲進度留在你自己的瀏覽器裡。",
+  alternates: {
+    canonical: "/zh/privacy",
+    languages: { en: "/privacy", "zh-TW": "/zh/privacy" },
+  },
+};
+
+export default function ZhPrivacyPage() {
+  return (
+    <ArticleShell
+      eyebrow="法律資訊"
+      title="隱私權政策"
+      lede="GuessSong 沒有帳號、不用登入、也沒有使用者檔案。這一頁說明真正會被存下來的東西是什麼、存多久，以及還有誰參與其中。"
+      meta={`最後更新 ${POLICY_LAST_UPDATED_ZH} · 營運者 GuessSong · ${CONTACT_EMAIL}`}
+      locale="zh"
+      backHref="/zh"
+      backLabel="← 回到 GuessSong"
+    >
+      <div className="callout">
+        <p className="callout-title">先講結論</p>
+        <p>
+          我們從來不問你是誰。你的遊戲內容 —— 歌單、玩家名字、分數 —— 都由你自己的瀏覽器保管，關掉分頁就消失。
+          真正會送到伺服器的只有三件事：一個歌單連結（用來讀出曲目）、歌名和歌手（用來找試聽片段），
+          以及你如果開了混合歌單模式，一個幾小時內就會自動刪除的房間。
+          本站有執行 Google AdSense 廣告和 Google Analytics，兩者會依各自的政策設置 Cookie。
+        </p>
+      </div>
+
+      <h2>我們是誰</h2>
+      <p>
+        GuessSong 是一個免費的開源團康遊戲，網址是 <code>www.guessong.app</code>。
+        原始碼公開在{" "}
+        <a href="https://github.com/Waynting/GuessSong" target="_blank" rel="noopener noreferrer">
+          github.com/Waynting/GuessSong
+        </a>
+        ，所以這一頁講的每一句話都可以直接對照程式碼檢查。任何隱私相關問題請寄到{" "}
+        <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>。
+      </p>
+
+      <h2>這裡沒有帳號</h2>
+      <p>
+        沒有註冊、沒有登入、沒有密碼，也沒有任何一步要你授權 Spotify。
+        我們不知道你的名字、Email 或 Spotify 身分，因為網站從來不問，也沒有地方可以放。
+        這裡沒有使用者資料庫。
+      </p>
+
+      <h2>留在你瀏覽器裡的東西</h2>
+      <p>
+        進行中的遊戲存在你裝置的 <strong>session storage</strong> —— 一個瀏覽器在你關掉分頁時就會清掉的空間。
+        裡面是從你貼上的歌單抓出來的曲目、你輸入的玩家名字、你選的片段長度，以及當下的分數。這些從來不會傳給我們。
+      </p>
+      <p>
+        網站也會用 <strong>local storage</strong> 記一些小設定，例如你是不是已經看過這一版的更新說明。
+        清除本站的瀏覽資料就會一起清掉。
+      </p>
+
+      <h2>會送到伺服器的東西</h2>
+      <h3>讀取歌單</h3>
+      <p>
+        當你貼上 Spotify 歌單連結時，這個連結會送到我們的伺服器，由伺服器去問 Spotify 的公開 Web API
+        要歌單名稱和曲目清單。我們用的是 Spotify 的 <em>Client Credentials</em> 流程，
+        這個流程驗證的是<em>這個應用程式</em>而不是你：Spotify 完全不會知道是誰在問，
+        我們也拿不到你的 Spotify 帳號、收藏或聽歌紀錄。抓回來的曲目清單會以歌單 ID 為鍵在我們這邊快取幾小時，
+        避免同一個熱門歌單被重複抓取。
+      </p>
+
+      <h3>尋找試聽片段</h3>
+      <p>
+        Spotify 在 2024 年底停止提供大部分歌曲的試聽片段，所以針對每一首歌，
+        網站會把<strong>歌名和歌手名稱</strong>送到 iTunes Search API，找不到的話再送到 Deezer，
+        用來找出 30 秒的試聽片段。送出去的就只有歌名和歌手。
+        結果會以曲目 ID 快取起來，包括「哪裡都沒有片段」這種結果。
+      </p>
+
+      <h3>混合歌單模式的房間</h3>
+      <p>
+        如果你建立房間讓其他人用手機交出自己的歌單，我們會在一個暫存的鍵值資料庫裡存下：
+        房間代碼、玩家自己輸入的顯示名稱，以及從他們提交的歌單抓出來的曲目清單。
+        這筆紀錄從建立的那一刻就帶著到期時間，時間一到就自動刪除；
+        設計上它也只會被消耗一次，就是主持人開始遊戲的時候。
+        如果你不希望自己的本名出現在裡面，輸入暱稱就好。
+      </p>
+
+      <h3>搶答器房間</h3>
+      <p>
+        搶答器模式跑在 Cloudflare Durable Objects 上，只在房間存在期間保留房內的玩家名字和誰先按。
+        房間結束後什麼都不留。
+      </p>
+
+      <h3>流量限制與濫用防護</h3>
+      <p>
+        為了避免單一訪客把我們跟 Spotify、iTunes 共用的額度用光，
+        伺服器會在很短的固定時間窗內以 <strong>IP 位址</strong>為單位計算請求次數。
+        存下來的東西是一個對應到該位址的計數器，只保留那個時間窗的長度（幾分鐘）然後就消失。
+        我們不會拿它建立任何個人檔案，也不會用它辨識任何人。
+      </p>
+
+      <h3>伺服器日誌</h3>
+      <p>
+        我們的主機服務商 Vercel 會在營運過程中記錄標準的請求日誌（時間、路徑、回應狀態、IP 位址、瀏覽器識別字串）。
+        這些由 Vercel 依其自身政策保存，只用於除錯與安全用途。
+      </p>
+
+      <h2>計數，而不是追蹤</h2>
+      <p>
+        我們會保留一小組彙總計數 —— 每天開了幾場遊戲、有多少人是從分享連結進來的 —— 就是單純的數字。
+        它們沒有附帶任何識別資訊，無法回推到某個人或某台裝置。
+      </p>
+
+      <h2>第三方、Cookie 與廣告</h2>
+      <p>本站執行三個 Google 服務，各自依照自己的政策設置 Cookie 或類似的識別技術：</p>
+      <ul>
+        <li>
+          <strong>Google AdSense</strong> 負責本站的廣告。Google 及其合作夥伴可能會使用 Cookie，
+          根據你先前造訪本站和其他網站的紀錄來投放廣告。
+        </li>
+        <li>
+          <strong>Google Analytics 4</strong> 提供彙總的使用統計 —— 瀏覽次數、哪些功能被使用、發生了哪些錯誤。
+          失敗原因一律記成固定的分類代碼，絕不記成原始文字，所以你貼上或輸入的內容不會被送進 Analytics。
+        </li>
+        <li>
+          <strong>Google Fonts</strong> 提供本站使用的兩套字體。
+        </li>
+      </ul>
+      <p>
+        Google 使用廣告 Cookie，讓 Google 及其合作夥伴能根據你造訪本站及網路上其他網站的紀錄向你放送廣告。
+        你可以到{" "}
+        <a href="https://www.google.com/settings/ads" target="_blank" rel="noopener noreferrer">
+          Google 廣告設定
+        </a>
+        {" "}停用個人化廣告，或到{" "}
+        <a href="https://www.aboutads.info/choices/" target="_blank" rel="noopener noreferrer">
+          aboutads.info/choices
+        </a>
+        {" "}停用第三方供應商為了個人化廣告而使用的 Cookie。Google 自身的資料處理方式說明於其{" "}
+        <a href="https://policies.google.com/technologies/partner-sites" target="_blank" rel="noopener noreferrer">
+          隱私權與條款
+        </a>
+        。
+      </p>
+      <p>
+        除此之外，我們如前所述依賴 Spotify、Apple（iTunes Search）、Deezer、Vercel、Upstash 與 Cloudflare。
+        我們不販售也不分享個人資訊 —— 這裡本來就沒有個人資訊可賣。
+      </p>
+
+      <h2>歐洲經濟區、英國與瑞士的訪客</h2>
+      <p>
+        在需要合法處理依據時，讓遊戲能運作的技術性處理（讀取歌單與試聽片段、流量限制、伺服器日誌）
+        我們依據<strong>正當利益</strong>；廣告與分析 Cookie 則依據<strong>同意</strong>，
+        在適用的情況下透過 Google 的同意機制取得。
+        你有權要求存取、更正、刪除、限制處理你的個人資料，或對處理提出反對，也有權向當地的監理機關申訴。
+        由於我們沒有帳號制度，多數情況下我們手上根本沒有可以回覆或刪除的資料 —— 但你寄信來，我們會明確這樣告訴你。
+      </p>
+
+      <h2>加州訪客</h2>
+      <p>
+        依 CCPA/CPRA 對這些詞的定義，我們不販售個人資訊，也不為了跨情境行為廣告而分享個人資訊。
+        要行使任何 CCPA 權利，請透過下方的聯絡方式與我們聯繫。
+      </p>
+
+      <h2>兒童</h2>
+      <p>
+        GuessSong 是面向一般大眾的遊戲，並非針對 13 歲以下兒童設計。我們不會刻意蒐集兒童的個人資訊。
+        如果你認為有兒童透過混合歌單房間提交了個人資訊，請告訴我們，我們會移除 ——
+        另外也請注意，這些房間無論如何都會在數小時內自行到期刪除。
+      </p>
+
+      <h2>政策變更</h2>
+      <p>
+        如果這份政策有實質變更，頁面上方的日期會跟著更新。頁尾連結的更新說明會記錄變更的時間點。
+      </p>
+
+      <h2>聯絡方式</h2>
+      <p>
+        疑問、請求與申訴：<a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>。
+        <Link href="/contact">聯絡頁面</Link>有更完整的聯絡說明。
+      </p>
+
+      <div className="article-cta">
+        <p>沒有東西要註冊。貼上歌單就能開始。</p>
+        <Link href="/zh" className="cta-primary">
+          開始遊戲 →
+        </Link>
+      </div>
+    </ArticleShell>
+  );
+}

--- a/app/zh/terms/page.tsx
+++ b/app/zh/terms/page.tsx
@@ -1,0 +1,142 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArticleShell } from "@/components/article-shell";
+import { CONTACT_EMAIL } from "@/lib/contact";
+import { POLICY_LAST_UPDATED_ZH } from "@/lib/legal";
+
+export const metadata: Metadata = {
+  title: "服務條款",
+  description:
+    "使用 GuessSong 即代表你接受的條款：這個遊戲是什麼、不是什麼、它和 Spotify／iTunes／Deezer 的關係，以及服務的限制。",
+  alternates: {
+    canonical: "/zh/terms",
+    languages: { en: "/terms", "zh-TW": "/zh/terms" },
+  },
+};
+
+export default function ZhTermsPage() {
+  return (
+    <ArticleShell
+      eyebrow="法律資訊"
+      title="服務條款"
+      lede="GuessSong 是免費的開源團康遊戲，以現狀提供。以下是你使用它時所接受的條款。"
+      meta={`最後更新 ${POLICY_LAST_UPDATED_ZH} · ${CONTACT_EMAIL}`}
+      locale="zh"
+      backHref="/zh"
+      backLabel="← 回到 GuessSong"
+    >
+      <h2>1. 這個服務是什麼</h2>
+      <p>
+        GuessSong 是一個免費、在瀏覽器裡跑的團康遊戲。你給它一個公開 Spotify 歌單的連結，
+        它會讀出這個歌單的曲目、幫每首歌找到一段公開的試聽片段，然後播出來讓在場的人猜歌名。
+        沒有東西要安裝、沒有帳號要註冊，也不收費。
+      </p>
+      <p>使用本站即表示你同意這些條款。如果你不同意，請不要使用本站。</p>
+
+      <h2>2. 我們不是 Spotify</h2>
+      <p>
+        <strong>
+          GuessSong 是獨立專案，與 Spotify AB、Apple Inc.、Deezer S.A. 沒有任何從屬、背書、
+          贊助或認證關係。
+        </strong>{" "}
+        Spotify、iTunes 和 Deezer 是各自所有權人的商標，在此僅用於說明本遊戲讀取資料的來源。
+      </p>
+      <p>
+        本站透過 Spotify 的公開 Web API 讀取公開歌單的中繼資料，
+        並透過公開的 iTunes Search API 與 Deezer 公開 API 取得試聽片段。
+        本站不下載、不儲存、不代管、也不重新散布任何音樂。
+        片段是直接從代管它的服務串流播放，該服務自己的條款適用於這段播放行為。
+        我們不移除、不繞過、也不干擾任何技術保護措施。
+      </p>
+
+      <h2>3. 可接受的使用方式</h2>
+      <p>你同意不會：</p>
+      <ul>
+        <li>將本站用於任何不法目的，或以任何侵害他人權利的方式使用；</li>
+        <li>
+          提交你無權分享的歌單連結，或提交不法、辱罵、仇恨性的內容 ——
+          這包含在混合歌單房間裡輸入的顯示名稱，因為其他玩家會看到；
+        </li>
+        <li>
+          以自動化、爬取或其他方式送出足以影響其他人使用的請求量，
+          或試圖繞過為此而設的流量限制；
+        </li>
+        <li>試圖未經授權存取本站、其基礎架構，或其他主持人建立的房間，包括猜測房間代碼；</li>
+        <li>
+          以需要你並未持有之授權的方式，利用本站重製、公開演出或散布音樂。
+          朋友間的私人遊戲夜和公開演出是兩回事，而只有你知道自己在辦哪一種。
+        </li>
+      </ul>
+
+      <h2>4. 房間與玩家提交的內容</h2>
+      <p>
+        混合歌單模式讓其他人可以把歌單連結和顯示名稱提交到你主持的房間。
+        那些內容屬於提交者本人，我們不主張其所有權，也不進行審核。
+        房間是暫時的，會自動到期。如果房間裡出現不當內容，主持人直接結束遊戲即可 ——
+        而房間無論如何都會自行刪除。
+      </p>
+
+      <h2>5. 可用性，以及會壞掉的地方</h2>
+      <p>
+        本服務以<strong>「現狀」及「現有可用」</strong>基礎提供，不提供任何明示或默示的擔保，
+        包括適售性、特定目的適用性與不侵權。以下是我們已知的失敗情況，先誠實講清楚：
+      </p>
+      <ul>
+        <li>有些歌曲在任何地方都找不到試聽片段而會被跳過，所以實際播出的歌可能比歌單裡的少；</li>
+        <li>Spotify 的官方編輯精選歌單完全讀不到，私人歌單或有地區限制的歌單也會失敗；</li>
+        <li>本站依賴的上游服務有自己的流量限制，當它們拒絕請求時，遊戲也會跟著失敗；</li>
+        <li>我們可能隨時變更、暫停或終止服務的任何部分，恕不另行通知。</li>
+      </ul>
+      <p>我們不保證服務不中斷、即時、安全或無錯誤。</p>
+
+      <h2>6. 責任限制</h2>
+      <p>
+        在法律允許的最大範圍內，GuessSong 及其維護者對於你使用或無法使用本服務所生的
+        任何間接、附隨、特殊、衍生或懲罰性損害，或任何資料、利潤或商譽的損失，均不負責。
+        由於本服務免費提供，我們對你的責任總額以你為它支付的金額為上限，也就是零。
+      </p>
+      <p>
+        本條款不排除或限制依法不得排除或限制的責任，
+        包括因過失導致死亡或人身傷害的責任，以及詐欺責任。
+      </p>
+
+      <h2>7. 程式碼與其授權</h2>
+      <p>
+        GuessSong 的原始碼以 MIT 授權公開於{" "}
+        <a href="https://github.com/Waynting/GuessSong" target="_blank" rel="noopener noreferrer">
+          github.com/Waynting/GuessSong
+        </a>
+        。該授權規範的是程式碼本身，並未授予 GuessSong 名稱、
+        遊戲播放的音樂，或程式碼所連接的任何第三方服務之任何權利 ——
+        而規範你使用這個網站的是本條款，不是該授權。
+      </p>
+
+      <h2>8. 隱私與廣告</h2>
+      <p>
+        <Link href="/zh/privacy">隱私權政策</Link>構成本條款的一部分，
+        說明本站會存下什麼以及有哪些第三方參與。本站刊登由 Google AdSense 投放的廣告。
+      </p>
+
+      <h2>9. 變更</h2>
+      <p>
+        我們可能更新本條款。頁面上方的日期記錄最後一次變更的時間，
+        變更後繼續使用本站即表示你接受更新後的條款。
+      </p>
+
+      <h2>10. 聯絡方式</h2>
+      <p>
+        關於本條款的疑問，或針對本站內容的權利申訴：
+        <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>。
+        我們會盡快處理有依據的下架請求 —— 需要附上哪些資訊，請見
+        <Link href="/contact">聯絡頁面</Link>。
+      </p>
+
+      <div className="article-cta">
+        <p>文件看完了，遊戲比較好玩。</p>
+        <Link href="/zh" className="cta-primary">
+          開始遊戲 →
+        </Link>
+      </div>
+    </ArticleShell>
+  );
+}

--- a/components/article-shell.tsx
+++ b/components/article-shell.tsx
@@ -1,0 +1,265 @@
+import Link from "next/link";
+import { SiteFooter, type FooterLocale } from "@/components/site-footer";
+
+/**
+ * Page chrome for everything on this site that is prose rather than product —
+ * `/guides/*`, `/privacy`, `/terms`, `/contact`.
+ *
+ * The two existing landing pages each carry their own ~250-line `<style>`
+ * block, which is fine for two pages that look nothing alike and unworkable
+ * for a dozen that must look identical. Everything here is a plain server
+ * component with no client boundary: these pages are static text, and pulling
+ * React state into them would cost a bundle for nothing.
+ *
+ * The typography deliberately matches the landing pages (Bebas Neue display,
+ * Outfit body, #111 ground, #1DB954 accent) so a reader who arrives on a guide
+ * from search does not feel like they landed on a different site.
+ */
+export interface ArticleShellProps {
+  /** The `<h1>`. Written as the page's own title, not the site's. */
+  title: string;
+  /** One or two sentences under the title. Renders as an `<h2>`-weight lede. */
+  lede?: string;
+  /** Small label above the title — section, category, or date. */
+  eyebrow?: string;
+  /** Rendered under the lede, before the prose. Meant for a "last updated" line. */
+  meta?: string;
+  locale?: FooterLocale;
+  /** Where the back link at the top points, and what it says. */
+  backHref?: string;
+  backLabel?: string;
+  children: React.ReactNode;
+}
+
+export function ArticleShell({
+  title,
+  lede,
+  eyebrow,
+  meta,
+  locale = "en",
+  backHref = "/",
+  backLabel = "← GuessSong",
+  children,
+}: ArticleShellProps) {
+  return (
+    <>
+      <style>{`
+        @import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Outfit:wght@300;400;500;600;700&display=swap');
+
+        :root {
+          --green: #1DB954;
+          --bg: #111111;
+          --surface: #1a1a1a;
+          --border: #2a2a2a;
+          --text: #f0f0f0;
+          --muted: #999;
+        }
+
+        body {
+          background: var(--bg);
+          color: var(--text);
+          font-family: 'Outfit', sans-serif;
+        }
+
+        .article-main {
+          min-height: 100vh;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          padding: 40px 20px 0;
+        }
+        .article-col {
+          width: 100%;
+          max-width: 720px;
+        }
+
+        .article-back {
+          display: inline-block;
+          color: var(--muted);
+          font-size: 13px;
+          text-decoration: none;
+          margin-bottom: 32px;
+          transition: color 0.15s ease;
+        }
+        .article-back:hover { color: var(--green); }
+
+        .article-eyebrow {
+          color: var(--green);
+          font-size: 12px;
+          font-weight: 500;
+          letter-spacing: 0.1em;
+          text-transform: uppercase;
+          margin-bottom: 10px;
+        }
+        .article-h1 {
+          font-family: 'Bebas Neue', sans-serif;
+          font-size: clamp(2.2rem, 6vw, 3.6rem);
+          line-height: 1;
+          letter-spacing: 0.02em;
+          margin-bottom: 16px;
+        }
+        .article-lede {
+          color: var(--muted);
+          font-size: 17px;
+          font-weight: 300;
+          line-height: 1.65;
+          margin-bottom: 12px;
+        }
+        .article-meta {
+          color: #666;
+          font-size: 12.5px;
+          font-weight: 300;
+          padding-bottom: 28px;
+          border-bottom: 1px solid var(--border);
+          margin-bottom: 36px;
+        }
+
+        /* --- Prose --- */
+        .article-body h2 {
+          font-family: 'Bebas Neue', sans-serif;
+          font-size: clamp(1.5rem, 3.5vw, 2rem);
+          line-height: 1.1;
+          letter-spacing: 0.03em;
+          margin: 44px 0 14px;
+          scroll-margin-top: 24px;
+        }
+        .article-body h3 {
+          font-size: 16px;
+          font-weight: 600;
+          margin: 28px 0 8px;
+          color: var(--text);
+        }
+        .article-body p {
+          color: #c8c8c8;
+          font-size: 15.5px;
+          font-weight: 300;
+          line-height: 1.75;
+          margin-bottom: 16px;
+        }
+        .article-body ul, .article-body ol {
+          margin: 0 0 18px;
+          padding-left: 22px;
+          color: #c8c8c8;
+          font-size: 15.5px;
+          font-weight: 300;
+          line-height: 1.75;
+        }
+        .article-body li { margin-bottom: 8px; }
+        .article-body li::marker { color: var(--green); }
+        .article-body strong { color: var(--text); font-weight: 600; }
+        .article-body a { color: var(--green); text-decoration: none; }
+        .article-body a:hover { text-decoration: underline; }
+        .article-body code {
+          background: var(--surface);
+          border: 1px solid var(--border);
+          border-radius: 5px;
+          padding: 1px 6px;
+          font-size: 13.5px;
+          font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+          color: #e6e6e6;
+        }
+        .article-body hr {
+          border: none;
+          border-top: 1px solid var(--border);
+          margin: 40px 0;
+        }
+        .article-body blockquote {
+          border-left: 2px solid var(--green);
+          padding: 2px 0 2px 16px;
+          margin: 0 0 18px;
+          color: var(--muted);
+          font-style: italic;
+        }
+        .article-body table {
+          width: 100%;
+          border-collapse: collapse;
+          margin-bottom: 20px;
+          font-size: 14.5px;
+          font-weight: 300;
+        }
+        .article-body th, .article-body td {
+          border: 1px solid var(--border);
+          padding: 9px 12px;
+          text-align: left;
+          color: #c8c8c8;
+        }
+        .article-body th {
+          background: var(--surface);
+          color: var(--text);
+          font-weight: 600;
+        }
+
+        .callout {
+          background: var(--surface);
+          border: 1px solid var(--border);
+          border-left: 2px solid var(--green);
+          border-radius: 10px;
+          padding: 16px 20px;
+          margin: 0 0 20px;
+        }
+        .callout p:last-child { margin-bottom: 0; }
+        .callout-title {
+          font-weight: 600;
+          font-size: 14px;
+          color: var(--text);
+          margin-bottom: 6px;
+        }
+
+        .article-cta {
+          background: var(--surface);
+          border: 1px solid var(--border);
+          border-radius: 14px;
+          padding: 26px 24px;
+          text-align: center;
+          margin: 44px 0 8px;
+        }
+        .article-cta p { margin-bottom: 16px; }
+        /* Selector-qualified because the CTA sits *inside* .article-body, and
+           ".article-body a" (0,1,1) outranks a bare ".cta-primary" (0,1,0) —
+           which paints the label green on a green pill, i.e. invisible. */
+        .cta-primary,
+        .article-body a.cta-primary {
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+          background: var(--green);
+          color: #000;
+          font-weight: 600;
+          font-size: 14.5px;
+          padding: 11px 24px;
+          border-radius: 999px;
+          text-decoration: none;
+        }
+        .cta-primary:hover,
+        .article-body a.cta-primary:hover { background: #1ed760; text-decoration: none; }
+
+        .link-btn {
+          color: var(--muted);
+          font-size: 13px;
+          text-decoration: none;
+        }
+        .link-btn:hover { color: var(--green); }
+      `}</style>
+
+      <main className="article-main">
+        <div className="article-col">
+          <Link href={backHref} className="article-back">
+            {backLabel}
+          </Link>
+
+          <article>
+            <header>
+              {eyebrow && <p className="article-eyebrow">{eyebrow}</p>}
+              <h1 className="article-h1">{title}</h1>
+              {lede && <p className="article-lede">{lede}</p>}
+              {meta && <p className="article-meta">{meta}</p>}
+            </header>
+            <div className="article-body">{children}</div>
+          </article>
+
+          <SiteFooter locale={locale} />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,0 +1,155 @@
+import Link from "next/link";
+import { CONTACT_EMAIL, REPORT_PROBLEM_MAILTO } from "@/lib/contact";
+import { ChangelogModal } from "@/components/changelog-modal";
+
+/**
+ * The site-wide footer, and the only place the policy pages are linked from.
+ *
+ * That last part is the reason it exists as a shared component rather than the
+ * three hand-rolled `<footer>` blocks it replaces. A reviewer — Google's or a
+ * player's — looks for the privacy policy in the footer, and a page that omits
+ * it reads as a page that does not have one. Three copies of a link list is
+ * three chances for one page to quietly stop carrying the link, which is the
+ * same hand-sync failure `lib/loop-links.ts` is shaped to avoid.
+ *
+ * `locale` swaps the labels and points the links at the `/zh` half of each
+ * pair. It is not a translation layer: the Chinese strings are written for a
+ * Chinese reader the same way `/zh` itself is, per the note in `lib/changelog.ts`.
+ */
+export type FooterLocale = "en" | "zh";
+
+const GITHUB_URL = "https://github.com/Waynting/GuessSong";
+
+interface FooterLink {
+  href: string;
+  label: string;
+  /** Set for links that leave the site. */
+  external?: boolean;
+}
+
+const LINKS: Record<FooterLocale, FooterLink[]> = {
+  en: [
+    { href: "/", label: "Play" },
+    { href: "/about", label: "How to play" },
+    { href: "/guides", label: "Guides" },
+    { href: "/privacy", label: "Privacy" },
+    { href: "/terms", label: "Terms" },
+    { href: "/contact", label: "Contact" },
+    { href: GITHUB_URL, label: "GitHub", external: true },
+  ],
+  zh: [
+    { href: "/zh", label: "開始遊戲" },
+    { href: "/guides", label: "遊戲指南" },
+    { href: "/zh/privacy", label: "隱私權政策" },
+    { href: "/zh/terms", label: "服務條款" },
+    { href: "/contact", label: "聯絡我們" },
+    { href: GITHUB_URL, label: "GitHub", external: true },
+  ],
+};
+
+const COPY: Record<FooterLocale, { report: string; tagline: string; alt: string; altHref: string }> = {
+  en: {
+    report: "Report a problem",
+    tagline:
+      "GuessSong is a free, open-source party game. It is not affiliated with, endorsed by, or connected to Spotify AB, Apple Inc. or Deezer.",
+    alt: "中文",
+    altHref: "/zh",
+  },
+  zh: {
+    report: "回報問題",
+    tagline:
+      "GuessSong 是免費的開源團康遊戲，與 Spotify AB、Apple Inc.、Deezer 沒有任何從屬或合作關係。",
+    alt: "English",
+    altHref: "/",
+  },
+};
+
+export function SiteFooter({ locale = "en" }: { locale?: FooterLocale }) {
+  const links = LINKS[locale];
+  const copy = COPY[locale];
+
+  return (
+    <footer className="site-footer">
+      <style>{`
+        .site-footer {
+          width: 100%;
+          margin-top: 48px;
+          padding-top: 24px;
+          border-top: 1px solid #2a2a2a;
+          text-align: center;
+          font-family: 'Outfit', sans-serif;
+        }
+        .site-footer-nav {
+          display: flex;
+          gap: 8px 18px;
+          justify-content: center;
+          align-items: center;
+          flex-wrap: wrap;
+          margin-bottom: 16px;
+        }
+        .site-footer-nav a,
+        .site-footer-nav button {
+          color: #999;
+          font-size: 13px;
+          font-weight: 400;
+          text-decoration: none;
+          background: none;
+          border: none;
+          padding: 0;
+          cursor: pointer;
+          font-family: inherit;
+          transition: color 0.15s ease;
+        }
+        .site-footer-nav a:hover,
+        .site-footer-nav button:hover { color: #1DB954; }
+        .site-footer-meta {
+          display: flex;
+          gap: 8px 14px;
+          justify-content: center;
+          align-items: center;
+          flex-wrap: wrap;
+          margin-bottom: 14px;
+        }
+        .site-footer-tagline {
+          color: #555;
+          font-size: 11.5px;
+          font-weight: 300;
+          line-height: 1.7;
+          max-width: 560px;
+          margin: 0 auto;
+          padding-bottom: 24px;
+        }
+        .site-footer-sep { color: #333; }
+      `}</style>
+
+      <nav className="site-footer-nav" aria-label={locale === "zh" ? "頁尾導覽" : "Footer"}>
+        {links.map((link) =>
+          link.external ? (
+            <a key={link.href} href={link.href} target="_blank" rel="noopener noreferrer">
+              {link.label}
+            </a>
+          ) : (
+            <Link key={link.href} href={link.href}>
+              {link.label}
+            </Link>
+          )
+        )}
+        <Link href={copy.altHref}>{copy.alt}</Link>
+      </nav>
+
+      <div className="site-footer-meta">
+        <a href={REPORT_PROBLEM_MAILTO} className="link-btn">
+          {copy.report}
+        </a>
+        <span aria-hidden className="site-footer-sep">·</span>
+        <ChangelogModal locale={locale} />
+      </div>
+
+      <p className="site-footer-tagline">
+        {copy.tagline}
+        <br />
+        © 2026 GuessSong · {CONTACT_EMAIL}
+      </p>
+    </footer>
+  );
+}

--- a/lib/changelog.ts
+++ b/lib/changelog.ts
@@ -49,6 +49,30 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "1.7.0",
+    date: "2026-08-21",
+    headline:
+      "There is now a guides section, and every page carries a proper footer with a privacy policy and terms.",
+    headlineZh: "新增了遊戲指南專區，每一頁的頁尾也都有了完整的隱私權政策與服務條款。",
+    changes: [
+      {
+        kind: "new",
+        text: "Guides. Eight longer pieces on running one of these evenings: how to host a music quiz night, how to pick a playlist that actually plays well, what clip length does to a room, how to score a game so the last round still matters, and what to do when a Spotify playlist refuses to load. Linked from the footer of every page.",
+        textZh: "遊戲指南。八篇比較長的文章，講的是怎麼把一場猜歌之夜辦好：怎麼主持、怎麼挑一個真的適合猜的歌單、片段長度會怎麼改變整個房間的氣氛、分數要怎麼算最後一輪才還有意義，以及歌單讀不出來的時候該怎麼辦。每一頁的頁尾都能進去。",
+      },
+      {
+        kind: "new",
+        text: "A privacy policy, terms of use and a contact page — the privacy policy and terms in both English and Chinese. The privacy policy says exactly what is stored and for how long, which for a game with no accounts is a shorter list than you might expect.",
+        textZh: "新增隱私權政策、服務條款和聯絡頁面，其中隱私權政策與服務條款都有中英文版本。隱私權政策明確寫出什麼東西會被存下來、存多久 —— 對一個沒有帳號的遊戲來說，這份清單比你想的短。",
+      },
+      {
+        kind: "better",
+        text: "One footer everywhere. The homepage, the how-to-play page and the Chinese page used to each have their own; now they share one, so the links to the policies, the guides and the release notes are in the same place on every page.",
+        textZh: "頁尾全站統一。首頁、玩法說明頁和中文頁以前各有各的頁尾，現在共用同一個 —— 政策、指南和更新說明的連結，在每一頁都在同一個位置。",
+      },
+    ],
+  },
+  {
     version: "1.6.0",
     date: "2026-08-15",
     headline:

--- a/lib/guides.ts
+++ b/lib/guides.ts
@@ -1,0 +1,264 @@
+import type { Metadata } from "next";
+
+/**
+ * The guides index — one entry per article under `/guides`.
+ *
+ * ## Why the metadata lives here and the prose does not
+ *
+ * Four things need to agree about every guide: the article route itself, the
+ * `/guides` index that lists it, `app/sitemap.ts`, and the "read next" links at
+ * the bottom of its siblings. Hand-syncing four copies is the failure mode
+ * `lib/loop-links.ts` is shaped to avoid, and it fails quietly here too — a
+ * guide missing from the sitemap is simply a page Google never comes back for,
+ * with nothing on screen to say so.
+ *
+ * So the *metadata* is declared once, here, and everything derives from it. The
+ * *body* stays as JSX in `app/guides/<slug>/page.tsx`, because prose with
+ * links, tables and callouts in it is not data and pretending otherwise means
+ * inventing a markup format to escape from. `tests/guides.test.ts` asserts
+ * every slug in this list has a directory and vice versa, which is the join
+ * these two halves would otherwise be missing.
+ */
+
+/** Grouping shown on the index page. Purely presentational. */
+export type GuideCategory = "Playing" | "Hosting" | "Troubleshooting";
+
+export interface Guide {
+  /** URL segment. Also the directory name under `app/guides/`. */
+  slug: string;
+  /** The `<h1>` and the index card's title. */
+  title: string;
+  /** `<title>` and the index card's heading, when the h1 is too long for both. */
+  navTitle: string;
+  /** Meta description. One sentence, written for a search result. */
+  description: string;
+  /** The lede under the h1 on the article itself. */
+  lede: string;
+  category: GuideCategory;
+  /** ISO date the article was published. Drives sitemap `lastModified`. */
+  published: string;
+  /** Rounded reading time in minutes, for the index card. */
+  minutes: number;
+  /** Slugs of two or three siblings, rendered as "read next". */
+  related: string[];
+}
+
+export const GUIDES: Guide[] = [
+  {
+    slug: "how-to-host-a-music-quiz-night",
+    title: "How to Host a Music Quiz Night That People Actually Enjoy",
+    navTitle: "How to host a music quiz night",
+    description:
+      "A practical guide to running a music quiz for friends: how long a round should be, how to seat the room, what to do about the person who knows every song, and the five mistakes that flatten a good night.",
+    lede: "Most music quizzes fail for reasons that have nothing to do with the music. Here is what actually decides whether the room stays in it.",
+    category: "Hosting",
+    published: "2026-08-21",
+    minutes: 8,
+    related: [
+      "music-quiz-scoring-rules",
+      "best-playlists-for-a-guess-the-song-game",
+      "clip-length-and-difficulty",
+    ],
+  },
+  {
+    slug: "best-playlists-for-a-guess-the-song-game",
+    title: "How to Pick a Playlist That Makes a Good Guessing Game",
+    navTitle: "Picking a playlist that plays well",
+    description:
+      "Not every playlist works as a quiz. How to choose one by era, spread and recognisability — and why the playlist you love most is often the worst one to play.",
+    lede: "A great playlist and a great quiz playlist are different objects. The difference is measurable, and you can check it before anyone sits down.",
+    category: "Playing",
+    published: "2026-08-21",
+    minutes: 7,
+    related: [
+      "clip-length-and-difficulty",
+      "how-to-host-a-music-quiz-night",
+      "spotify-playlist-not-working",
+    ],
+  },
+  {
+    slug: "clip-length-and-difficulty",
+    title: "Five Seconds or Thirty? How Clip Length Changes the Game",
+    navTitle: "Clip length and difficulty",
+    description:
+      "Clip length is the difficulty dial in a guess the song game. What each setting does to the room, why the intro is the hardest part of a song, and how to pick a length for the group in front of you.",
+    lede: "It is the only setting that changes the game rather than the content, and it is the one most hosts leave on the default.",
+    category: "Playing",
+    published: "2026-08-21",
+    minutes: 6,
+    related: [
+      "music-quiz-scoring-rules",
+      "best-playlists-for-a-guess-the-song-game",
+      "how-to-host-a-music-quiz-night",
+    ],
+  },
+  {
+    slug: "music-quiz-scoring-rules",
+    title: "Scoring a Music Quiz: Rules That Keep It Close",
+    navTitle: "Scoring rules that keep it close",
+    description:
+      "Why 3 points for the title and 1 for the album, what a runaway leader does to a room, and five scoring variants — comeback rounds, steals, wagers — you can run without any extra equipment.",
+    lede: "Scoring is not bookkeeping. It is the mechanism that decides whether the last third of the night is worth playing.",
+    category: "Playing",
+    published: "2026-08-21",
+    minutes: 7,
+    related: [
+      "how-to-host-a-music-quiz-night",
+      "clip-length-and-difficulty",
+      "mixed-playlist-mode-guide",
+    ],
+  },
+  {
+    slug: "mixed-playlist-mode-guide",
+    title: "Mixed Playlist Mode: When Everyone Brings Their Own Music",
+    navTitle: "Mixed Playlist Mode explained",
+    description:
+      "How to run a round where every player submits their own playlist: the two ways to collect them, why guessing whose song it is beats guessing the title, and how to read the Taste Card at the end.",
+    lede: "The best question a music game can ask is not “what is this song”. It is “who in this room put it on a playlist”.",
+    category: "Playing",
+    published: "2026-08-21",
+    minutes: 7,
+    related: [
+      "music-quiz-scoring-rules",
+      "how-to-host-a-music-quiz-night",
+      "party-games-for-small-groups",
+    ],
+  },
+  {
+    slug: "spotify-playlist-not-working",
+    title: "Why Your Spotify Playlist Will Not Load, and How to Fix It",
+    navTitle: "Playlist will not load",
+    description:
+      "Four causes account for nearly every playlist that fails to load in a Spotify-based game: editorial playlists, private playlists, the wrong kind of link, and rate limiting. How to tell them apart in seconds.",
+    lede: "Almost every failed playlist is one of four things, and three of them you can fix without leaving the page.",
+    category: "Troubleshooting",
+    published: "2026-08-21",
+    minutes: 7,
+    related: [
+      "why-spotify-previews-disappeared",
+      "best-playlists-for-a-guess-the-song-game",
+      "how-to-host-a-music-quiz-night",
+    ],
+  },
+  {
+    slug: "why-spotify-previews-disappeared",
+    title: "Spotify's Preview Clips Disappeared. Here Is What We Measured",
+    navTitle: "Where the preview clips went",
+    description:
+      "In late 2024 Spotify stopped returning 30-second preview URLs to new API applications. What we measured, what broke, and how a music game finds clips now that the obvious source is gone.",
+    lede: "Zero previews out of twenty tracks, across four markets. This is what a whole category of music apps quietly worked around.",
+    category: "Troubleshooting",
+    published: "2026-08-21",
+    minutes: 8,
+    related: [
+      "spotify-playlist-not-working",
+      "best-playlists-for-a-guess-the-song-game",
+      "clip-length-and-difficulty",
+    ],
+  },
+  {
+    slug: "party-games-for-small-groups",
+    title: "Party Games for Small Groups Where Nobody Ends Up Sitting Out",
+    navTitle: "Party games for small groups",
+    description:
+      "Games for four to twelve people, chosen by the one property that matters at that size: everyone stays in every round. Includes what to do when the group is too small, too loud, or does not know each other.",
+    lede: "At four to twelve people, the failure mode is not boredom. It is elimination — the person knocked out first has nothing to do for forty minutes.",
+    category: "Hosting",
+    published: "2026-08-21",
+    minutes: 7,
+    related: [
+      "how-to-host-a-music-quiz-night",
+      "mixed-playlist-mode-guide",
+      "music-quiz-scoring-rules",
+    ],
+  },
+];
+
+/** Lookup by slug. Returns undefined for an unknown one — callers 404. */
+export function getGuide(slug: string): Guide | undefined {
+  return GUIDES.find((g) => g.slug === slug);
+}
+
+/**
+ * Resolve a guide's `related` slugs to entries, dropping any that no longer
+ * exist. A retired guide should cost its siblings a link, not a crash.
+ */
+export function relatedGuides(slug: string): Guide[] {
+  const guide = getGuide(slug);
+  if (!guide) return [];
+  return guide.related
+    .map((s) => getGuide(s))
+    .filter((g): g is Guide => Boolean(g) && g!.slug !== slug);
+}
+
+/** The order the index page renders its groups in. */
+export const GUIDE_CATEGORIES: GuideCategory[] = [
+  "Playing",
+  "Hosting",
+  "Troubleshooting",
+];
+
+export function guidesByCategory(category: GuideCategory): Guide[] {
+  return GUIDES.filter((g) => g.category === category);
+}
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://www.guessong.app";
+
+/**
+ * Look a guide up, or throw.
+ *
+ * The route files call this with a slug written by us, in the same file as the
+ * prose, so an unknown one is a typo that should fail the build — never a
+ * visitor's blank <title> or a page rendered with holes in it. `getGuide` stays
+ * the forgiving version for callers that legitimately might not find one (the
+ * homepage teaser filters its picks).
+ */
+export function requireGuide(slug: string): Guide {
+  const guide = getGuide(slug);
+  if (!guide) {
+    throw new Error(
+      `Unknown guide slug "${slug}". Every article under app/guides/ needs a matching entry in lib/guides.ts.`
+    );
+  }
+  return guide;
+}
+
+/**
+ * Build a guide route's `metadata` export from the index.
+ *
+ * Lives here rather than beside the component that consumes it for the reason
+ * `lib/song-count.ts` gives: the test suite only reaches `lib/`. This is pure
+ * data derivation with no JSX in it, and it is the half worth pinning — the
+ * half that decides what a search result says.
+ */
+export function guideMetadata(slug: string): Metadata {
+  const guide = requireGuide(slug);
+  const url = `${BASE_URL}/guides/${guide.slug}`;
+  return {
+    title: guide.navTitle,
+    description: guide.description,
+    alternates: { canonical: `/guides/${guide.slug}` },
+    openGraph: {
+      type: "article",
+      url,
+      title: guide.title,
+      description: guide.description,
+      publishedTime: guide.published,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: guide.title,
+      description: guide.description,
+    },
+  };
+}
+
+/** Formats an ISO day the same way on the server and the client. */
+export function formatGuideDate(iso: string): string {
+  const [year, month, day] = iso.split("-").map(Number);
+  const months = [
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+  ];
+  return `${day} ${months[month - 1]} ${year}`;
+}

--- a/lib/legal.ts
+++ b/lib/legal.ts
@@ -1,0 +1,15 @@
+/**
+ * The one date the policy pages print, and the one place it is written.
+ *
+ * `/privacy`, `/terms` and their `/zh` counterparts all show a "last updated"
+ * line, and a reviewer reads a mismatch between two of them as a page that was
+ * quietly edited. Four hand-kept dates is four chances for that; this is one.
+ *
+ * It is a literal rather than a build timestamp on purpose: the date has to
+ * mean "the day the wording last changed", not "the day this was last
+ * deployed". Bump it when the policy text actually changes.
+ */
+export const POLICY_LAST_UPDATED = "21 August 2026";
+
+/** The same date written for a Chinese reader. */
+export const POLICY_LAST_UPDATED_ZH = "2026 年 8 月 21 日";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guesssong",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -1,0 +1,224 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { readdirSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  GUIDES,
+  getGuide,
+  relatedGuides,
+  GUIDE_CATEGORIES,
+  guidesByCategory,
+  guideMetadata,
+  formatGuideDate,
+} from "@/lib/guides";
+import sitemap from "@/app/sitemap";
+
+/**
+ * `lib/guides.ts` declares each article once and four things derive from it:
+ * the route, the index page, the sitemap, and the "read next" links on its
+ * siblings. Every one of those fails silently when it drifts — a guide missing
+ * from the sitemap is a page Google never returns for, and a "read next"
+ * pointing at a retired slug is a 404 a reader finds before we do. These tests
+ * are the join between the metadata and the prose it describes.
+ */
+
+const GUIDES_DIR = join(process.cwd(), "app/guides");
+
+/** Article directories under app/guides — the non-route files are not routes. */
+function articleDirs(): string[] {
+  return readdirSync(GUIDES_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+}
+
+describe("guides index", () => {
+  it("has a page directory for every declared guide", () => {
+    for (const guide of GUIDES) {
+      const page = join(GUIDES_DIR, guide.slug, "page.tsx");
+      expect(existsSync(page), `${guide.slug} is declared but has no page.tsx`).toBe(true);
+    }
+  });
+
+  it("declares every page directory", () => {
+    // The other direction: an article that exists but is not in the index is
+    // unreachable from /guides and absent from the sitemap.
+    for (const dir of articleDirs()) {
+      expect(getGuide(dir), `app/guides/${dir} has no entry in lib/guides.ts`).toBeDefined();
+    }
+  });
+
+  it("wires each page to its own slug", () => {
+    // A copy-pasted article that kept the source's SLUG constant renders the
+    // wrong title, description and canonical under the right URL.
+    for (const guide of GUIDES) {
+      const source = readFileSync(join(GUIDES_DIR, guide.slug, "page.tsx"), "utf8");
+      expect(source).toContain(`const SLUG = "${guide.slug}"`);
+    }
+  });
+
+  it("uses unique slugs", () => {
+    const slugs = GUIDES.map((g) => g.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("uses URL-safe slugs", () => {
+    for (const guide of GUIDES) {
+      expect(guide.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+  });
+
+  it("gives every guide the copy the index and the article both need", () => {
+    for (const guide of GUIDES) {
+      expect(guide.title.length).toBeGreaterThan(10);
+      expect(guide.navTitle.length).toBeGreaterThan(5);
+      expect(guide.lede.length).toBeGreaterThan(20);
+      // Google truncates well before 200; a description longer than that is one
+      // that gets cut mid-sentence in the only place it is ever read.
+      expect(guide.description.length).toBeGreaterThan(60);
+      expect(guide.description.length).toBeLessThan(260);
+      expect(guide.minutes).toBeGreaterThan(0);
+    }
+  });
+
+  it("dates every guide as a real ISO day", () => {
+    for (const guide of GUIDES) {
+      expect(guide.published).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(Number.isNaN(new Date(guide.published).getTime())).toBe(false);
+    }
+  });
+
+  it("puts every guide in a category the index renders", () => {
+    // A category the index does not loop over is a guide nobody can reach.
+    for (const guide of GUIDES) {
+      expect(GUIDE_CATEGORIES).toContain(guide.category);
+    }
+  });
+
+  it("resolves every related slug, and never to itself", () => {
+    for (const guide of GUIDES) {
+      for (const slug of guide.related) {
+        expect(getGuide(slug), `${guide.slug} links to unknown guide ${slug}`).toBeDefined();
+        expect(slug).not.toBe(guide.slug);
+      }
+      expect(relatedGuides(guide.slug).length).toBe(guide.related.length);
+    }
+  });
+
+  it("gives every guide at least one inbound link from a sibling", () => {
+    // An article nothing links to is one Google reaches only via the sitemap,
+    // and one a reader never finds from the article they are already on.
+    const linked = new Set(GUIDES.flatMap((g) => g.related));
+    for (const guide of GUIDES) {
+      expect(linked.has(guide.slug), `nothing links to ${guide.slug}`).toBe(true);
+    }
+  });
+});
+
+describe("guide lookups", () => {
+  // The happy paths are covered above by the directory/slug joins. These are
+  // the branches those never reach — the ones that only run once a guide is
+  // renamed or retired, which is exactly when nobody is looking.
+  it("returns undefined for a slug that is not a guide", () => {
+    expect(getGuide("no-such-guide")).toBeUndefined();
+    expect(getGuide("")).toBeUndefined();
+  });
+
+  it("returns no related guides for an unknown slug", () => {
+    // relatedGuides reads through getGuide, so an unknown slug must fall out
+    // as an empty list rather than throwing. A retired guide should cost its
+    // siblings a link, not crash the page they are on.
+    expect(relatedGuides("no-such-guide")).toEqual([]);
+  });
+
+  it("never returns a guide as its own related guide", () => {
+    for (const guide of GUIDES) {
+      expect(relatedGuides(guide.slug).map((g) => g.slug)).not.toContain(guide.slug);
+    }
+  });
+
+  it("resolves related slugs to the guides themselves, in declared order", () => {
+    const guide = GUIDES[0];
+    expect(relatedGuides(guide.slug).map((g) => g.slug)).toEqual(guide.related);
+  });
+
+  it("partitions every guide across the rendered categories exactly once", () => {
+    // The index renders GUIDE_CATEGORIES and nothing else, so a guide in a
+    // category missing from that list is a page with no route to it from
+    // /guides — reachable only from the sitemap, and invisible on the site.
+    const rendered = GUIDE_CATEGORIES.flatMap((c) => guidesByCategory(c));
+    expect(rendered.map((g) => g.slug).sort()).toEqual(GUIDES.map((g) => g.slug).sort());
+  });
+
+  it("returns nothing for a category no guide uses", () => {
+    expect(guidesByCategory("Nonexistent" as never)).toEqual([]);
+  });
+});
+
+describe("guideMetadata", () => {
+  it("derives title, description and canonical from the guides index", () => {
+    for (const guide of GUIDES) {
+      const meta = guideMetadata(guide.slug);
+      expect(meta.title).toBe(guide.navTitle);
+      expect(meta.description).toBe(guide.description);
+      expect(meta.alternates?.canonical).toBe(`/guides/${guide.slug}`);
+      expect(meta.openGraph?.title).toBe(guide.title);
+    }
+  });
+
+  it("throws on an unknown slug rather than returning a hollow page", () => {
+    // The slug is written by us, in the same file as the prose, so a bad one
+    // is a typo that should fail the build — never a visitor's blank <title>.
+    expect(() => guideMetadata("no-such-guide")).toThrow(/Unknown guide slug/);
+  });
+});
+
+describe("formatGuideDate", () => {
+  it("formats an ISO day without touching the locale", () => {
+    // Deliberately not toLocaleDateString: the server and the client must
+    // produce the same string or React logs a hydration mismatch on a page
+    // whose only job is to be read.
+    expect(formatGuideDate("2026-08-21")).toBe("21 August 2026");
+    expect(formatGuideDate("2026-01-01")).toBe("1 January 2026");
+    expect(formatGuideDate("2026-12-31")).toBe("31 December 2026");
+  });
+
+  it("formats every guide's own date", () => {
+    for (const guide of GUIDES) {
+      expect(formatGuideDate(guide.published)).toMatch(/^\d{1,2} [A-Z][a-z]+ \d{4}$/);
+    }
+  });
+});
+
+describe("sitemap", () => {
+  const urls = sitemap().map((entry) => entry.url);
+
+  it("lists every guide", () => {
+    for (const guide of GUIDES) {
+      expect(urls.some((u) => u.endsWith(`/guides/${guide.slug}`))).toBe(true);
+    }
+  });
+
+  it("lists the guides index itself", () => {
+    expect(urls.some((u) => u.endsWith("/guides"))).toBe(true);
+  });
+
+  it("lists the policy pages", () => {
+    // An ad network's site review looks for these, and a page it cannot find
+    // reads exactly like a page that does not exist.
+    for (const path of ["/privacy", "/terms", "/contact", "/zh/privacy", "/zh/terms"]) {
+      expect(urls.some((u) => u.endsWith(path)), `sitemap is missing ${path}`).toBe(true);
+    }
+  });
+
+  it("has no duplicate URLs", () => {
+    expect(new Set(urls).size).toBe(urls.length);
+  });
+
+  it("keeps every URL absolute and on one origin", () => {
+    for (const url of urls) {
+      expect(url).toMatch(/^https?:\/\//);
+    }
+    const origins = new Set(urls.map((u) => new URL(u).origin));
+    expect(origins.size).toBe(1);
+  });
+});

--- a/tests/site-policy.test.ts
+++ b/tests/site-policy.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The policy pages and the footer that links to them.
+ *
+ * These exist because an ad network's site review — and a visitor looking for
+ * who to complain to — both start at the footer. The failure they guard is not
+ * a crash: a page that quietly stops linking to the privacy policy still
+ * renders, still passes a build, and reads to a reviewer exactly like a site
+ * that does not have one. Nothing else in the suite would notice.
+ */
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), "utf8");
+
+const POLICY_PAGES = [
+  "app/privacy/page.tsx",
+  "app/terms/page.tsx",
+  "app/contact/page.tsx",
+  "app/zh/privacy/page.tsx",
+  "app/zh/terms/page.tsx",
+];
+
+describe("policy pages", () => {
+  it("all exist", () => {
+    for (const page of POLICY_PAGES) {
+      expect(existsSync(join(process.cwd(), page)), `${page} is missing`).toBe(true);
+    }
+  });
+
+  it("each declares its own metadata", () => {
+    // Without one, every policy page inherits the homepage title and canonical
+    // from the root layout — three pages claiming to be "/" in search results.
+    for (const page of POLICY_PAGES) {
+      const source = read(page);
+      expect(source, `${page} has no metadata export`).toContain("export const metadata");
+      expect(source, `${page} declares no canonical`).toContain("canonical");
+    }
+  });
+
+  it("declares each language pair on both sides", () => {
+    // A one-sided hreflang is a weaker signal than none, the same rule
+    // app/sitemap.ts follows for the / and /zh cluster.
+    for (const [en, zh] of [
+      ["app/privacy/page.tsx", "app/zh/privacy/page.tsx"],
+      ["app/terms/page.tsx", "app/zh/terms/page.tsx"],
+    ]) {
+      for (const page of [en, zh]) {
+        const source = read(page);
+        expect(source, `${page} declares no language alternates`).toContain("languages");
+      }
+    }
+  });
+});
+
+describe("privacy policy", () => {
+  const en = read("app/privacy/page.tsx");
+  const zh = read("app/zh/privacy/page.tsx");
+
+  it("discloses the advertising and analytics that actually run", () => {
+    // app/layout.tsx loads both. A policy that omits one is a policy that is
+    // wrong, which is worse than not having written it down.
+    for (const [name, source] of [["en", en], ["zh", zh]] as const) {
+      expect(source, `${name} does not name AdSense`).toContain("AdSense");
+      expect(source, `${name} does not name Analytics`).toContain("Analytics");
+      expect(source.toLowerCase(), `${name} does not mention cookies`).toContain("cookie");
+    }
+  });
+
+  it("gives readers a way to opt out of personalised advertising", () => {
+    for (const source of [en, zh]) {
+      expect(source).toContain("google.com/settings/ads");
+    }
+  });
+
+  it("carries a contact address on both sides", () => {
+    for (const source of [en, zh]) {
+      expect(source).toContain("CONTACT_EMAIL");
+    }
+  });
+
+  it("dates both sides from the same module", () => {
+    // Two hand-kept dates drift, and a reviewer reads a mismatch as a page that
+    // was quietly edited. lib/legal.ts is the single source.
+    expect(en).toContain("POLICY_LAST_UPDATED");
+    expect(zh).toContain("POLICY_LAST_UPDATED_ZH");
+  });
+});
+
+describe("terms", () => {
+  const en = read("app/terms/page.tsx");
+  const zh = read("app/zh/terms/page.tsx");
+
+  it("disclaims affiliation with the services the game reads from", () => {
+    // Using these names to describe what the game does is fine; implying a
+    // relationship is not, and it is the kind of thing a rewrite drops.
+    for (const source of [en, zh]) {
+      expect(source).toContain("Spotify AB");
+      expect(source).toContain("Deezer");
+    }
+  });
+});
+
+describe("site footer", () => {
+  const footer = read("components/site-footer.tsx");
+
+  it("links to the policy pages in both locales", () => {
+    for (const href of ["/privacy", "/terms", "/contact", "/zh/privacy", "/zh/terms"]) {
+      expect(footer, `footer does not link to ${href}`).toContain(`"${href}"`);
+    }
+  });
+
+  it("links to the guides", () => {
+    expect(footer).toContain('"/guides"');
+  });
+
+  it("is the footer every public page renders", () => {
+    // The three landing pages each had their own <footer> before this; the
+    // whole point of the shared one is that a page cannot lose the policy links
+    // by being edited on its own.
+    for (const page of ["app/page.tsx", "app/about/page.tsx", "app/zh/page.tsx"]) {
+      expect(read(page), `${page} does not render SiteFooter`).toContain("SiteFooter");
+    }
+  });
+
+  it("keeps the Chinese footer in Chinese", () => {
+    // /zh is written natively rather than translated — an English label leaking
+    // into its footer is a visible defect, not a fallback. Same rule as
+    // lib/changelog.ts.
+    const zhBlock = footer.slice(footer.indexOf("zh: ["), footer.indexOf("];", footer.indexOf("zh: [")));
+    expect(zhBlock).toContain("隱私權政策");
+    expect(zhBlock).toContain("服務條款");
+    expect(zhBlock).not.toContain("Privacy");
+  });
+});
+
+describe("robots", () => {
+  const robots = read("app/robots.ts");
+
+  it("does not disallow the content pages", () => {
+    // The disallow list is for ephemeral rooms and the counting redirect. A
+    // guide or a policy page landing in it would be invisible to exactly the
+    // crawler it was written for.
+    const disallowed = robots.slice(robots.indexOf("disallow:"), robots.indexOf("]", robots.indexOf("disallow:")));
+    for (const path of ["/guides", "/privacy", "/terms", "/contact"]) {
+      expect(disallowed, `robots.ts disallows ${path}`).not.toContain(`"${path}"`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

AdSense refused the site under **"Low value content" (缺乏價值的內容)**. This PR is the response.

The diagnosis was not subtle. `app/robots.ts` disallows `/game`, `/api`, `/share`, `/buzz`, `/j` and `/r`, leaving exactly three indexable URLs — `/`, `/about`, `/zh`. `/zh` is `/` in another language and `/about` repeats `/`'s FAQ almost verbatim, so the site's unique indexable surface was closer to one and a half pages. The homepage's entire prose was two paragraphs plus six FAQ answers; everything else on it is form controls. And there was **no privacy policy at all**, on a site whose `app/layout.tsx` loads both AdSense and GA4 — that alone is disqualifying, and it is the item most likely to have triggered the category.

**Content**

- `/guides` plus eight articles (1,100–1,450 words each). Two of them — `spotify-playlist-not-working` and `why-spotify-previews-disappeared` — are written from measurements this project already made: the 0/20 preview result across four markets, the `37i9` editorial-playlist 404, iTunes signalling throttling with `403` rather than `429`, the `absent`/`unavailable` distinction. That content exists nowhere else, which is the actual bar the policy asks about.
- `/privacy`, `/terms`, `/contact`, `/zh/privacy`, `/zh/terms`. Written against what the code actually does — Client Credentials meaning Spotify is never told who is asking, title-and-artist being all that reaches iTunes and Deezer, room records carrying an expiry from creation, rate-limit counters living for the length of one window. A template would have been faster and wrong in ways a reviewer can check.

**Infrastructure**

- `lib/guides.ts` declares a guide once; the route, the `/guides` index, `app/sitemap.ts` and the "read next" links all derive from it. Same single-declaration rule as `lib/loop-links.ts`, and it fails the same silent way — a guide missing from the sitemap is a page Google never returns for.
- `components/site-footer.tsx` replaces three hand-rolled `<footer>` blocks and is the only place the policy pages are linked from. A page that omits the privacy link reads to a reviewer as a site that does not have one; three copies is three chances to lose it by editing one page alone.
- `components/article-shell.tsx` is the shared prose chrome. Server component, no client boundary.
- `requireGuide` / `guideMetadata` / `formatGuideDate` live in `lib/guides.ts` rather than beside the component, for the reason `lib/song-count.ts` gives: the suite only reaches `lib/`.

**Result**

| | before | after |
|---|---|---|
| indexable pages | 3 | 18 |
| English words | ~1,700 | ~15,200 |
| Chinese characters | ~1,080 | ~4,400 |
| privacy policy | none | bilingual |

Route table checked: every new page is `○` (static). `/icon` and `/opengraph-image` are still `○`, `/icons/[size]` still `●` with all three sizes — the invariant in CLAUDE.md holds.

## Test Coverage

Tests: **487 → 497 (+10 new)**. Coverage gate: **PASS (100%)**.

```
CODE PATHS
[+] lib/guides.ts
  ├── getGuide(slug)
  │   ├── [*** TESTED] found
  │   └── [*** TESTED] unknown slug -> undefined
  ├── relatedGuides(slug)
  │   ├── [*** TESTED] resolves all, in declared order
  │   ├── [*** TESTED] unknown slug -> []
  │   └── [*** TESTED] never returns itself
  └── guidesByCategory(cat)
      ├── [*** TESTED] partitions every guide exactly once
      └── [*** TESTED] empty for an unused category
[+] lib/guides.ts (metadata half)
  ├── requireGuide()      [*** TESTED] throws on unknown slug
  ├── guideMetadata()     [*** TESTED] title/description/canonical/og derive from the index
  └── formatGuideDate()   [*** TESTED] locale-free, server == client
[+] app/sitemap.ts        [*** TESTED] guides, index, policy pages, no dupes, single origin
[+] app/guides/*          [**  TESTED] slug<->directory both ways, SLUG constant matches path,
                                       every guide has an inbound sibling link
[+] components/site-footer + 13 prose pages
                          [**  TESTED] policy links both locales, AdSense/Analytics/cookie
                                       disclosure, opt-out link, no English in the /zh footer,
                                       robots.ts does not disallow any content path

COVERAGE: 19/19 paths tested (100%)
```

The seven gaps found on the first pass were all branches in the two pure-function modules — the ones that only run once a guide is renamed or retired, which is exactly when nobody is looking. All filled.

## Pre-Landing Review

3 issues (1 critical, 2 informational) — **all auto-fixed**.

- `[AUTO-FIXED]` **[P1] (confidence 9/10) app/guides/page.tsx:22** — `CATEGORY_BLURB` was typed `Record<string, string>`, so a new `GuideCategory` with no blurb would render `undefined` under the heading at line 206 instead of failing the build. Re-keyed to `Record<GuideCategory, string>`, the same rule `lib/error-messages.ts` follows. Verified: removing a blurb now fails `tsc` with `TS2741: Property 'Troubleshooting' is missing`.
- `[AUTO-FIXED]` **[P3] (confidence 10/10) CHANGELOG.md:61** — claimed "28 assertions"; actual is 38. The count moved when the coverage pass added 10 tests.
- `[AUTO-FIXED]` **[P3] (confidence 10/10) CHANGELOG.md:43** — attributed the throw-on-unknown-slug to `app/guides/guide-shell.tsx`; `requireGuide` had moved to `lib/guides.ts`. Also dropped the "Known gaps" bullet about `CATEGORY_BLURB`, which the P1 fix made untrue.

Specialist subagent dispatch was not run in this session (Agent tool not available); the checklist pass ran inline. Pass 1 categories other than Enum Completeness are N/A — no SQL, no DB, no concurrency, no LLM, no subprocess in this diff.

## Design Review

Design Review (lite): 1 finding — 1 auto-fixed.

- **Contrast, all article-shell CTAs** — `.article-body a { color: var(--green) }` (0,1,1) outranked `.cta-primary { color: #000 }` (0,1,0), painting every "Start a game" label green on a green pill. Invisible on all 13 prose pages. Found by rendering the pages, not by reading them. Fixed by qualifying the selector; verified in-browser: `rgb(0,0,0) on rgb(29,185,84)` across `/guides/*`, `/privacy`, `/terms`, `/contact`, `/zh/privacy`.

No `outline: none`, no `!important`. Console clean on every new page.

## Eval Results

No prompt-related files changed — evals skipped.

## Plan Completion

No plan file detected — this was not a `/spec`-driven change.

## TODOS

No `TODOS.md` in this repo. It uses `CHANGELOG.md`'s "Known gaps" section instead, per CLAUDE.md; a parallel list was not created.

## Documentation

`/document-release` runs as a subagent, which was not available this session; the sync ran inline instead.

- **`CLAUDE.md`** — new `### Content pages` section recording the four invariants that fail silently: `lib/guides.ts` as the single declaration four things derive from; why `requireGuide`/`guideMetadata` live in `lib/` and not beside the component; `site-footer.tsx` being the only place policy pages are linked from; `CATEGORY_BLURB` keyed by the union. Also records that the guides are English-only deliberately, and that the new paths must stay out of `robots.ts`'s disallow list.
- **`README.md`** — the project-layout route tree did not mention `/guides` or the policy pages.

Committed as `dc8d970`.

## Known gaps

- **The guides are English only.** `/zh` is written natively rather than translated; eight translated articles under it would be the one seam in the thing that page is for. Its footer links to `/guides` under a Chinese label and lands in English — kept because hiding the section from Chinese readers is worse.
- **`dateModified` equals `datePublished`** in the Article JSON-LD. Correct today, quietly wrong the first time an article is edited. Wants a second optional field in `lib/guides.ts`, not a build timestamp.
- **`GUIDE_CATEGORIES` is ordered by hand.** A category added to the union but not to that array makes its guides unreachable from `/guides`; the partition test catches it, the compiler does not.

## Test plan

- [x] Vitest: 497 tests, 28 files, 0 failures (fresh run at `c9ca4e9`, after the review fixes)
- [x] `npm run build`: compiled, 35/35 static pages, route table invariant intact
- [x] `npm run lint`: no warnings or errors
- [x] `tsc --noEmit`: clean
- [x] First commit verified independently: 497 passing at `d6830c1` with `package.json` still at 1.6.0 — bisect-safe
- [x] Rendered in a real browser at desktop width: `/guides`, `/guides/why-spotify-previews-disappeared`, `/privacy`, `/zh/privacy` — no console errors, CTA contrast verified after the fix
- [ ] **After deploy**: confirm `/guides`, `/privacy`, `/terms`, `/contact` return 200 on `www.guessong.app` *before* filing the AdSense re-review. Appeals are limited; spending one while the new pages are still 404 costs an attempt for nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
