### PR TITLE
Ration our own Spotify quota, and say so before the host presses Start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,179 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2026-08-23
+
+1.7.1 made the refusal message honest. It did not make it *early*: the only way
+to learn the site was throttled was still to paste a playlist, press Start, and
+be turned away. On the morning this shipped Spotify was refusing the app with
+`retry-after: 48925` — 13.6 hours — and every host arriving at the setup page
+had to spend a request to find that out.
+
+A hand-written banner was the obvious answer and the wrong one. The quota
+clears on Spotify's schedule, usually overnight, so a static notice needs
+somebody to remember to take it down the next morning. Every mechanism in this
+codebase that has depended on somebody remembering has eventually failed
+silently, and a stale "the site is down" banner over a working site is a worse
+failure than the one it was put up for.
+
+So the notice reads the same KV key the admission gate writes.
+
+### Added
+
+- **`GET /api/status` and `getSpotifyServiceStatus()`** (`app/api/status/route.ts`,
+  `lib/playlist-cache.ts`). One KV read — an `mget` of `spotify:cooldown` and
+  `spotify:budget:spent`, the two gates below — with no upstream call, no budget
+  claimed and no miss recorded; it is outside the admission path entirely. Rate limited like every other route (`STATUS_LIMIT` 120 /
+  10 minutes), which is the two commands per call the limit is protecting.
+
+- **`components/service-notice.tsx`**, mounted on `/`, `/zh` and `/j/[code]` —
+  the three places somebody is about to hand the app a playlist URL. Deliberately
+  *not* on `/game`: a party mid-round already has its tracks and cannot act on
+  the news.
+
+  It takes an optional `locale`, the way `SiteFooter` and `ChangelogModal` do,
+  and `/zh` passes `"zh"`. Left to `useErrorLocale()` alone it renders the
+  *device* language — correct for an error, since one room is read by several
+  phones, and wrong for a page written natively in Chinese, where an English
+  string is a visible defect rather than a fallback. Caught by loading `/zh` in
+  an `en-US` browser, which is exactly what a Taiwanese host on an English
+  phone is.
+
+- **`lib/service-notice.ts`** holds `shouldShowNotice` and the UI strings, in
+  `lib/` for the reason `lib/song-count.ts` gives — the suite only reaches
+  `lib/`, and vitest cannot import a `.tsx` module here.
+
+### Notes on two things that are easy to undo
+
+- **The notice's code comes from `cooldownError`, not from a second threshold.**
+  `getSpotifyServiceStatus` builds the error and reads its `code` off it, so the
+  banner and the Start button are rendered from one decision. Re-deriving
+  "is this a blip or the daily quota" beside the component would let the two
+  surfaces disagree about the same fact, and the reader has no way to tell which
+  one is lying. `tests/playlist-cache.test.ts` asserts the two codes are equal.
+
+- **The dismissal is keyed by `AppErrorCode`, not a boolean.** A host who waved
+  away a 90-second `spotify_cooldown` has not been told that the day's quota is
+  now gone; collapsing those into one flag hides the more serious message behind
+  a dismissal of the lesser one. It is `sessionStorage`, not `localStorage`, for
+  the matching reason — the next visit may be a different outage.
+
+- **`types/service-status.ts` holds the wire type**, not `lib/playlist-cache.ts`,
+  so the browser bundle does not pull in `lib/kv.ts` and the Upstash client
+  through it. Same split, same reason, as `types/preview.ts`.
+
+- **Everything fails open.** `getSpotifyServiceStatus` returns "not throttled"
+  on a KV error and the client returns null on a failed fetch, so a cache outage
+  renders no notice rather than a false one.
+
+### The gate the notice reports on
+
+The other half of this release is what decides whether there is anything to put
+a notice about.
+
+`SPOTIFY_MAX_LOADS_PER_MINUTE` has never fired in production. `spotify:budget`
+was sampled at 0-1 throughout the morning of 2026-08-23 while the site was cut
+off, because a day's traffic arriving at one or two loads a minute passes a
+40-a-minute ceiling without ever touching it. It bounds a burst — twelve phones
+submitting into one QR room — and Spotify meters a day. Nothing bounded the
+dimension that actually cuts the app off.
+
+**The window is rolling, not a calendar day.** Measured the same morning: the
+app was refused after only 476 cold loads that day, because the previous
+evening's 2,152 were still inside Spotify's window, and the `Retry-After`
+resolved to 19:53 UTC rather than to any midnight. A `dayBucket` counter reset
+at 00:00 UTC would let a busy evening and the following busy morning each pass
+their own cap and together exceed anything Spotify allows — the exact failure it
+would have been added to prevent. So the counter is twenty-four hourly buckets,
+summed on every cold load.
+
+### Added
+
+- **`hourBucket()`** (`lib/kv.ts`), the same clock as `dayBucket` one resolution
+  finer, because a rolling window cannot be built out of calendar buckets.
+
+- **`claimDailyBudget()`** (`lib/playlist-cache.ts`) and
+  `SPOTIFY_MAX_LOADS_PER_DAY`, default **2000** loads per rolling 24h. Every
+  input to that number is an inference — Spotify publishes no figure; the
+  dashboard showed ~3,850 requests on the day the quota died; a cold load costs
+  ~1.2 requests since 1.7.1 — so 2,000 loads is ~2,400 requests, under the wall
+  by a margin and just under a normal day's 2,152 cold loads. It will therefore
+  refuse at the margin of a busy day, and that is the trade taken deliberately:
+  ours is a counter that rolls forward hour by hour, Spotify's is a penalty box
+  with a fixed 13.4-hour sentence.
+
+- **`spotify_daily_budget_spent`** (`lib/error-messages.ts`). Not a reuse of
+  `spotify_quota_exhausted`, whose text says Spotify has cut the site off. When
+  this gate fires Spotify has done nothing; we refused ourselves. Producing the
+  same screen from a false account of who decided is the same class of untruth
+  as the message that used to tell throttled hosts to check their playlist was
+  public, and it is excluded from `isDeterministicPlaylistFailure` for the same
+  reason every other throttling code is.
+
+- **`getDailyBudgetStatus()`**, and an hour-by-hour block in `npm run stats`.
+  The limit above is a guess, and the shape of the window is the only evidence
+  there is for tuning it — a day spent by lunchtime and a day spent at 11pm need
+  opposite changes. `playlist:stats:*:miss` already says how many loads were
+  spent; nothing said *when*.
+
+### Changed
+
+- **`getSpotifyServiceStatus` reads both gates**, in the one `mget` it was
+  already spending. There are two ways for the playlist path to be shut, and at
+  a limit tuned just under a normal day the second is not the rare case — a
+  notice blind to it would be confidently wrong on exactly the days it matters.
+  Spotify's own refusal outranks ours when both are live: it is the longer wait
+  and the one the host can do nothing about.
+
+### Notes on three more things that are easy to undo
+
+- **The daily gate runs after the per-minute one, never before.** A load turned
+  away for bursting has not gone upstream, so it must not spend a slot in a
+  window that takes a day to give one back; a load turned away by the daily gate
+  has spent a minute slot instead, which is back in sixty seconds. Reversing
+  them lets one burst permanently shrink the day.
+
+- **It reads, then increments — the opposite of `claimGlobalBudget`.** A minute
+  counter that counts its own refusals is self-healing; a 24h one is not.
+  Refusals would inflate the very sum that caused them and hold the gate shut
+  for a day, so only loads that are actually going upstream may touch
+  `spotify:budget:h:*`, and refusals are counted separately under
+  `spotify:budget:refused:*`. The cost is that the check is not atomic against
+  itself and a burst can overshoot by whatever is in flight — already capped by
+  the per-minute gate, and a rounding error against a limit in the thousands.
+
+- **`spotify:budget:spent` exists so the notice does not walk the window.**
+  `/api/status` is a page-view-rate path whose whole cost claim is one KV read;
+  summing twenty-four buckets there would make the notice more expensive than
+  the gate it reports on. The gate leaves a flag with a TTL to the hour
+  boundary, which is when the oldest bucket rolls out and the answer can change.
+
+### Known gaps
+
+- **This does not reserve anything for the evening.** It stops the 13.4-hour
+  lockout, but a busy afternoon can still fill the window before the parties
+  start. Real pacing needs the hourly distribution of traffic, which nothing in
+  this repo recorded before today; the `npm run stats` block added here is the
+  instrument for deciding it, and it needs a full day of data first.
+- **The 2,000 is a guess and should be re-derived from the dashboard.** The
+  honest measurement is the request count on a day the quota survives, against
+  one where it does not.
+- No analytics event. Whether the notice is seen or dismissed is currently
+  unmeasured, which is the failure mode this repo keeps rediscovering. Adding
+  one means extending the union in `lib/analytics.ts` and registering the params
+  as GA4 custom dimensions, and registration is not retroactive.
+- `startCooldown` still does not log the `Retry-After` it received, so the logs
+  cannot answer "how long did Spotify actually ask for" — diagnosing this on
+  2026-08-23 needed a hand-run `curl`.
+- The notice is a modal. If throttling turns out to be frequent rather than
+  exceptional, an inline banner on the setup form is the less intrusive shape.
+- `next dev` cannot render any page in this repo: `tailwind.config.ts:54` calls
+  `require("tailwindcss-animate")` under ESM and throws while postcss compiles
+  the CSS. API routes still serve, so it fails looking like a component bug —
+  no console error, `chrome-error://chromewebdata/`, dev server gone. Unrelated
+  to this release; `npm run build && npm run start` is the way to see UI until
+  it is fixed.
+
 ## [1.7.1] - 2026-08-23
 
 Spotify stopped answering. Not the rolling-window throttle the code was built

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,8 @@ UPSTASH_REDIS_REST_URL / _TOKEN             # Required in production — see bel
 NEXT_PUBLIC_BASE_URL                        # Optional — defaults to https://www.guessong.app
 NEXT_PUBLIC_GA_MEASUREMENT_ID               # Optional — enables GA4
 NEXT_PUBLIC_ADSENSE_CLIENT_ID               # Optional — AdSense publisher id, defaults to ca-pub-2238954049312975
