### PR TITLE
v1.7.0 fix: annotate both halves of every language pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,41 @@ nowhere else, which is the actual bar the policy is asking about.
   lands in English. Better than hiding the section from Chinese readers, but it
   is a seam.
 
+### Fixed after release (2026-08-21, follow-up PR)
+
+Shipped hours after 1.7.0 merged, no version bump: the defect is invisible to
+players, and the repo ties a `package.json` bump to a `lib/changelog.ts` entry
+that the footer overlay prints to them. An entry reading "corrected our hreflang
+annotations" fails the bar every existing entry meets.
+
+- **The policy pages' language clusters were annotated on one side only.**
+  `app/sitemap.ts` gave `/privacy` and `/terms` the full `en`/`zh-TW`/`x-default`
+  set and gave `/zh/privacy` and `/zh/terms` nothing at all. That is precisely
+  what the comment at the top of the same file warns against — "a one-sided
+  declaration is a weaker signal than none" — broken three entries below the
+  line that says it, because the two halves were typed out separately.
+
+  The fix is not the missing values. It is `languageCluster()`: a pair is now
+  one call that computes the annotation set once and hands it to both halves, so
+  writing one side without the other is impossible rather than discouraged. The
+  landing pair goes through it too, which removed the hand-kept
+  `LANGUAGE_ALTERNATES` constant.
+
+- **The four policy pages declared `en` and `zh-TW` but no `x-default`,** unlike
+  `/` and `/zh`. Same cluster, two annotation depths.
+
+- **Both were invisible to the suite, which is the actual finding.**
+  `tests/site-policy.test.ts` asserted that the string `"languages"` appeared in
+  each page — true of a two-tag set and a three-tag set alike. It now parses the
+  block, requires all three tags, and requires both halves of a pair to name
+  identical URLs. `tests/guides.test.ts` gained the property from the other
+  direction: every alternate a sitemap entry names must itself be in the
+  sitemap, carrying an identical set. Both were confirmed to fail against the
+  original defect before being kept.
+
+  A rule stated in a comment did not survive contact with the same file it was
+  written in. That is the lesson worth keeping, not the hreflang.
+
 ## [1.6.0] - 2026-08-15
 
 Mixed Playlist Mode gets an artifact and an instrument, and the loop counters

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,8 @@ Four rules hold this together, and each replaces something that fails silently:
 
 **The guides are English only, deliberately.** `/zh` is written natively rather than translated, so eight translated articles under it would be the one seam in the thing that page is for. The policy pages are bilingual because those have to be readable by the person they bind. `/zh`'s footer links to `/guides` under a Chinese label and lands in English — a known seam, kept because hiding the section from Chinese readers is worse.
 
+**A language pair goes through `languageCluster()` in `app/sitemap.ts`, never two hand-written entries.** The rule it enforces — every URL in a cluster carries the identical annotation set, because a one-sided declaration is a weaker signal than none — was written as a comment at the top of that file and then broken three entries below it, on the policy pages, in the release that added them. The helper computes the set once and gives it to both halves. `tests/guides.test.ts` asserts every alternate a sitemap entry names is itself in the sitemap with a matching set, and `tests/site-policy.test.ts` parses each policy page's `languages` block for all three tags rather than merely grepping for the word.
+
 `/guides`, `/privacy`, `/terms` and `/contact` must stay out of `app/robots.ts`'s disallow list. That list is for ephemeral room codes and the counting redirect; a content page landing in it would be invisible to exactly the crawler it was written for. `tests/site-policy.test.ts` asserts this.
 
 ## Environment Variables

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
     "What GuessSong stores, what it does not, and which third parties are involved. GuessSong has no accounts and no login: game state lives in your own browser.",
   alternates: {
     canonical: "/privacy",
-    languages: { en: "/privacy", "zh-TW": "/zh/privacy" },
+    languages: { en: "/privacy", "zh-TW": "/zh/privacy", "x-default": "/privacy" },
   },
 };
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,37 +3,60 @@ import { GUIDES } from "@/lib/guides";
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://www.guessong.app";
 
-// Every URL in a language cluster has to carry the full annotation set —
-// a one-sided declaration is a weaker signal than none.
-const LANGUAGE_ALTERNATES = {
-  en: BASE_URL,
-  "zh-TW": `${BASE_URL}/zh`,
-  "x-default": BASE_URL,
-};
+type Entry = MetadataRoute.Sitemap[number];
+type EntryOptions = Pick<Entry, "changeFrequency" | "priority" | "lastModified">;
+
+/**
+ * Both halves of a language pair, annotated identically.
+ *
+ * Every URL in a language cluster has to carry the full annotation set — a
+ * one-sided declaration is a weaker signal than none. That rule was written at
+ * the top of this file and then broken three entries below it in 1.7.0: the
+ * policy pages got `en`/`zh-TW`/`x-default` on the English half and nothing at
+ * all on the `/zh` half, because the two were typed out separately.
+ *
+ * So a cluster is one call now. The annotation set is computed once and handed
+ * to both halves, which makes writing one side without the other impossible
+ * rather than merely discouraged. `tests/guides.test.ts` asserts the property
+ * from the other direction — every alternate a sitemap entry names must itself
+ * be in the sitemap, carrying the identical set.
+ */
+function languageCluster(
+  enPath: string,
+  zhPath: string,
+  options: EntryOptions,
+  zhOverrides: Partial<EntryOptions> = {}
+): MetadataRoute.Sitemap {
+  const en = `${BASE_URL}${enPath}`;
+  const zh = `${BASE_URL}${zhPath}`;
+  // x-default points at the English half: it is the canonical entry point and
+  // the one `app/layout.tsx` already names.
+  const languages = { en, "zh-TW": zh, "x-default": en };
+
+  return [
+    { url: en, ...options, alternates: { languages } },
+    { url: zh, ...options, ...zhOverrides, alternates: { languages } },
+  ];
+}
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();
 
+  // The landing pair. /zh keeps its slightly lower priority — it is the same
+  // content for a smaller audience, not a different page.
+  const landing = languageCluster(
+    "",
+    "/zh",
+    { lastModified: now, changeFrequency: "monthly", priority: 1 },
+    { priority: 0.9 }
+  );
+
   const core: MetadataRoute.Sitemap = [
-    {
-      url: BASE_URL,
-      lastModified: now,
-      changeFrequency: "monthly",
-      priority: 1,
-      alternates: { languages: LANGUAGE_ALTERNATES },
-    },
     {
       url: `${BASE_URL}/about`,
       lastModified: now,
       changeFrequency: "monthly",
       priority: 0.8,
-    },
-    {
-      url: `${BASE_URL}/zh`,
-      lastModified: now,
-      changeFrequency: "monthly",
-      priority: 0.9,
-      alternates: { languages: LANGUAGE_ALTERNATES },
     },
     {
       url: `${BASE_URL}/guides`,
@@ -57,52 +80,23 @@ export default function sitemap(): MetadataRoute.Sitemap {
   // Policy pages are low priority but must be crawlable and discoverable: an
   // ad network's site review looks for them, and a page it cannot find reads
   // exactly like a page that does not exist.
+  const policyOptions: EntryOptions = {
+    lastModified: now,
+    changeFrequency: "yearly",
+    priority: 0.4,
+  };
+
   const policy: MetadataRoute.Sitemap = [
-    {
-      url: `${BASE_URL}/privacy`,
-      lastModified: now,
-      changeFrequency: "yearly",
-      priority: 0.4,
-      alternates: {
-        languages: {
-          en: `${BASE_URL}/privacy`,
-          "zh-TW": `${BASE_URL}/zh/privacy`,
-          "x-default": `${BASE_URL}/privacy`,
-        },
-      },
-    },
-    {
-      url: `${BASE_URL}/terms`,
-      lastModified: now,
-      changeFrequency: "yearly",
-      priority: 0.4,
-      alternates: {
-        languages: {
-          en: `${BASE_URL}/terms`,
-          "zh-TW": `${BASE_URL}/zh/terms`,
-          "x-default": `${BASE_URL}/terms`,
-        },
-      },
-    },
+    ...languageCluster("/privacy", "/zh/privacy", policyOptions),
+    ...languageCluster("/terms", "/zh/terms", policyOptions),
+    // English only — there is one inbox behind it, and both footers point here.
     {
       url: `${BASE_URL}/contact`,
       lastModified: now,
       changeFrequency: "yearly",
       priority: 0.5,
     },
-    {
-      url: `${BASE_URL}/zh/privacy`,
-      lastModified: now,
-      changeFrequency: "yearly",
-      priority: 0.4,
-    },
-    {
-      url: `${BASE_URL}/zh/terms`,
-      lastModified: now,
-      changeFrequency: "yearly",
-      priority: 0.4,
-    },
   ];
 
-  return [...core, ...guides, ...policy];
+  return [...landing, ...core, ...guides, ...policy];
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
     "The terms you accept by using GuessSong: what the game is, what it is not, how it relates to Spotify, iTunes and Deezer, and the limits of the service.",
   alternates: {
     canonical: "/terms",
-    languages: { en: "/terms", "zh-TW": "/zh/terms" },
+    languages: { en: "/terms", "zh-TW": "/zh/terms", "x-default": "/terms" },
   },
 };
 

--- a/app/zh/privacy/page.tsx
+++ b/app/zh/privacy/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
     "GuessSong 會存什麼、不存什麼，以及有哪些第三方服務參與。這個遊戲沒有帳號、不用登入，遊戲進度留在你自己的瀏覽器裡。",
   alternates: {
     canonical: "/zh/privacy",
-    languages: { en: "/privacy", "zh-TW": "/zh/privacy" },
+    languages: { en: "/privacy", "zh-TW": "/zh/privacy", "x-default": "/privacy" },
   },
 };
 

--- a/app/zh/terms/page.tsx
+++ b/app/zh/terms/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
     "使用 GuessSong 即代表你接受的條款：這個遊戲是什麼、不是什麼、它和 Spotify／iTunes／Deezer 的關係，以及服務的限制。",
   alternates: {
     canonical: "/zh/terms",
-    languages: { en: "/terms", "zh-TW": "/zh/terms" },
+    languages: { en: "/terms", "zh-TW": "/zh/terms", "x-default": "/terms" },
   },
 };
 

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -214,6 +214,50 @@ describe("sitemap", () => {
     expect(new Set(urls).size).toBe(urls.length);
   });
 