-SPOTIFY_MAX_LOADS_PER_MINUTE                # Optional — global upstream ceiling, default 40
+SPOTIFY_MAX_LOADS_PER_MINUTE                # Optional — global upstream burst ceiling, default 40
+SPOTIFY_MAX_LOADS_PER_DAY                   # Optional — global ceiling per rolling 24h, default 2000
 PREVIEW_MAX_LOOKUPS_PER_MINUTE              # Optional — global iTunes/Deezer ceiling, default 120
 ```
 

--- a/app/api/status/route.ts
+++ b/app/api/status/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSpotifyServiceStatus } from "@/lib/playlist-cache";
+import { enforceRateLimit } from "@/lib/rate-limit";
+
+/**
+ * Whether Spotify is currently refusing this app, phrased for a page rather
+ * than for a request that already failed.
+ *
+ * Exists so a host learns the site is throttled *before* pasting a playlist
+ * and pressing Start, instead of after. The alternative that was rejected is a
+ * hand-written banner: the quota clears on Spotify's schedule, usually
+ * overnight, and a static notice would then need someone to remember to take
+ * it down. Everything in this codebase that depends on someone remembering has
+ * eventually failed silently, so the notice reads the same KV key the
+ * admission gate does and disappears on its own.
+ *
+ * Costs one KV read, and nothing here can reach Spotify — that is the point.
+ * `getSpotifyServiceStatus` fails open, so a KV outage renders no notice
+ * rather than a false one.
+ */
+
+/**
+ * Generous on purpose: the notice fires once per page load per visitor, so the
+ * ceiling has to sit above ordinary browsing while still bounding a script
+ * that discovers the endpoint. Two KV commands per call (this limiter's incr
+ * plus the cooldown read) is what the limit is protecting.
+ */
+const STATUS_LIMIT = 120;
+const STATUS_WINDOW_SECONDS = 10 * 60;
+
+export async function GET(req: NextRequest) {
+  const limited = await enforceRateLimit(
+    req,
+    "service:status",
+    STATUS_LIMIT,
+    STATUS_WINDOW_SECONDS,
+    "rate_limited"
+  );
+  if (limited) return limited;
+
+  const status = await getSpotifyServiceStatus();
+  return NextResponse.json(status);
+}

--- a/app/j/[code]/page.tsx
+++ b/app/j/[code]/page.tsx
@@ -16,6 +16,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { LoopCtaButton, LoopFooter } from "@/components/loop-cta";
+import { ServiceNotice } from "@/components/service-notice";
 
 type SubmitStatus = "idle" | "loading" | "done" | "error";
 
@@ -144,6 +145,7 @@ export default function JoinRoomPage() {
             {status === "loading" ? "Submitting..." : "Submit Playlist"}
           </Button>
           {error && <p className="text-sm text-destructive">{error}</p>}
+          <ServiceNotice />
           <LoopFooter surface="join_footer" />
         </CardContent>
       </Card>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,7 @@ import {
   shouldRememberRejection,
 } from "@/lib/error-messages";
 import { useErrorLocale } from "@/lib/use-error-locale";
+import { ServiceNotice } from "@/components/service-notice";
 import { buildGamePayload, GAME_STORAGE_KEY } from "@/lib/game-session";
 import { isBuzzerConfigured } from "@/lib/buzzer-client";
 import type { OpenRoom } from "@/lib/room-client";
@@ -1425,6 +1426,7 @@ export default function SetupPage() {
             </p>
           </section>
 
+          <ServiceNotice />
           <SiteFooter />
 
         </div>

--- a/app/zh/page.tsx
+++ b/app/zh/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { SiteFooter } from "@/components/site-footer";
+import { ServiceNotice } from "@/components/service-notice";
 
 export const metadata: Metadata = {
   // Unlike the English pages, the H1 here IS the keyword — /zh is not the brand
@@ -427,6 +428,7 @@ export default function ZhPage() {
             </div>
           </section>
 
+          <ServiceNotice locale="zh" />
           <SiteFooter locale="zh" />
         </div>
       </main>

--- a/components/service-notice.tsx
+++ b/components/service-notice.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+/**
+ * A one-time popup telling a host that new playlists are not loading, shown
+ * before they paste a link rather than after they press Start.
+ *
+ * Driven by `GET /api/status`, which reads the same KV cooldown key the
+ * admission gate in lib/playlist-cache.ts writes. That is the whole design:
+ * the notice appears when Spotify starts refusing and disappears when the key
+ * expires, with nobody editing anything. A hand-written banner would need
+ * someone to remember to take it down the next morning, and this codebase has
+ * a long record of things that depend on someone remembering.
+ *
+ * Renders through a portal into document.body for the reason
+ * components/changelog-modal.tsx documents: the landing pages' `.fade-in`
+ * containers leave a transform behind, which makes them the containing block
+ * for `position: fixed` descendants and would clip an inline overlay.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { errorMessage, type ErrorLocale } from "@/lib/error-messages";
+import { useErrorLocale } from "@/lib/use-error-locale";
+import {
+  NOTICE_DISMISS_KEY,
+  SERVICE_NOTICE_UI,
+  shouldShowNotice,
+} from "@/lib/service-notice";
+import type { SpotifyServiceStatus } from "@/types/service-status";
+
+/**
+ * Module scope, so a client-side navigation between the pages that mount this
+ * does not re-ask. Same shape of memo as lib/preview-cache.ts's cooldown memo,
+ * and for the same reason: a site-wide, minute-scale signal is not worth one
+ * request per mount. Throttling lasts minutes to hours, so a minute of
+ * staleness costs nothing.
+ */
+const STATUS_MEMO_MS = 60_000;
+let memo: { at: number; status: SpotifyServiceStatus } | null = null;
+
+async function readStatus(signal: AbortSignal): Promise<SpotifyServiceStatus | null> {
+  if (memo && Date.now() - memo.at < STATUS_MEMO_MS) return memo.status;
+  try {
+    const res = await fetch("/api/status", { signal });
+    if (!res.ok) return null;
+    const status = (await res.json()) as SpotifyServiceStatus;
+    memo = { at: Date.now(), status };
+    return status;
+  } catch {
+    // Fail quiet. A notice that cannot confirm there is a problem must not
+    // invent one — the same fail-open rule getSpotifyServiceStatus follows.
+    return null;
+  }
+}
+
+export interface ServiceNoticeProps {
+  /**
+   * Forces the language, the way SiteFooter and ChangelogModal are given one.
+   *
+   * Without it this notice reads the *device* language, which is right for an
+   * error — one room is read by several phones — and wrong for `/zh`, a page
+   * written natively in Chinese. An English string there is a visible defect
+   * rather than a fallback, so that page states its language instead of
+   * hoping the reader's device agrees.
+   */
+  locale?: ErrorLocale;
+}
+
+export function ServiceNotice({ locale: forced }: ServiceNoticeProps = {}) {
+  const detected = useErrorLocale();
+  const locale = forced ?? detected;
+  const [status, setStatus] = useState<SpotifyServiceStatus | null>(null);
+  const [dismissedCode, setDismissedCode] = useState<string | null>(null);
+  const [mounted, setMounted] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setMounted(true);
+    try {
+      setDismissedCode(sessionStorage.getItem(NOTICE_DISMISS_KEY));
+    } catch {
+      // Private mode and blocked site data both throw here. Not knowing about
+      // a past dismissal is the harmless direction: the host sees it again.
+    }
+    const controller = new AbortController();
+    readStatus(controller.signal).then(setStatus);
+    return () => controller.abort();
+  }, []);
+
+  const open = mounted && shouldShowNotice(status, dismissedCode);
+
+  const close = useCallback(() => {
+    const code = status?.code;
+    if (code) {
+      try {
+        sessionStorage.setItem(NOTICE_DISMISS_KEY, code);
+      } catch {
+        // Dismissal then lasts for this render only. Better than failing the
+        // click.
+      }
+      setDismissedCode(code);
+    }
+  }, [status]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    dialogRef.current?.focus();
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        close();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const focusables = dialogRef.current?.querySelectorAll<HTMLElement>(
+        'button, [href], [tabindex]:not([tabindex="-1"])'
+      );
+      if (!focusables || focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [open, close]);
+
+  if (!open || !status?.code) return null;
+
+  const ui = SERVICE_NOTICE_UI[locale];
+  // Params are passed for both codes. `spotify_cooldown` renders the seconds;
+  // `spotify_quota_exhausted` carries no {seconds} placeholder on purpose (a
+  // countdown measured in hours is a promise the app cannot keep) so the same
+  // call is correct for both. See lib/error-messages.ts.
+  const body = errorMessage(status.code, locale, {
+    params: { seconds: status.retryAfterSeconds },
+  });
+
+  return createPortal(
+    <div
+      role="presentation"
+      onClick={close}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 100,
+        background: "rgba(0,0,0,0.72)",
+        backdropFilter: "blur(3px)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "16px",
+        animation: "sn-fade 0.15s ease-out",
+      }}
+    >
+      <style>{`
+        @keyframes sn-fade { from { opacity: 0 } to { opacity: 1 } }
+        .sn-dismiss {
+          background: #1DB954;
+          color: #06210f;
+          border: 0;
+          border-radius: 999px;
+          padding: 11px 26px;
+          font-family: Outfit, system-ui, sans-serif;
+          font-size: 15px;
+          font-weight: 600;
+          cursor: pointer;
+        }
+        .sn-dismiss:hover { background: #24d363 }
+      `}</style>
+      <div
+        ref={dialogRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="sn-title"
+        aria-describedby="sn-body"
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: "#1a1a1a",
+          border: "1px solid #2c2c2c",
+          borderRadius: "16px",
+          maxWidth: "460px",
+          width: "100%",
+          padding: "26px 24px 22px",
+          outline: "none",
+          boxShadow: "0 24px 60px rgba(0,0,0,0.55)",
+        }}
+      >
+        <h2
+          id="sn-title"
+          style={{
+            margin: "0 0 12px",
+            fontFamily: "'Bebas Neue', Impact, sans-serif",
+            fontSize: "27px",
+            letterSpacing: "0.5px",
+            color: "#fff",
+            lineHeight: 1.15,
+          }}
+        >
+          {ui.title}
+        </h2>
+        <p
+          id="sn-body"
+          style={{
+            margin: "0 0 20px",
+            fontFamily: "Outfit, system-ui, sans-serif",
+            fontSize: "15px",
+            lineHeight: 1.65,
+            color: "#bdbdbd",
+          }}
+        >
+          {body}
+        </p>
+        <button
+          type="button"
+          className="sn-dismiss"
+          onClick={close}
+          aria-label={ui.close}
+        >
+          {ui.dismiss}
+        </button>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/lib/changelog.ts
+++ b/lib/changelog.ts
@@ -49,6 +49,41 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "1.7.2",
+    date: "2026-08-23",
+    headline:
+      "When Spotify has cut the site off, you now find out before you paste a playlist instead of after you press Start.",
+    headlineZh:
+      "當 Spotify 把整個網站擋下來的時候，現在你在貼上歌單之前就會知道，而不是按下開始以後才發現。",
+    changes: [
+      {
+        kind: "new",
+        text: "A notice on the way in when new playlists are not loading. Spotify limits this whole site as one, so when its daily allowance runs out nobody can load anything new — and until now the only way to discover that was to paste a link, press Start, and be refused.",
+        textZh: "當新歌單載入不了的時候，一進站就會看到公告。Spotify 是把整個網站當成一個來限制的，所以它的每日額度用完時，任何人都載不了新歌單 —— 而在此之前，唯一發現的方法是貼上連結、按下開始，然後被拒絕。",
+      },
+      {
+        kind: "better",
+        text: "The notice takes itself down. It reads the same signal the game does, so the moment Spotify starts answering again it is gone, without anybody having to remember to remove it.",
+        textZh: "這個公告會自己消失。它讀的是遊戲本身在讀的同一個訊號，所以 Spotify 一恢復回應它就不見了，不需要任何人記得回來把它拿掉。",
+      },
+      {
+        kind: "better",
+        text: "Players joining a mixed-playlist room see it too, since their submission goes through the same place. A room that quietly collected nothing was the worst version of this.",
+        textZh: "加入混合歌單房間的玩家也看得到，因為他們送出的歌單走的是同一條路。房間安安靜靜什麼都沒收到，是這件事最糟的版本。",
+      },
+      {
+        kind: "new",
+        text: "The site now paces how many new playlists it loads from Spotify across the day, instead of using the allowance up as fast as it arrives. On a busy day that means a handful of hosts are asked to wait at the edges — which is the trade for not having Spotify shut every new playlist out for thirteen hours at a time, which is what happened this week.",
+        textZh: "網站現在會把向 Spotify 載入新歌單的數量分配到一整天，而不是有多少就用多快。忙碌的日子裡，這代表少數幾位主持人會在邊緣被請稍等 —— 這是為了不要再被 Spotify 一次擋掉十三個小時所做的取捨，而那正是這週發生的事。",
+      },
+      {
+        kind: "better",
+        text: "Playlists you have already loaded keep working through all of this. Whatever is happening with Spotify, a party that has started is not interrupted by it.",
+        textZh: "在這整個過程中，你已經載入過的歌單都還是能用。不管 Spotify 那邊發生什麼事，已經開始的派對不會被打斷。",
+      },
+    ],
+  },
+  {
     version: "1.7.1",
     date: "2026-08-23",
     headline:

--- a/lib/error-messages.ts
+++ b/lib/error-messages.ts
@@ -55,6 +55,7 @@ export type AppErrorCode =
   | "spotify_rate_limited"
   | "spotify_cooldown"
   | "spotify_quota_exhausted"
+  | "spotify_daily_budget_spent"
   | "spotify_busy"
   | "spotify_not_configured"
   | "spotify_auth_failed"
@@ -167,6 +168,22 @@ export const ERROR_MESSAGES: Record<AppErrorCode, Record<ErrorLocale, string>> =
   spotify_quota_exhausted: {
     en: "Spotify has cut the whole site off for today — every game here shares one quota with Spotify and it is spent. Playlists that have already been loaded still work; new ones come back once Spotify resets. Your playlist URL is fine.",
     zh: "Spotify 今天已經把整個網站擋下來了 — 這裡所有的遊戲共用同一份 Spotify 配額，而它用完了。已經載入過的歌單還是可以玩，新的歌單要等 Spotify 重置後才會恢復。你的歌單連結沒有問題。",
+  },
+  /**
+   * The self-imposed twin of `spotify_quota_exhausted`, and the distinction is
+   * worth a separate code because the two are not the same event: that one is
+   * Spotify refusing us, this one is us refusing ourselves *before* Spotify
+   * does. Saying "Spotify has cut the whole site off" when it has not would be
+   * the same class of untruth as telling a throttled host their playlist is
+   * private — technically it produces the same screen, and it teaches the
+   * reader something false about who decided.
+   *
+   * Carries no `{seconds}` for the reason above it: the wait is until enough
+   * of the rolling window ages out, which is not a countdown worth watching.
+   */
+  spotify_daily_budget_spent: {
+    en: "This site limits how many new playlists it loads from Spotify in a day, so one busy afternoon can't leave the evening with nothing — and today's allowance is gone. Playlists that have already been loaded still work, and some allowance frees up every hour. Your playlist URL is fine.",
+    zh: "這個網站每天會限制向 Spotify 載入新歌單的數量，免得一個下午就把整晚的額度用光 — 今天的額度已經用完了。已經載入過的歌單還是可以玩，每小時也會釋出一些額度。你的歌單連結沒有問題。",
   },
   spotify_busy: {
     en: "Too many new playlists are being loaded across the site right now. Please try again in a minute — your playlist URL is fine.",
@@ -430,7 +447,8 @@ export function errorMessage(
  *
  * Only failures that are a fact about the URL. Every throttling code is
  * excluded, and must stay excluded: `spotify_rate_limited`, `spotify_cooldown`,
- * `spotify_quota_exhausted` and `spotify_busy` are facts about a shared quota
+ * `spotify_quota_exhausted`, `spotify_daily_budget_spent` and `spotify_busy`
+ * are facts about a shared quota
  * that clears on its own, so
  * suppressing the retry would strand a host whose playlist was always fine —
  * the same class of mistake as the message that used to tell throttled hosts to

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -88,6 +88,23 @@ export function dayBucket(at: Date = new Date()): string {
   return at.toISOString().slice(0, 10);
 }
 
+/**
+ * The same clock one resolution finer, for counters that have to add up to a
+ * *rolling* window rather than a calendar one.
+ *
+ * `lib/playlist-cache.ts` needs this because Spotify's quota turned out not to
+ * be a calendar day. Measured on production 2026-08-23: a `QUOTA_EXCEEDED`
+ * whose `Retry-After` resolved to 19:53 UTC — an instant roughly 24h after the
+ * previous evening's burn, not to any midnight. A day bucket against that
+ * window lets two busy half-days sit inside one rolling 24h and each pass its
+ * own cap; twenty-four of these, summed, is the window itself.
+ *
+ * UTC, and `at` for tests, for the same reasons `dayBucket` gives.
+ */
+export function hourBucket(at: Date = new Date()): string {
+  return at.toISOString().slice(0, 13);
+}
+
 type MemoryEntry = { value: unknown; expiresAt: number };
 
 declare global {

--- a/lib/playlist-cache.ts
+++ b/lib/playlist-cache.ts
@@ -28,7 +28,7 @@
  * "broken" — same contract as app/api/preview/route.ts, which this follows.
  */
 
-import { dayBucket, getKvStore } from "@/lib/kv";
+import { dayBucket, getKvStore, hourBucket } from "@/lib/kv";
 import {
   getPlaylistWithTracks,
   isSpotifyEditorial,
@@ -37,6 +37,7 @@ import {
 } from "@/lib/spotify";
 import { stripTrackForStorage } from "@/lib/game-session";
 import type { AppErrorCode } from "@/lib/error-messages";
+import type { SpotifyServiceStatus } from "@/types/service-status";
 import type { Track } from "@/types";
 
 /**
@@ -101,6 +102,68 @@ const COOLDOWN_KEY = "spotify:cooldown";
 const GLOBAL_LOAD_WINDOW_SECONDS = 60;
 const DEFAULT_GLOBAL_LOAD_LIMIT = 40;
 const BUDGET_KEY = "spotify:budget";
+
+/**
+ * The same idea over the window that actually cuts us off.
+ *
+ * The per-minute gate above bounds a *burst*. It has never once fired in
+ * production — `spotify:budget` was observed at 0-1 all through the outage of
+ * 2026-08-23 — because it is guarding the wrong dimension. Spotify's refusal
+ * is a quota over roughly 24 hours, and a day's worth of traffic arriving at
+ * an average of one or two loads a minute passes a 40-a-minute ceiling
+ * without ever touching it. Both gates are needed: this one cannot stop a QR
+ * room's twelve simultaneous submits, and that one cannot stop an ordinary
+ * Sunday.
+ *
+ * **The window is rolling, not a calendar day, and that is not a detail.**
+ * Measured 2026-08-23: the app was refused after only 476 cold loads that day,
+ * because the previous evening's 2,152 were still inside Spotify's window, and
+ * the `Retry-After` pointed at 19:53 UTC rather than any midnight. A
+ * `dayBucket` counter reset at 00:00 UTC would have let a busy evening and the
+ * following busy morning each pass their own cap while together exceeding
+ * anything Spotify would allow — the exact failure it was added to prevent. So
+ * the counter is twenty-four hourly buckets, summed.
+ *
+ * The hourly buckets are also the only record of *when* the day is spent,
+ * which is the number the limit below has to be tuned against; `npm run stats`
+ * prints them.
+ */
+const DAILY_WINDOW_HOURS = 24;
+const HOUR_BUCKET_TTL_SECONDS = (DAILY_WINDOW_HOURS + 1) * 60 * 60;
+const HOUR_BUDGET_PREFIX = "spotify:budget:h";
+const HOUR_REFUSED_PREFIX = "spotify:budget:refused";
+
+/**
+ * Written when the window is spent, read by `getSpotifyServiceStatus`.
+ *
+ * The status route is a page-view-rate path and its whole cost claim is "one
+ * KV read". Summing twenty-four hourly buckets there to answer a yes/no would
+ * quietly make the notice more expensive than the gate it reports on, so the
+ * gate leaves a flag behind instead and the notice reads it in the same `mget`
+ * it already spends on the cooldown. TTL'd to the hour boundary, which is when
+ * the oldest bucket rolls out and the answer can change.
+ */
+const DAILY_SPENT_KEY = "spotify:budget:spent";
+
+/**
+ * Loads allowed upstream per rolling 24h, before we start refusing on
+ * Spotify's behalf.
+ *
+ * Every input to this number is an inference, so it is env-overridable and
+ * deliberately easy to find. What is known: Spotify does not publish a figure;
+ * the developer dashboard showed ~3,850 requests on the day the quota died;
+ * and since 1.7.1 a cold load costs ~1.2 requests rather than ~2.2. 2,000
+ * loads is therefore ~2,400 requests — under the wall by a margin, and just
+ * under a normal day's 2,152 cold loads, so it will occasionally refuse at the
+ * margin.
+ *
+ * That last part is the trade, stated plainly: refusing perhaps a hundred
+ * loads at the edge of a busy day is chosen over Spotify refusing *every*
+ * uncached load for 13.4 unconditional hours, which is what it did. Ours is a
+ * counter that rolls forward hour by hour; theirs is a penalty box with a
+ * fixed sentence.
+ */
+const DEFAULT_DAILY_LOAD_LIMIT = 2000;
 
 /**
  * Spotify's Retry-After on QUOTA_EXCEEDED is sometimes enormous and sometimes
@@ -272,6 +335,112 @@ async function claimGlobalBudget(): Promise<boolean> {
   }
 }
 
+function dailyLoadLimit(): number {
+  const configured = Number(process.env.SPOTIFY_MAX_LOADS_PER_DAY);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_DAILY_LOAD_LIMIT;
+}
+
+/** The window, newest hour first, as keys under `prefix`. */
+function windowKeys(prefix: string, now: Date): string[] {
+  return Array.from({ length: DAILY_WINDOW_HOURS }, (_, i) =>
+    `${prefix}:${hourBucket(new Date(now.getTime() - i * 60 * 60 * 1000))}`
+  );
+}
+
+function sum(counts: Array<number | null>): number {
+  return counts.reduce<number>(
+    (total, n) => total + (typeof n === "number" && Number.isFinite(n) ? n : 0),
+    0
+  );
+}
+
+/**
+ * How long until the oldest hour in the window rolls out and its share of the
+ * budget comes back. Reported as a header, never rendered as a countdown —
+ * `spotify_daily_budget_spent` carries no `{seconds}`, for the reason
+ * lib/error-messages.ts gives.
+ */
+function secondsToNextHour(now: Date): number {
+  return Math.ceil((3600000 - (now.getTime() % 3600000)) / 1000);
+}
+
+/**
+ * Claims one load against the rolling 24h budget. Returns false when the
+ * window is spent.
+ *
+ * Read-then-increment rather than the increment-then-compare `claimGlobalBudget`
+ * uses, and the asymmetry is deliberate in both directions. A minute counter
+ * that counts its own refusals is self-healing — the window is gone in sixty
+ * seconds. A 24h one is not: refusals would inflate the very sum that caused
+ * them and hold the gate shut for a day, so only loads that are actually going
+ * upstream may touch it. The cost is that the check is not atomic against
+ * itself, so a burst can overshoot by however many requests are in flight at
+ * once — which the per-minute gate has already capped at `globalLoadLimit()`,
+ * a rounding error against a limit in the thousands.
+ *
+ * Fails *open*, like every other gate in this file: losing the safety net has
+ * to mean "back to how it was", not "nobody can play".
+ */
+async function claimDailyBudget(now: Date): Promise<boolean> {
+  try {
+    const store = await getKvStore();
+    const used = sum(await store.mget<number>(windowKeys(HOUR_BUDGET_PREFIX, now)));
+    if (used >= dailyLoadLimit()) {
+      // Counted, not logged per request: a spent window refuses every uncached
+      // load for as long as it lasts, and a log line each would be the noisiest
+      // output in the app on the day it is least useful to read.
+      const frees = secondsToNextHour(now);
+      await store.incr(
+        `${HOUR_REFUSED_PREFIX}:${hourBucket(now)}`,
+        HOUR_BUCKET_TTL_SECONDS
+      );
+      await store.set(DAILY_SPENT_KEY, { until: now.getTime() + frees * 1000 }, frees);
+      return false;
+    }
+    await store.incr(
+      `${HOUR_BUDGET_PREFIX}:${hourBucket(now)}`,
+      HOUR_BUCKET_TTL_SECONDS
+    );
+    return true;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * The rolling window as `npm run stats` reads it: the totals, and the shape
+ * of the day that produced them.
+ *
+ * `byHour` is oldest first. It answers the question the limit has to be tuned
+ * against and that nothing else in this repo can — not "how many loads did we
+ * spend" (`playlist:stats:*:miss` has that) but *when*, and therefore whether
+ * a cap is starving the evening to feed the afternoon.
+ */
+export async function getDailyBudgetStatus(now: Date = new Date()): Promise<{
+  used: number;
+  refused: number;
+  limit: number;
+  byHour: Array<{ hour: string; used: number; refused: number }>;
+}> {
+  const store = await getKvStore();
+  const usedKeys = windowKeys(HOUR_BUDGET_PREFIX, now);
+  const refusedKeys = windowKeys(HOUR_REFUSED_PREFIX, now);
+  const [used, refused] = await Promise.all([
+    store.mget<number>(usedKeys),
+    store.mget<number>(refusedKeys),
+  ]);
+  const byHour = usedKeys
+    .map((key, i) => ({
+      hour: key.slice(HOUR_BUDGET_PREFIX.length + 1),
+      used: sum([used[i]]),
+      refused: sum([refused[i]]),
+    }))
+    .reverse();
+  return { used: sum(used), refused: sum(refused), limit: dailyLoadLimit(), byHour };
+}
+
 /**
  * Hit/miss counters, bucketed by day and held for a week.
  *
@@ -372,6 +541,77 @@ function cooldownError(secondsRemaining: number): SpotifyApiError {
 }
 
 /**
+ * The cooldown as a fact a *page* can render, rather than an error a request
+ * had to hit to find out.
+ *
+ * Read-only, and deliberately outside the admission path: it claims no budget,
+ * records no miss and never goes upstream, so asking "is Spotify refusing us
+ * right now?" costs one KV read. That is what lets the site notice be live
+ * instead of a banner somebody has to remember to take down — the same key
+ * that parks the loads clears the notice when it expires.
+ *
+ * The code comes from `cooldownError`, not from a second threshold written
+ * here. A notice that said "throttled, back in ten minutes" while the host's
+ * own Start button said "the daily quota is gone" would be worse than no
+ * notice: two numbers for one fact, and the reader has to guess which is
+ * lying. One function decides, both surfaces read it.
+ */
+export type { SpotifyServiceStatus };
+
+const OPEN_STATUS: SpotifyServiceStatus = {
+  throttled: false,
+  code: null,
+  retryAfterSeconds: 0,
+};
+
+export async function getSpotifyServiceStatus(): Promise<SpotifyServiceStatus> {
+  // Both gates in one command, because there are two ways for the playlist
+  // path to be shut and a notice that knew about only one would be confidently
+  // wrong on the days the other fires — which, at a limit tuned just under a
+  // normal day, is not the rare case.
+  //
+  // Fail-open is the only defensible answer here, for the same reason
+  // lib/rate-limit.ts fails open: a KV outage must not put a "we are broken"
+  // banner on a site that is, as far as anyone can tell, fine.
+  let cooldown: { until: number } | null = null;
+  let spent: { until: number } | null = null;
+  try {
+    const store = await getKvStore();
+    [cooldown, spent] = await store.mget<{ until: number }>([
+      COOLDOWN_KEY,
+      DAILY_SPENT_KEY,
+    ]);
+  } catch {
+    return OPEN_STATUS;
+  }
+
+  const remainingOf = (entry: { until: number } | null): number =>
+    typeof entry?.until === "number" ? Math.ceil((entry.until - Date.now()) / 1000) : 0;
+
+  // Spotify's own refusal outranks ours. When both are live the host is facing
+  // the longer wait, and it is the one they can do nothing about.
+  const cooling = remainingOf(cooldown);
+  if (cooling > 0) {
+    return {
+      throttled: true,
+      code: cooldownError(cooling).code,
+      retryAfterSeconds: cooling,
+    };
+  }
+
+  const rationed = remainingOf(spent);
+  if (rationed > 0) {
+    return {
+      throttled: true,
+      code: "spotify_daily_budget_spent",
+      retryAfterSeconds: rationed,
+    };
+  }
+
+  return OPEN_STATUS;
+}
+
+/**
  * Coalesces concurrent loads of the same playlist within one lambda instance.
  *
  * Mixed Playlist Mode fires one request per contributor from a single click,
@@ -406,6 +646,17 @@ async function fetchAndCache(
   if (!(await claimGlobalBudget())) {
     throw new SpotifyApiError("spotify_busy", 429, {
       retryAfterSeconds: GLOBAL_LOAD_WINDOW_SECONDS,
+    });
+  }
+
+  // After the per-minute gate, never before it. A load refused for bursting
+  // has not gone upstream, so it must not spend a slot in the 24h window that
+  // takes a day to give one back; a load refused here has spent a minute slot
+  // instead, which is back in sixty seconds.
+  const now = new Date();
+  if (!(await claimDailyBudget(now))) {
+    throw new SpotifyApiError("spotify_daily_budget_spent", 429, {
+      retryAfterSeconds: secondsToNextHour(now),
     });
   }
 

--- a/lib/service-notice.ts
+++ b/lib/service-notice.ts
@@ -1,0 +1,53 @@
+import type { ErrorLocale } from "@/lib/error-messages";
+import type { SpotifyServiceStatus } from "@/types/service-status";
+
+/**
+ * The site notice that tells a host the playlist path is down *before* they
+ * paste a link, rather than after they press Start.
+ *
+ * The logic lives here rather than beside the component for the reason
+ * lib/song-count.ts and lib/guides.ts give: the suite only reaches lib/, and
+ * vitest cannot import a .tsx module in this project. The component keeps the
+ * JSX and nothing else.
+ */
+
+/**
+ * Per-tab, not persistent. A host who dismisses this is saying "I have read
+ * it", not "never show me this again" — the next visit may be a different
+ * outage, and localStorage would silence it. sessionStorage forgets when the
+ * tab closes, which is the same lifetime as the game payload it sits next to.
+ */
+export const NOTICE_DISMISS_KEY = "guesssong_notice_dismissed";
+
+/**
+ * Keyed by the *code*, not a boolean.
+ *
+ * A dismissal is scoped to the thing that was dismissed. `spotify_cooldown`
+ * (a blip, minutes) and `spotify_quota_exhausted` (the daily quota, hours) are
+ * materially different news, and a host who waved away the first one has not
+ * been told the second. Storing a bare flag would collapse them and hide the
+ * more serious message behind a dismissal of the lesser one.
+ */
+export function shouldShowNotice(
+  status: SpotifyServiceStatus | null,
+  dismissedCode: string | null
+): boolean {
+  if (!status?.throttled || !status.code) return false;
+  return status.code !== dismissedCode;
+}
+
+export const SERVICE_NOTICE_UI: Record<
+  ErrorLocale,
+  { title: string; dismiss: string; close: string }
+> = {
+  en: {
+    title: "New playlists aren't loading right now",
+    dismiss: "Got it",
+    close: "Dismiss notice",
+  },
+  zh: {
+    title: "現在新歌單載入不了",
+    dismiss: "知道了",
+    close: "關閉公告",
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guesssong",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/scripts/loop-stats.mjs
+++ b/scripts/loop-stats.mjs
@@ -440,6 +440,50 @@ if (cacheRows.length > 0) {
   }
 }
 
+/**
+ * Spotify's admission gate, over the window Spotify actually meters.
+ *
+ * The per-minute ceiling has never fired in production and never will at this
+ * traffic shape; the rolling 24h one is the gate that decides whether an
+ * evening has any playlist loads left in it. Its limit is a guess — Spotify
+ * publishes no number — so the hour-by-hour shape below is the only evidence
+ * there is for tuning it. Read it for *when* the window fills, not just
+ * whether: a day spent by lunchtime and a day spent at 11pm need opposite
+ * changes.
+ *
+ * The keys are written by `claimDailyBudget` in lib/playlist-cache.ts.
+ */
+const budgetHours = Array.from({ length: 24 }, (_, i) =>
+  new Date(Date.now() - i * 60 * 60 * 1000).toISOString().slice(0, 13)
+).reverse();
+const [budgetUsed, budgetRefused] = [
+  await mgetAll(budgetHours.map((h) => `spotify:budget:h:${h}`)),
+  await mgetAll(budgetHours.map((h) => `spotify:budget:refused:${h}`)),
+];
+const num = (v) => (Number.isFinite(Number(v)) ? Number(v) : 0);
+const usedTotal = budgetUsed.reduce((t, v) => t + num(v), 0);
+const refusedTotal = budgetRefused.reduce((t, v) => t + num(v), 0);
+
+if (usedTotal + refusedTotal > 0) {
+  const peak = Math.max(...budgetUsed.map(num), 1);
+  console.log("\nSpotify upstream budget — rolling 24h, the window that cuts us off");
+  console.log(
+    `  ${usedTotal} loads sent upstream, ${refusedTotal} refused here before Spotify saw them`
+  );
+  console.log("");
+  for (const [i, hour] of budgetHours.entries()) {
+    const used = num(budgetUsed[i]);
+    const refused = num(budgetRefused[i]);
+    // Hours with nothing in them are the finding, not noise — a flat evening
+    // after a full afternoon is exactly the shape a daily cap can produce.
+    const bar = "█".repeat(Math.round((used / peak) * 32));
+    const tail = refused > 0 ? `  (${refused} refused)` : "";
+    console.log(
+      `  ${hour.slice(11)}:00  ${String(used).padStart(4)}  ${bar}${tail}`
+    );
+  }
+}
+
 console.log(
   "\nRead these as floors, not measurements:\n" +
     "  · Repeat hosts are undercounted — iOS clears localStorage after 7 days\n" +

--- a/tests/error-messages.test.ts
+++ b/tests/error-messages.test.ts
@@ -77,6 +77,7 @@ describe("the message table", () => {
       "spotify_rate_limited",
       "spotify_cooldown",
       "spotify_quota_exhausted",
+      "spotify_daily_budget_spent",
       "spotify_busy",
     ] as const) {
       expect(ERROR_MESSAGES[code].en).not.toMatch(/public/i);
@@ -138,6 +139,7 @@ describe("isDeterministicPlaylistFailure", () => {
       "spotify_rate_limited",
       "spotify_cooldown",
       "spotify_quota_exhausted",
+      "spotify_daily_budget_spent",
       "spotify_busy",
       "rate_limited",
       "rate_limited_playlist",

--- a/tests/playlist-cache.test.ts
+++ b/tests/playlist-cache.test.ts
@@ -1,7 +1,13 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as spotify from "@/lib/spotify";
-import { loadPlaylist, getCacheStats, __resetInFlightForTests } from "@/lib/playlist-cache";
+import {
+  loadPlaylist,
+  getCacheStats,
+  getDailyBudgetStatus,
+  getSpotifyServiceStatus,
+  __resetInFlightForTests,
+} from "@/lib/playlist-cache";
 import type { Track } from "@/types";
 
 /**
@@ -24,12 +30,21 @@ vi.mock("@/lib/kv", () => ({
   // reproduces it rather than stubbing it — a mocked bucket would let the key
   // format drift here without any test noticing.
   dayBucket: (at: Date = new Date()) => at.toISOString().slice(0, 10),
+  hourBucket: (at: Date = new Date()) => at.toISOString().slice(0, 13),
   getKvStore: async () => ({
     async get(key: string) {
       if (kv.flags.failReads) throw new Error("kv unavailable");
       const entry = kv.mem.get(key);
       if (!entry || Date.now() > entry.expiresAt) return null;
       return entry.value;
+    },
+    async mget(keys: string[]) {
+      if (kv.flags.failReads) throw new Error("kv unavailable");
+      return keys.map((key) => {
+        const entry = kv.mem.get(key);
+        if (!entry || Date.now() > entry.expiresAt) return null;
+        return entry.value;
+      });
     },
     async set(key: string, value: unknown, ttlSeconds: number) {
       if (kv.flags.failWrites) throw new Error("kv unavailable");
@@ -519,5 +534,233 @@ describe("KV degradation", () => {
     kv.flags.failWrites = true;
 
     await expect(loadPlaylist(URL_A)).resolves.toMatchObject({ totalTracks: 2 });
+  });
+});
+
+/**
+ * The read-only half of the cooldown, used by the site notice.
+ *
+ * The property that matters is that it agrees with the error a host would get
+ * from the same state, and that asking costs nothing upstream — a notice that
+ * spent a Spotify call to report that Spotify calls are failing would be a
+ * joke at the quota's expense.
+ */
+describe("getSpotifyServiceStatus", () => {
+  it("reports open when nothing is parked", async () => {
+    await expect(getSpotifyServiceStatus()).resolves.toEqual({
+      throttled: false,
+      code: null,
+      retryAfterSeconds: 0,
+    });
+  });
+
+  it("reports a blip with the same code the host would be shown", async () => {
+    upstream().mockRejectedValueOnce(
+      new spotify.SpotifyApiError("spotify_rate_limited", 429, { retryAfterSeconds: 90 })
+    );
+    const err = await loadPlaylist(URL_A).catch((e) => e);
+
+    const status = await getSpotifyServiceStatus();
+    expect(status.throttled).toBe(true);
+    expect(status.code).toBe("spotify_cooldown");
+    expect(status.code).toBe(err.code);
+    expect(status.retryAfterSeconds).toBeGreaterThan(0);
+  });
+
+  it("reports a spent daily quota with the countdown-free code", async () => {
+    upstream().mockRejectedValueOnce(
+      new spotify.SpotifyApiError("spotify_rate_limited", 429, { retryAfterSeconds: 48513 })
+    );
+    const err = await loadPlaylist(URL_A).catch((e) => e);
+
+    const status = await getSpotifyServiceStatus();
+    expect(status.code).toBe("spotify_quota_exhausted");
+    expect(status.code).toBe(err.code);
+    // Honest, even though the message that renders it carries no {seconds}.
+    expect(status.retryAfterSeconds).toBeGreaterThan(10 * 60);
+  });
+
+  it("never reaches Spotify", async () => {
+    upstream().mockRejectedValueOnce(
+      new spotify.SpotifyApiError("spotify_rate_limited", 429, { retryAfterSeconds: 90 })
+    );
+    await loadPlaylist(URL_A).catch(() => {});
+    const before = upstreamCalls();
+
+    await getSpotifyServiceStatus();
+    await getSpotifyServiceStatus();
+
+    expect(upstreamCalls()).toBe(before);
+  });
+
+  /**
+   * Fail open, like every other KV consumer here. A cache outage must not put
+   * a "we are broken" notice on a site that is, as far as anyone can tell,
+   * fine.
+   */
+  it("reports open when KV cannot be read", async () => {
+    upstream().mockRejectedValueOnce(
+      new spotify.SpotifyApiError("spotify_rate_limited", 429, { retryAfterSeconds: 90 })
+    );
+    await loadPlaylist(URL_A).catch(() => {});
+
+    kv.flags.failReads = true;
+
+    await expect(getSpotifyServiceStatus()).resolves.toMatchObject({
+      throttled: false,
+      code: null,
+    });
+  });
+});
+
+/**
+ * The gate the per-minute one cannot be: Spotify refuses on a rolling ~24h
+ * quota, and 40-a-minute is never reached by a day's worth of traffic
+ * arriving at one or two loads a minute. Every assertion here is again about
+ * upstream call *count* — the point is not the error, it is that the call
+ * never left the building.
+ */
+describe("rolling 24h upstream budget", () => {
+  beforeEach(() => {
+    process.env.SPOTIFY_MAX_LOADS_PER_DAY = "3";
+  });
+
+  afterEach(() => {
+    delete process.env.SPOTIFY_MAX_LOADS_PER_DAY;
+  });
+
+  const uniqueUrl = (i: number) => `https://open.spotify.com/playlist/d${i}aaaaaaaaaa`;
+
+  it("refuses new playlists past the daily ceiling before Spotify does", async () => {
+    for (let i = 0; i < 3; i++) await loadPlaylist(uniqueUrl(i));
+    expect(upstreamCalls()).toBe(3);
+
+    await expect(loadPlaylist(uniqueUrl(9))).rejects.toMatchObject({
+      code: "spotify_daily_budget_spent",
+      status: 429,
+    });
+    expect(upstreamCalls()).toBe(3);
+  });
+
+  it("does not spend the day's budget on cached playlists", async () => {
+    await loadPlaylist(URL_A);
+    for (let i = 0; i < 10; i++) {
+      await expect(loadPlaylist(URL_A)).resolves.toMatchObject({ totalTracks: 2 });
+    }
+
+    // One load spent, so two of a ceiling of three are still there.
+    await expect(getDailyBudgetStatus()).resolves.toMatchObject({ used: 1, limit: 3 });
+    expect(upstreamCalls()).toBe(1);
+  });
+
+  /**
+   * The ordering rule in `fetchAndCache`, pinned. A load turned away for
+   * bursting never went upstream, so it must not spend a slot in a window that
+   * takes a day to give one back — otherwise a single burst permanently
+   * shrinks the day.
+   */
+  it("does not spend the day's budget on a load the per-minute gate refused", async () => {
+    process.env.SPOTIFY_MAX_LOADS_PER_MINUTE = "1";
+    try {
+      await loadPlaylist(uniqueUrl(0));
+      await expect(loadPlaylist(uniqueUrl(1))).rejects.toMatchObject({ code: "spotify_busy" });
+    } finally {
+      delete process.env.SPOTIFY_MAX_LOADS_PER_MINUTE;
+    }
+
+    await expect(getDailyBudgetStatus()).resolves.toMatchObject({ used: 1, refused: 0 });
+  });
+
+  /**
+   * The counterpart, and the reason this gate reads before it increments: a
+   * refusal that counted itself would inflate the sum that caused it and hold
+   * the window shut for a day.
+   */
+  it("counts its own refusals separately from the loads it allowed", async () => {
+    for (let i = 0; i < 3; i++) await loadPlaylist(uniqueUrl(i));
+    for (let i = 0; i < 4; i++) await loadPlaylist(uniqueUrl(9)).catch(() => {});
+
+    await expect(getDailyBudgetStatus()).resolves.toMatchObject({
+      used: 3,
+      refused: 4,
+      limit: 3,
+    });
+  });
+
+  it("sums the window across hours rather than resetting at midnight", async () => {
+    const now = new Date();
+    const anHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+    const hour = (at: Date) => at.toISOString().slice(0, 13);
+
+    // Two loads recorded an hour ago, by hand, in the shape the gate writes.
+    kv.mem.set(`spotify:budget:h:${hour(anHourAgo)}`, {
+      value: 2,
+      expiresAt: Date.now() + 60 * 60 * 1000,
+    });
+
+    // One more fits; the next does not, even though this hour has spent one.
+    await loadPlaylist(uniqueUrl(0));
+    await expect(loadPlaylist(uniqueUrl(1))).rejects.toMatchObject({
+      code: "spotify_daily_budget_spent",
+    });
+    expect(upstreamCalls()).toBe(1);
+
+    const status = await getDailyBudgetStatus(now);
+    expect(status.used).toBe(3);
+    expect(status.byHour.at(-1)).toMatchObject({ hour: hour(now), used: 1 });
+  });
+
+  it("tells the host to wait rather than to fix their URL", async () => {
+    for (let i = 0; i < 3; i++) await loadPlaylist(uniqueUrl(i));
+
+    const err = await loadPlaylist(uniqueUrl(9)).catch((e) => e);
+    // The hazard lib/error-messages.ts pins in both languages: a refusal that
+    // sends the host back to editing a URL that was always fine.
+    expect(err.message).not.toMatch(/public/i);
+    expect(err.retryAfterSeconds).toBeGreaterThan(0);
+    expect(err.retryAfterSeconds).toBeLessThanOrEqual(3600);
+  });
+
+  it("fails open when KV is unavailable, rather than blocking every load", async () => {
+    kv.flags.failReads = true;
+    await expect(loadPlaylist(URL_A)).resolves.toMatchObject({ totalTracks: 2 });
+    expect(upstreamCalls()).toBe(1);
+  });
+
+  /**
+   * There are two ways for the playlist path to be shut, and the site notice
+   * has to know about both. A banner blind to this gate would leave hosts
+   * pasting a link to find out what the page could have told them — which is
+   * the whole thing 1.7.2 exists to stop.
+   */
+  it("shows up in the service notice, not just at the Start button", async () => {
+    for (let i = 0; i < 3; i++) await loadPlaylist(uniqueUrl(i));
+    await expect(getSpotifyServiceStatus()).resolves.toMatchObject({ throttled: false });
+
+    await loadPlaylist(uniqueUrl(9)).catch(() => {});
+
+    const status = await getSpotifyServiceStatus();
+    expect(status).toMatchObject({ throttled: true, code: "spotify_daily_budget_spent" });
+    expect(status.retryAfterSeconds).toBeGreaterThan(0);
+  });
+
+  /**
+   * Spotify's own refusal outranks ours: it is the longer wait and the one the
+   * host can do nothing about.
+   */
+  it("yields to a real Spotify cooldown when both are live", async () => {
+    for (let i = 0; i < 3; i++) await loadPlaylist(uniqueUrl(i));
+    await loadPlaylist(uniqueUrl(9)).catch(() => {});
+
+    upstream().mockRejectedValueOnce(
+      new spotify.SpotifyApiError("spotify_rate_limited", 429, { retryAfterSeconds: 52531 })
+    );
+    delete process.env.SPOTIFY_MAX_LOADS_PER_DAY;
+    await loadPlaylist(URL_B).catch(() => {});
+
+    await expect(getSpotifyServiceStatus()).resolves.toMatchObject({
+      throttled: true,
+      code: "spotify_quota_exhausted",
+    });
   });
 });

--- a/tests/service-notice.test.ts
+++ b/tests/service-notice.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import {
+  NOTICE_DISMISS_KEY,
+  SERVICE_NOTICE_UI,
+  shouldShowNotice,
+} from "@/lib/service-notice";
+import type { SpotifyServiceStatus } from "@/types/service-status";
+
+const OPEN: SpotifyServiceStatus = {
+  throttled: false,
+  code: null,
+  retryAfterSeconds: 0,
+};
+const BLIP: SpotifyServiceStatus = {
+  throttled: true,
+  code: "spotify_cooldown",
+  retryAfterSeconds: 90,
+};
+const QUOTA: SpotifyServiceStatus = {
+  throttled: true,
+  code: "spotify_quota_exhausted",
+  retryAfterSeconds: 48_513,
+};
+const RATIONED: SpotifyServiceStatus = {
+  throttled: true,
+  code: "spotify_daily_budget_spent",
+  retryAfterSeconds: 1_800,
+};
+
+describe("shouldShowNotice", () => {
+  it("stays hidden before the status has arrived", () => {
+    expect(shouldShowNotice(null, null)).toBe(false);
+  });
+
+  it("stays hidden when Spotify is not refusing us", () => {
+    expect(shouldShowNotice(OPEN, null)).toBe(false);
+  });
+
+  it("shows when throttled and nothing has been dismissed", () => {
+    expect(shouldShowNotice(BLIP, null)).toBe(true);
+    expect(shouldShowNotice(QUOTA, null)).toBe(true);
+  });
+
+  it("stays hidden once that same code has been dismissed", () => {
+    expect(shouldShowNotice(QUOTA, "spotify_quota_exhausted")).toBe(false);
+  });
+
+  /**
+   * The reason the dismissal is keyed by code rather than a bare flag. A host
+   * who waved away a 90-second blip has not been told that the day's quota is
+   * now gone, and those are materially different pieces of news — one is worth
+   * waiting out at the Start button, the other is not.
+   */
+  it("shows again when a worse code replaces a dismissed one", () => {
+    expect(shouldShowNotice(QUOTA, "spotify_cooldown")).toBe(true);
+  });
+
+  /**
+   * The seam between the two gates. `spotify_daily_budget_spent` is us
+   * refusing ourselves before Spotify does, `spotify_quota_exhausted` is
+   * Spotify refusing us, and a host who dismissed the first has not been told
+   * the second — which is the more serious news, and the one they can do
+   * nothing about. Keyed dismissal is what keeps those separate.
+   */
+  it("shows our own rationing, and does not let it mask Spotify's refusal", () => {
+    expect(shouldShowNotice(RATIONED, null)).toBe(true);
+    expect(shouldShowNotice(RATIONED, "spotify_daily_budget_spent")).toBe(false);
+    expect(shouldShowNotice(QUOTA, "spotify_daily_budget_spent")).toBe(true);
+  });
+
+  it("stays hidden if throttled is set without a code", () => {
+    expect(
+      shouldShowNotice(
+        { throttled: true, code: null, retryAfterSeconds: 60 },
+        null
+      )
+    ).toBe(false);
+  });
+});
+
+describe("SERVICE_NOTICE_UI", () => {
+  it("carries both languages, and they differ", () => {
+    for (const key of ["title", "dismiss", "close"] as const) {
+      expect(SERVICE_NOTICE_UI.en[key].trim()).not.toBe("");
+      expect(SERVICE_NOTICE_UI.zh[key].trim()).not.toBe("");
+      expect(SERVICE_NOTICE_UI.en[key]).not.toBe(SERVICE_NOTICE_UI.zh[key]);
+    }
+  });
+
+  /**
+   * `/zh` is written natively rather than translated, so an English string
+   * leaking through there is a visible defect. Same rule tests/site-policy.ts
+   * pins for the footer.
+   */
+  it("keeps the Chinese strings free of ASCII letters", () => {
+    for (const key of ["title", "dismiss", "close"] as const) {
+      expect(SERVICE_NOTICE_UI.zh[key]).not.toMatch(/[A-Za-z]/);
+    }
+  });
+
+  it("namespaces the dismissal key like the other session keys", () => {
+    expect(NOTICE_DISMISS_KEY.startsWith("guesssong_")).toBe(true);
+  });
+});