+  it("annotates both halves of every language pair identically", () => {
+    // The rule is written at the top of app/sitemap.ts and was broken three
+    // entries below it in 1.7.0: the policy pages carried en/zh-TW/x-default on
+    // the English half and nothing on the /zh half. A comment did not stop that
+    // and would not stop it again — a one-sided cluster still renders, still
+    // builds, and just reads to Google as a weaker signal than declaring
+    // nothing. This is the assertion that makes it loud.
+    const entries = sitemap();
+    const byUrl = new Map(entries.map((e) => [e.url, e]));
+
+    for (const entry of entries) {
+      const languages = entry.alternates?.languages;
+      if (!languages) continue;
+
+      for (const [tag, target] of Object.entries(languages)) {
+        const href = String(target);
+        // x-default routinely points at a URL already named by another tag;
+        // what matters is that the target is in the sitemap and agrees.
+        const counterpart = byUrl.get(href);
+        expect(
+          counterpart,
+          `${entry.url} names ${tag}=${href}, which is not in the sitemap`
+        ).toBeDefined();
+        expect(
+          counterpart!.alternates?.languages,
+          `${entry.url} and its ${tag} counterpart ${href} declare different alternate sets`
+        ).toEqual(languages);
+      }
+    }
+  });
+
+  it("gives every language pair an x-default", () => {
+    // Without it Google picks the fallback itself, and the whole point of
+    // declaring a cluster is not leaving that to chance.
+    const clustered = sitemap().filter((e) => e.alternates?.languages);
+    expect(clustered.length).toBeGreaterThan(0);
+    for (const entry of clustered) {
+      expect(
+        Object.keys(entry.alternates!.languages!),
+        `${entry.url} declares alternates without an x-default`
+      ).toContain("x-default");
+    }
+  });
+
   it("keeps every URL absolute and on one origin", () => {
     for (const url of urls) {
       expect(url).toMatch(/^https?:\/\//);

--- a/tests/site-policy.test.ts
+++ b/tests/site-policy.test.ts
@@ -40,17 +40,28 @@ describe("policy pages", () => {
     }
   });
 
-  it("declares each language pair on both sides", () => {
+  it("declares each language pair on both sides, with the same three tags", () => {
     // A one-sided hreflang is a weaker signal than none, the same rule
-    // app/sitemap.ts follows for the / and /zh cluster.
+    // app/sitemap.ts follows. The first version of this test only checked that
+    // the word "languages" appeared, which is why all four pages shipped with
+    // en and zh-TW but no x-default and nothing noticed.
     for (const [en, zh] of [
       ["app/privacy/page.tsx", "app/zh/privacy/page.tsx"],
       ["app/terms/page.tsx", "app/zh/terms/page.tsx"],
     ]) {
       for (const page of [en, zh]) {
         const source = read(page);
-        expect(source, `${page} declares no language alternates`).toContain("languages");
+        const block = source.match(/languages: \{[^}]*\}/)?.[0];
+        expect(block, `${page} declares no language alternates`).toBeDefined();
+        for (const tag of ["en:", '"zh-TW":', '"x-default":']) {
+          expect(block, `${page} is missing ${tag} in its language alternates`).toContain(tag);
+        }
       }
+      // Both halves must name the same URLs, not just the same tags.
+      expect(
+        read(en).match(/languages: \{[^}]*\}/)?.[0],
+        `${en} and ${zh} declare different alternates`
+      ).toBe(read(zh).match(/languages: \{[^}]*\}/)?.[0]);
     }
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #25. Two hreflang defects, both introduced by that PR, plus the reason neither was caught.

**1. The policy pages' language clusters were annotated on one side only.** `app/sitemap.ts` gave `/privacy` and `/terms` the full `en`/`zh-TW`/`x-default` set and gave `/zh/privacy` and `/zh/terms` nothing at all. That is exactly what the comment at the top of the same file warns against — *"a one-sided declaration is a weaker signal than none"* — broken three entries below the line that says it, because the two halves were typed out separately.

**2. The four policy pages declared `en` and `zh-TW` but no `x-default`,** unlike `/` and `/zh`. Same cluster, two annotation depths.

**3. Neither was visible to the suite, which is the actual finding.** `tests/site-policy.test.ts` asserted that the string `"languages"` appeared in each page — true of a two-tag set and a three-tag set alike.

### The fix is the shape, not the values

`languageCluster()` makes a pair **one call** that computes the annotation set once and hands it to both halves. Writing one side without the other is now impossible rather than discouraged. The landing pair (`/` + `/zh`) goes through it too, which removed the hand-kept `LANGUAGE_ALTERNATES` constant.

A rule stated in a comment did not survive contact with the same file it was written in. That is the part worth keeping.

## Test Coverage

Tests: **497 → 499 (+2)**.

- `tests/guides.test.ts` — *"annotates both halves of every language pair identically"*: every alternate a sitemap entry names must itself be in the sitemap, carrying an identical set. Plus *"gives every language pair an x-default"*.
- `tests/site-policy.test.ts` — the existing hreflang test now parses the `languages` block, requires all three tags by name, and requires both halves of a pair to name identical URLs.

**Both tests were confirmed to fail against the original defect before being kept.** Reintroducing bug 1:

```
× annotates both halves of every language pair identically
  AssertionError: https://www.guessong.app and its zh-TW counterpart
  https://www.guessong.app/zh declare different alternate sets
```

Reintroducing bug 2:

```
× declares each language pair on both sides, with the same three tags
  AssertionError: app/zh/privacy/page.tsx is missing "x-default":
  in its language alternates
```

Each names the exact file. A test that passes on fixed code but would not have caught the bug is worth nothing.

## Output, before and after

Built sitemap:

| URL | before | after |
|---|---|---|
| `/`, `/zh` | en, zh-TW, x-default | unchanged |
| `/privacy`, `/terms` | en, zh-TW, x-default | unchanged |
| `/zh/privacy`, `/zh/terms` | *(none)* | **en, zh-TW, x-default** |
| `/about`, `/guides`, `/contact`, articles | *(none)* | unchanged — single-language, correctly bare |

Built page HTML — all four policy pages now emit `hrefLang="en"`, `hrefLang="zh-TW"`, `hrefLang="x-default"`. Sitemap URL count unchanged at 17.

## Pre-Landing Review

No new issues. The diff is one helper, four one-line metadata edits, two tests and documentation.

Worth recording: production was re-checked after #25 merged and this is the only thing that came back wrong. All 17 pages return 200, the sitemap serves the production domain, `robots.txt` disallows none of the new paths, `ads.txt` matches the publisher id, the AdSense loader is present on every page, and 15,212 English words plus 4,366 Chinese characters are in server-rendered HTML rather than client-only.

One earlier report was mistaken and is corrected here: a fourth `hrefLang` on `/` looked like a duplicate `<link>` tag. It is `<a href="/zh" hrefLang="zh-TW">` on the language-switcher link in the body, which is correct usage. `/` has exactly three `<link rel="alternate">` tags.

## Design Review

No visual changes — metadata only.

## Version

**No bump; stays 1.7.0.** The defect is invisible to players, and this repo ties a `package.json` bump to a `lib/changelog.ts` entry that the footer overlay prints to them. An entry reading "corrected our hreflang annotations" fails the bar every existing entry meets — they all describe visible game behaviour. Recorded in `CHANGELOG.md` under 1.7.0 as a post-release fix instead, dated and marked as a follow-up so the history stays honest about sequencing.

## Documentation

- `CLAUDE.md` — the `### Content pages` section gains the invariant: a language pair goes through `languageCluster()`, never two hand-written entries, and which test guards it from each direction.
- `CHANGELOG.md` — `### Fixed after release` under 1.7.0, including why there is no version bump.

## Test plan

- [x] Vitest: 499 tests, 28 files, 0 failures
- [x] Both new assertions verified to fail against the reintroduced defects, then restored
- [x] `npm run build`: compiled, 35/35 static, route table invariant intact
- [x] `npm run lint`: clean · `tsc --noEmit`: clean
- [x] Built `sitemap.xml.body` and the four policy pages' HTML inspected directly for the emitted tags
- [ ] **After deploy**: re-check `curl -s https://www.guessong.app/sitemap.xml` shows all three tags on both halves of each pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)