--- a/types/service-status.ts
+++ b/types/service-status.ts
@@ -1,0 +1,20 @@
+import type { AppErrorCode } from "@/lib/error-messages";
+
+/**
+ * The wire shape of `GET /api/status`, shared by both sides.
+ *
+ * Separate from lib/playlist-cache.ts for the same reason types/preview.ts is
+ * separate from lib/preview-cache.ts: the notice component needs the contract,
+ * and that module reaches for lib/kv.ts and through it the Upstash client,
+ * none of which belongs in a browser bundle.
+ */
+export interface SpotifyServiceStatus {
+  throttled: boolean;
+  /**
+   * The exact code a host pressing Start would get right now, so the notice
+   * and the error can never contradict each other. Null when nothing is wrong.
+   */
+  code: AppErrorCode | null;
+  /** Honest seconds, straight from the stored `until`. Zero when open. */
+  retryAfterSeconds: number;
+}


### PR DESCRIPTION
On 2026-08-23 Spotify spent GuessSong's daily app quota and refused every uncached playlist load for 13.6 hours:

```
HTTP/2 429
retry-after: 48925
{"error":{"status":429,"message":"Too many requests","reason":"QUOTA_EXCEEDED"}}
```

Reproducible from a laptop on a home IP with the same client id, which rules out Vercel's shared egress and names the **client id** as the thing being throttled. Redeploying cannot help: the quota is per app, and the cooldown lives in KV.

This is two halves of one problem, and both are needed.

## 1. Ration before Spotify does

`SPOTIFY_MAX_LOADS_PER_MINUTE` guards a *burst* and has never once fired — `spotify:budget` sat at 0–1 all through the outage — because it is guarding the wrong dimension. Spotify's refusal is a quota over roughly 24 hours, and an ordinary Sunday arriving at one or two loads a minute sails past a 40-a-minute ceiling.

`claimDailyBudget` adds the missing gate: loads per **rolling** 24h, counted as twenty-four hourly buckets and summed.

Rolling rather than a calendar day, and that is not a detail. The app was refused after only **476** cold loads that day — the previous evening's 2,152 were still inside Spotify's window, and the `Retry-After` pointed at 19:53 UTC rather than any midnight. A `dayBucket` counter resetting at 00:00 UTC would have let a busy evening and the following busy morning each pass their own cap while together exceeding anything Spotify allows: the exact failure it was added to prevent.

`DEFAULT_DAILY_LOAD_LIMIT = 2000` (`SPOTIFY_MAX_LOADS_PER_DAY`) is an inference and is commented as one. It will occasionally refuse at the margin of a busy day. That trade is stated plainly in the code: refusing perhaps a hundred loads at the edge is chosen over Spotify refusing *every* uncached load for 13.4 unconditional hours, which is what actually happened.

## 2. Say so on the way in

Until now the only way to discover the site was throttled was to paste a playlist, press Start, and be turned away.

`GET /api/status` reads both gates in a single `mget` and `ServiceNotice` shows it on `/`, `/zh` and `/j/[code]` — the three places somebody is about to hand the app a playlist URL. Not on `/game`: a party mid-round already has its tracks and cannot act on the news.

A hand-written banner was the obvious alternative and the wrong one. The quota clears on Spotify's schedule, usually overnight, so a static notice needs somebody to remember to take it down. This reads the same keys the gate writes, so it appears and disappears on its own.

## Things here that are easy to undo by accident

- **The notice's code comes from `cooldownError`, not a second threshold.** The banner and the Start button render from one decision, so they cannot disagree about the same fact. Asserted in `tests/playlist-cache.test.ts`.
- **Spotify's refusal outranks ours.** When both gates are live the host is told about the longer wait, and the one they can do nothing about.
- **`claimDailyBudget` is read-then-increment**, unlike the per-minute gate's increment-then-compare. A minute counter that counts its own refusals is self-healing; a 24h one is not — refusals would inflate the sum that caused them and hold the gate shut for a day.
- **The dismissal is keyed by `AppErrorCode`, not a boolean.** A host who waved away a 90-second blip has not been told the day's quota is gone.
- **`types/service-status.ts` holds the wire type**, so the browser bundle does not pull in `lib/kv.ts` and the Upstash client. Same split as `types/preview.ts`.
- **Everything fails open**, like every other KV consumer here. A cache outage renders no notice rather than a false one.

## Verification

- 532 tests pass; `npm run lint` clean; `npm run build` clean.
- Route table unchanged: `/icon` and `/opengraph-image` are `○`, `/icons/[size]` is `●` with all three sizes.
- `GET /api/status` against real production KV returned `{"throttled":true,"code":"spotify_quota_exhausted","retryAfterSeconds":46386}`.
- Popup verified rendering in a real browser against the production build, in both languages, with dismissal writing `sessionStorage` and no console errors.

## Notes

- Two Claude sessions wrote this in the same working tree; the halves were merged deliberately, not by accident. Worth a careful read of `lib/playlist-cache.ts` as one piece.
- `next dev` cannot render **any** page in this repo: `tailwind.config.ts:54` calls `require("tailwindcss-animate")` under ESM. API routes still serve, so it fails looking like a component bug. Pre-existing and untouched here; use `npm run build && npm run start` to see UI. Worth its own PR.
- No analytics event for the notice yet — whether it is seen or dismissed is unmeasured, which is the failure mode this repo keeps rediscovering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
