### PR TITLE
v1.7.4 fix: the client-side exception on Start, and a notice that warns before the allowance runs out

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,7 @@
 # Spotify's Web API and needs these to authenticate. This is app-level
 # Client Credentials, NOT a user login — no redirect URI, no Spotify account
 # sign-in, and the player never sees a Spotify auth screen.
-# Skip these only if you're just trying the 3 built-in trial playlists,
-# which are bundled locally and never call the Spotify API.
+# Nothing loads without these.
 # Get these at https://developer.spotify.com/dashboard
 SPOTIFY_CLIENT_ID=
 SPOTIFY_CLIENT_SECRET=
@@ -26,6 +25,26 @@ NEXT_PUBLIC_ADSENSE_CLIENT_ID=
 # https://upstash.com
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
+
+# Optional — how hard the app rations Spotify's shared quota on its own behalf.
+# Spotify throttles per client id, so every visitor of a deployment shares one
+# budget, and a busy afternoon can leave the evening with nothing. These are the
+# ceilings that stop that; defaults are in lib/playlist-cache.ts.
+#
+#   SPOTIFY_MAX_LOADS_PER_MINUTE  burst ceiling on uncached loads   (default 40)
+#   SPOTIFY_MAX_LOADS_PER_DAY     rolling 24h ceiling               (default 2000)
+#   SPOTIFY_BUDGET_WARN_RATIO     when hosts get the heads-up popup (default 0.8)
+#
+# The warn ratio is a fraction of the daily ceiling: at 0.8 of 2000, hosts see a
+# "close to today's allowance" notice from the 1600th load, while the site still
+# works. Raise it to warn later and less often.
+SPOTIFY_MAX_LOADS_PER_MINUTE=
+SPOTIFY_MAX_LOADS_PER_DAY=
+SPOTIFY_BUDGET_WARN_RATIO=
+
+# Optional — global ceiling on iTunes/Deezer preview lookups per minute
+# (default 120). Counted in lookups, not requests: one track can cost several.
+PREVIEW_MAX_LOOKUPS_PER_MINUTE=
 
 # Required for Buzzer Mode only. Points at the Cloudflare Worker in worker/,
 # which hosts the live buzzer rooms as Durable Objects — Vercel serves the app,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,164 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.4] - 2026-08-24
+
+A host wrote in: the site loads, they paste a playlist, they press Start, and
+the page becomes
+
+> Application error: a client-side exception has occurred while loading
+> www.guessong.app (see the browser console for more information).
+
+Chrome and Safari both. Several different public playlists. They read every
+troubleshooting page on the site and found nothing, which is the part worth
+sitting with — there was nothing to find, because the message names no cause,
+offers no action, and its one instruction is to open a developer console.
+
+`POST /api/playlist` was answering 200 with a valid track list throughout. The
+failure was entirely on the client, and the reason it could take the whole page
+down is that **`app/` had no error boundary anywhere in it**. Any throw, from
+any component or effect, unmounted the tree and fell through to Next's default
+screen. Nothing recorded it either: the first anyone heard was the email.
+
+So this release does two things — removes the throws that were reachable on the
+path from Start to `/game`, and makes sure the next one that is not reachable
+today lands somewhere a host can act on.
+
+### Fixed
+
+- **The game payload is validated on the way out of sessionStorage**
+  (`lib/game-session.ts`). `parseGamePayload` cast `d.tracks` with
+  `as Track[]` — a blind cast, sitting in a module whose every other field goes
+  through a guard. `app/game/page.tsx`'s preview-prefetch effect dereferences
+  `t.artists[0]` on mount, so a single entry without an `artists` array was a
+  `TypeError` inside an effect with no `try` of its own. Reproduced against the
+  production build: it renders exactly the reported sentence.
+
+  `normalizeTrack` now repairs what a game can play without and drops only what
+  it cannot. `artists` becomes `[]` and `durationMs` becomes `0`; a track with
+  no `id` or no `name` is dropped, because nothing can look up a clip for the
+  first and there is no answer to reveal for the second. Players get the same
+  treatment — a nameless entry is dropped rather than rendered as a blank
+  scoreboard row. The repair-or-drop split is the rule `GAME_MODES` and
+  `PLAYLIST_SOURCES` already follow, and for the same reason: a payload sitting
+  in a host's sessionStorage at deploy time has to keep playing.
+
+- **Every read and write of the payload is guarded** (`lib/game-storage.ts`,
+  new). `sessionStorage` *throws* rather than returning null in a locked-down
+  browser — Safari with "Block All Cookies", Chrome with site data disallowed,
+  several embedded webviews — and it throws on the property access itself, so
+  the `try` has to wrap the access and not just the call. `lib/host-session.ts`
+  has documented this since it was written and guards everything it owns; the
+  game payload was the one path that did not. `app/game/page.tsx:215` read the
+  key bare inside a mount effect.
+
+  `saveGameTo` / `loadGameFrom` / `clearGameFrom` take the store as an argument
+  so `tests/game-storage.test.ts` can hand them one that throws, which is the
+  case no browser on a developer's desk reproduces on demand.
+
+- **A browser that refuses storage is no longer reported as a bad playlist**
+  (`app/page.tsx`, `lib/error-messages.ts`). All three `setItem` call sites sat
+  inside the same `try` as the playlist fetch, so a `SecurityError` there came
+  out of `describeError` as `playlist_load_failed` — "Couldn't load that
+  playlist". That is the same mistake as the message that used to tell
+  throttled hosts to check their URL was public, and it produces the same
+  behaviour: the host swaps playlists all evening, reads the help page, and
+  gets nowhere. Exactly what the report describes.
+
+  New code `storage_blocked` names the browser and says what to change.
+  Deliberately *not* in `isDeterministicPlaylistFailure`: the same URL will work
+  fine once the setting is changed, so the retry has to stay open.
+
+### Added
+
+- **`app/error.tsx` and `app/global-error.tsx`**, rendering
+  `components/crash-screen.tsx`. The route boundary catches everything below the
+  root layout; the global one catches the root layout itself and supplies its
+  own `<html>`/`<body>`, so nothing it renders may depend on anything the layout
+  would have loaded.
+
+  The screen says the site broke rather than the playlist, offers **Start over**
+  (clears the stored game, returns to setup — the recovery for the whole class
+  of causes, since an unreadable payload is gone the moment it is dropped),
+  **Try again** (`reset()`, for the transient half such as a chunk that failed
+  to load once), a link to the issue tracker, and Next's error `digest` as a
+  reference a bug report can quote. Bilingual through `lib/error-messages.ts`
+  like every other player-facing string.
+
+- **The `client_error` analytics event** (`lib/analytics.ts`), fired from the
+  boundary and bucketed by which boundary caught it — `route` or `root`. No
+  message, no stack, no digest: stack frames carry pasted playlist URLs and
+  query strings into GA4, which is the cardinality-and-user-input rule the rest
+  of that file already keeps. The digest goes to `console.error` on the device,
+  which is where the person reading it already is.
+
+- **The site notice now warns before it refuses** (`lib/service-notice.ts`,
+  `lib/playlist-cache.ts`, `types/service-status.ts`,
+  `components/service-notice.tsx`). 1.7.2 put a notice in front of the host, but
+  only once the allowance was already spent — by which point the only thing left
+  to tell them is to come back tomorrow.
+
+  `GET /api/status` now answers with `approachingLimit` as well as `throttled`,
+  and the notice has two states with two headlines. `warning` fires at
+  `SPOTIFY_BUDGET_WARN_RATIO` (new, default `0.8`) of `SPOTIFY_MAX_LOADS_PER_DAY`
+  and says the site still works, which is the whole point: a host reading it at
+  eight o'clock can load their playlist while there is allowance for it, or pick
+  one that is already cached. `blocked` is the existing refusal notice,
+  unchanged.
+
+  Three properties this had to have, all tested:
+
+  - **It costs nothing extra.** `claimDailyBudget` already has the day's `used`
+    in hand on every cold load, so the threshold is a conditional `set` on the
+    crossing loads and nothing on the rest; `getSpotifyServiceStatus` reads the
+    flag as one more key in the `mget` it already spends.
+    `tests/playlist-cache.test.ts` counts the reads — summing 24 hourly buckets
+    in the status route would have made the notice more expensive than the gate
+    it reports on, which is the trap `DAILY_SPENT_KEY` was built to avoid one
+    step earlier.
+  - **A refusal outranks the warning it grew out of.** `throttled` and
+    `approachingLimit` are never both true. "You are about to run out" tells
+    someone who already has that the site still works.
+  - **The two headlines are different sentences.** "New playlists aren't
+    loading" is false during a warning, and a host who reads it walks away from
+    a site that would have worked for them — strictly worse than staying quiet.
+    Dismissal stays keyed by error code, so waving away `spotify_budget_low` at
+    eight does not silence `spotify_daily_budget_spent` at ten.
+
+### Documentation
+
+- `CLAUDE.md` gains two sections: **A client-side throw must never be a dead
+  end** (why the boundaries exist, and the three rules on the Start → `/game`
+  path) and **The site notice warns before it refuses**.
+- `README.md`: new **When the client throws** and **The site notice** sections;
+  `/api/status` added to the route table, which had never listed it;
+  `SPOTIFY_MAX_LOADS_PER_DAY` added to the environment table, which had never
+  listed it either; test and file counts corrected (they said 17 files / 273
+  cases against an actual 31 / 567).
+- `.env.example`: the three Spotify budget knobs and
+  `PREVIEW_MAX_LOOKUPS_PER_MINUTE` documented; dropped the note about "the 3
+  built-in trial playlists", which have not existed since 1.5.0.
+
+### Known gaps
+
+- **The reported crash is fixed by construction, not by reproduction.** The
+  malformed-track path was reproduced against the production build and produces
+  the reported sentence exactly; the storage-blocked path was reproduced with
+  `sessionStorage` overridden to throw. Which of the two that host hit is not
+  known, and a third cause reaching the same screen is not ruled out — a chunk
+  that fails to load mid-navigation would look identical. `client_error` is
+  there so the next one is a number rather than an email. That the reporter had
+  the same failure in Chrome *and* Safari is consistent with iOS, where both are
+  WebKit, and no WebKit engine was available here to test against.
+- **`app/error.tsx` cannot catch a throw during a server render**, and neither
+  boundary catches an unhandled promise rejection. Neither is reachable on the
+  path this release is about, but neither is impossible.
+- **The warning threshold has never run against real traffic.** 0.8 of 2,000 is
+  1,600 loads, and a normal day is ~2,152 cold loads, so it should trip most
+  evenings. If it turns out to trip at lunchtime every day it becomes wallpaper;
+  `SPOTIFY_BUDGET_WARN_RATIO` is retunable from Vercel without a deploy for
+  exactly that reason.
+
 ## [1.7.3] - 2026-08-23
 
 1.7.2 put the notice in front of the host before they paste a link. It said the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,7 @@ NEXT_PUBLIC_GA_MEASUREMENT_ID               # Optional — enables GA4
 NEXT_PUBLIC_ADSENSE_CLIENT_ID               # Optional — AdSense publisher id, defaults to ca-pub-2238954049312975
 SPOTIFY_MAX_LOADS_PER_MINUTE                # Optional — global upstream burst ceiling, default 40
 SPOTIFY_MAX_LOADS_PER_DAY                   # Optional — global ceiling per rolling 24h, default 2000
+SPOTIFY_BUDGET_WARN_RATIO                   # Optional — fraction of the daily ceiling that triggers the heads-up notice, default 0.8
 PREVIEW_MAX_LOOKUPS_PER_MINUTE              # Optional — global iTunes/Deezer ceiling, default 120
 ```
 
@@ -177,6 +178,73 @@ Four things `tests/error-messages.test.ts` will catch, all easy to do by acciden
 - **The two quota codes must say the app is free, that the quota is not for sale, and where to go instead** — in both languages. A host told only "the allowance is gone" is left with two readings and both are wrong: that nobody is looking after the site, or that money would fix it. Spotify sells no bigger quota to a project this size, so an apology and an honest account is the whole of what is on offer, and the open-source line is the only real remedy in it. `components/service-notice.tsx` renders that last part as a link (`SELF_HOST_URL`) rather than prose, because the same string is also shown as plain text under the Start button where nothing is clickable. The test pins apology, "free" and "open source" on both `spotify_quota_exhausted` and `spotify_daily_budget_spent`, in `en` *and* `zh` — a translation is where the awkward second half of a sentence gets dropped.
 
 The buzzer Worker keeps its own wire codes (`BuzzerErrorCode` in `lib/buzzer-protocol.ts`, which is shared verbatim with the Worker and must stay dependency-free). `BUZZER_ERROR_CODES` maps them onto app codes — that mapping is the only thing connecting the two, so a new wire code needs an entry there.
+
+## A client-side throw must never be a dead end
+
+`app/error.tsx` and `app/global-error.tsx` exist because there was no error
+boundary anywhere in `app/`, and the cost of that is on record: an uncaught
+throw on the path from Start to `/game` replaced a host's party with Next's
+default — *"Application error: a client-side exception has occurred (see the
+browser console for more information)"* — which names no cause, offers no
+action, and reported nothing anywhere. It was found from a user email, not from
+telemetry. **Deleting either boundary restores that**, and nothing on screen
+will say so until the next report arrives.
+
+Three rules hold the Start → `/game` path together, and each replaces something
+that shipped:
+
+- **`parseGamePayload` validates the track list; it must never go back to
+  `as Track[]`.** The game page dereferences `t.artists[0]` in its
+  preview-prefetch effect on mount, so one entry without an `artists` array was
+  a TypeError there and the whole page died. `normalizeTrack` repairs what a
+  game can play without (`artists` → `[]`, `durationMs` → `0`) and drops only
+  what it cannot (no `id`, no `name`). That split is the same rule `GAME_MODES`
+  follows and for the same reason: a payload already in a host's sessionStorage
+  has to keep playing across a deploy, not fail to parse mid-party.
+- **`lib/game-storage.ts` is the only path to the game payload.**
+  `sessionStorage` *throws* rather than returning null in a locked-down browser
+  — Safari with "Block All Cookies", several embedded webviews — and the throw
+  is on the property access itself, which is why the `try` wraps the access and
+  not just the call. `lib/host-session.ts` documented this and guarded
+  everything it owned; this payload was the one path that did not.
+- **A refused write is `storage_blocked`, never `playlist_load_failed`.** The
+  write used to sit inside the same `try` as the playlist fetch, so a browser
+  refusing storage was reported as a bad playlist — the same class of mistake as
+  telling a throttled host to check their URL was public, and it produced the
+  same behaviour: a host swapping playlists all evening and reading the help
+  page. `tests/error-messages.test.ts` pins that neither of the two browser
+  codes mentions the playlist.
+
+The boundary reports through `client_error` in `lib/analytics.ts`, bucketed by
+which boundary caught it. **No message, stack or digest may join those params** —
+stack frames carry pasted playlist URLs and query strings, which is exactly the
+cardinality-and-user-input rule the rest of that file keeps. The digest goes to
+`console.error` and onto the crash screen, where the person who can quote it
+already is.
+
+## The site notice warns before it refuses
+
+`components/service-notice.tsx` has two states and the earlier one is the
+feature. `warning` fires at `SPOTIFY_BUDGET_WARN_RATIO` of the daily ceiling
+while the site still works; `blocked` is the original refusal notice. A host who
+is told only at the refusal has already lost the choice the warning gives them —
+load the playlist now, or pick one that is already cached.
+
+- **The threshold is evaluated where `used` is already in hand.**
+  `claimDailyBudget` has the day's count on every cold load, so the warning
+  costs one conditional `set` on the crossing loads and nothing on the rest.
+  `getSpotifyServiceStatus` reads the flag as one more key in the `mget` it
+  already spends. Answering it by summing 24 hourly buckets in the status route
+  would make the notice more expensive than the gate it reports on — the same
+  reasoning `DAILY_SPENT_KEY` records, one step earlier.
+- **`throttled` and `approachingLimit` are never both true.** A live refusal
+  outranks the warning it grew out of: "you are about to run out" tells someone
+  who already has that the site still works.
+- **The two headlines must stay different sentences.** "New playlists aren't
+  loading" is false during a warning, and a host who reads it walks away from a
+  site that would have worked for them — strictly worse than not warning at all.
+  `tests/service-notice.test.ts` pins that, and pins that dismissing
+  `spotify_budget_low` does not silence the refusal that follows it.
 
 ## Analytics
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ cp .env.example .env.local
 | `NEXT_PUBLIC_BUZZER_WS_URL` | Buzzer Mode only | `ws://127.0.0.1:8787` locally, `wss://guesssong-buzzer.<subdomain>.workers.dev` in production. Unset → the Buzzer Mode toggle is hidden. |
 | `NEXT_PUBLIC_BASE_URL` | Optional | Defaults to `https://www.guessong.app`. |
 | `NEXT_PUBLIC_GA_MEASUREMENT_ID` | Optional | Injects GA4 when set. Events no-op outside production regardless. |
-| `SPOTIFY_MAX_LOADS_PER_MINUTE` | Optional | Global ceiling on uncached Spotify playlist loads. Default `40`. |
+| `SPOTIFY_MAX_LOADS_PER_MINUTE` | Optional | Global ceiling on uncached Spotify playlist loads, per minute. Default `40`. |
+| `SPOTIFY_MAX_LOADS_PER_DAY` | Optional | Global ceiling per rolling 24h, counted in hourly buckets. Default `2000`. This is the one that stops Spotify's daily app quota being spent in an afternoon — see [Caching and admission control](#caching-and-admission-control). |
+| `SPOTIFY_BUDGET_WARN_RATIO` | Optional | How much of the daily ceiling has to be gone before hosts see the heads-up popup. Default `0.8`. Raise it to warn later and less often. |
 | `PREVIEW_MAX_LOOKUPS_PER_MINUTE` | Optional | Global ceiling on iTunes/Deezer lookups. Default `120`. |
 | `DEV_ORIGINS` | Optional, dev only | Comma-separated LAN hostnames (no scheme, no port) added to `allowedDevOrigins`. Needed to test from a phone. |
 
@@ -175,13 +177,15 @@ app/
   share/                     Web Share Target handler + /share/unsupported explainer
   icons/[size]/              PWA icons, prerendered at build (never per request)
   api/                       See the table below
+  error.tsx, global-error.tsx  Error boundaries — see "When the client throws" below
   icon.tsx, opengraph-image.tsx, robots.ts, sitemap.ts
 components/                  Buzzer button + host panel, room panel, mixed collector,
-                             install banner, changelog modal, ui/ (shadcn primitives)
+                             install banner, changelog modal, service notice,
+                             crash screen, ui/ (shadcn primitives)
 lib/                         All shared logic — see "Architecture" below
 worker/                      Cloudflare Worker + BuzzerRoom Durable Object
-tests/                       22 Vitest files, 366 cases
-types/                       Track, room, and preview wire types
+tests/                       31 Vitest files, 567 cases
+types/                       Track, room, preview, and service-status wire types
 ```
 
 ## API Routes
@@ -197,6 +201,7 @@ Every route is IP rate limited (`lib/rate-limit.ts`) with a fixed window; limits
 | `/api/room/[code]/submit` | POST | `{playerName, playlistUrl}` → `{ok, trackCount}`. | 20 / 10 min |
 | `/api/room/[code]/status` | GET | Who has submitted so far (host polls every 4s). | 200 / 10 min |
 | `/api/room/[code]/pool` | GET | `?sampledPerPlayer=N` + `x-host-token` header → the sampled, deduped pool. One-shot consume. | 20 / 10 min |
+| `/api/status` | GET | `{throttled, approachingLimit, code, retryAfterSeconds}` — how much of the shared Spotify allowance is left. One KV read, never touches Spotify. Drives the site notice. | 120 / 10 min |
 | `/share` | GET | Web Share Target — extracts a playlist from shared text and redirects to `/?playlist=…`. | — |
 | `/icons/[size]` | GET | Generated PWA icons (`192`, `512`, `maskable`). | — |
 
@@ -226,6 +231,26 @@ Spotify throttles per **client ID**, so every visitor shares one budget — per-
 
 Vercel pins WebSocket connections to a single function instance with no guarantee a second connection lands on the same one — there's nothing to broadcast a room to. So live rooms run on Cloudflare instead. The host `POST`s to the Worker's `/rooms`, which generates a 4-character code from an ambiguity-free alphabet and claims a Durable Object by that name; the DO *is* the registry, so a non-null return is the collision check. Players connect to `/rooms/:code/ws`, and ordering is decided by the DO's single-threaded execution — no locks, no CAS. Verdicts stay human: the room decides *who* was first, a person decides *whether* they were right. Max 12 players, 3h idle timeout.
 
+### When the client throws
+
+The app had no error boundary anywhere in `app/`, which meant any uncaught client-side error — a mount effect, a chunk that failed to load, a stored payload that could not be read — replaced the whole page with Next's default: *"Application error: a client-side exception has occurred (see the browser console for more information)."* For a host with a room full of people waiting, that sentence names no cause, offers no action, and its only instruction is to open a developer console. It also reported nothing, so the first anyone heard of a crash was an email weeks later.
+
+`app/error.tsx` and `app/global-error.tsx` now catch both levels and render `components/crash-screen.tsx`: a bilingual message saying the site broke rather than the playlist, a **Start over** button that clears the stored game and returns to setup, a **Try again** that re-runs the render, and Next's error `digest` printed as a reference a bug report can quote. Every catch fires the `client_error` analytics event, bucketed by which boundary caught it — never the message or the stack, which would carry pasted playlist URLs into GA4.
+
+Two hardenings sit underneath, both on the path from Start to `/game`:
+
+- **The stored game is validated, not cast.** `parseGamePayload` used to `as Track[]` whatever JSON came back, so one malformed entry reached the render and threw. It now repairs what it can (a missing `artists` becomes `[]`, a missing `durationMs` becomes `0`) and drops only what nothing can play — no `id`, no `name`. The repair-or-drop split is the same rule the `GAME_MODES` guard follows: a game already sitting in a host's sessionStorage has to keep playing across a deploy.
+- **Storage is guarded on both sides.** `sessionStorage` *throws* rather than returning null in a locked-down browser (Safari with "Block All Cookies", several embedded webviews), and the throw is on the property access itself. `lib/game-storage.ts` is now the only way the payload is written and read. A refused write is reported as `storage_blocked` — it used to sit inside the same `try` as the playlist fetch and surface as "Couldn't load that playlist", which sent hosts off to swap links that were never the problem.
+
+### The site notice
+
+`components/service-notice.tsx` is a one-time popup about the shared Spotify allowance, shown before a host pastes a link rather than after they press Start. It has two states, and the earlier one is the point:
+
+- **warning** — the day's allowance is nearly spent and everything still works. Fires at `SPOTIFY_BUDGET_WARN_RATIO` (default 0.8). A host reading this at eight can load their playlist while there is allowance for it; told at ten, when the refusal lands, they have no move left.
+- **blocked** — new playlists are not loading, because Spotify is refusing us or we are rationing ourselves.
+
+Both read `GET /api/status`, which reads the same KV keys the admission gate writes — so the notice appears and disappears on its own, with nobody remembering to take a banner down. The threshold is evaluated on the pass `claimDailyBudget` was already making, and the status route still costs exactly one KV read; summing 24 hourly buckets there would have made the notice more expensive than the gate it reports on. Dismissal is keyed by error code, not a flag, so waving away the warning does not silence the refusal it predicted.
+
 ### Error messages
 
 `lib/error-messages.ts` is the only place a user-visible error string exists — one code union and one `{en, zh}` table, so a missing translation is a compile error. The server sends `{error, code}` and the client picks the language from the device locale. Localising server-side would be wrong: one room is read by several devices, and cached 404s would freeze one language into the cache for everyone.
@@ -237,7 +262,7 @@ Two hand-written changelogs, and a release updates both: [`CHANGELOG.md`](./CHAN
 ## Testing
 
 ```bash
-npm test              # 17 files, 273 cases — vitest, jsdom
+npm test              # 31 files, 567 cases — vitest, jsdom
 cd worker && npm test # Durable Object tests inside workerd
 ```
 

--- a/app/api/status/route.ts
+++ b/app/api/status/route.ts
@@ -3,10 +3,15 @@ import { getSpotifyServiceStatus } from "@/lib/playlist-cache";
 import { enforceRateLimit } from "@/lib/rate-limit";
 
 /**
- * Whether Spotify is currently refusing this app, phrased for a page rather
+ * How much of the shared Spotify allowance is left, phrased for a page rather
  * than for a request that already failed.
  *
- * Exists so a host learns the site is throttled *before* pasting a playlist
+ * Two answers, not one: `throttled` when a host pressing Start would be
+ * refused, and `approachingLimit` while the day's allowance is running down and
+ * everything still works. The second is the one that changes an evening — it
+ * reaches a host while loading a playlist is still an option.
+ *
+ * Exists so a host learns where the site stands *before* pasting a playlist
  * and pressing Start, instead of after. The alternative that was rejected is a
  * hand-written banner: the quota clears on Spotify's schedule, usually
  * overnight, and a static notice would then need someone to remember to take
@@ -14,7 +19,8 @@ import { enforceRateLimit } from "@/lib/rate-limit";
  * eventually failed silently, so the notice reads the same KV key the
  * admission gate does and disappears on its own.
  *
- * Costs one KV read, and nothing here can reach Spotify — that is the point.
+ * Costs one KV read — one `mget` over three keys, unchanged by the warning —
+ * and nothing here can reach Spotify, which is the point.
  * `getSpotifyServiceStatus` fails open, so a KV outage renders no notice
  * rather than a false one.
  */

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+/**
+ * The segment-level error boundary, and the one that matters here.
+ *
+ * `app/` had none at all, so every client-side throw — a mount effect on
+ * `/game`, a chunk that failed to load mid-navigation, a payload that could not
+ * be read — landed on Next's built-in fallback and told the host to open a
+ * developer console. This catches all of them below the root layout, which
+ * means the page keeps its fonts and the host keeps a way out.
+ *
+ * Deliberately not a `try/catch` at each throw site: the value of a boundary is
+ * that it also catches the throw nobody predicted, which is the category the
+ * reported bug was in.
+ */
+
+import { CrashScreen } from "@/components/crash-screen";
+
+export default function RouteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <CrashScreen error={error} reset={reset} boundary="route" />;
+}

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -6,15 +6,14 @@ import type { Track } from "@/types";
 import { trackEvent, type PlaylistSource } from "@/lib/analytics";
 import { canInstall, promptInstall } from "@/lib/pwa";
 import {
-  parseGamePayload,
   countRoundsPlayed,
   mergeRoomRoster,
-  GAME_STORAGE_KEY,
   type GameMode,
   type GamePlayer as Player,
   type BuzzerRoomHandle,
   type MixedPlaylistMeta,
 } from "@/lib/game-session";
+import { loadGame } from "@/lib/game-storage";
 import { fetchPreview, fetchPreviewBatch } from "@/lib/preview-client";
 import { isPreviewSettled, type PreviewBatchTrack } from "@/types/preview";
 import { BuzzerHostPanel, type BuzzerControls } from "@/components/buzzer-host-panel";
@@ -212,9 +211,10 @@ export default function GamePage() {
   }
 
   useEffect(() => {
-    const raw = sessionStorage.getItem(GAME_STORAGE_KEY);
-    if (!raw) { router.push("/"); return; }
-    const data = parseGamePayload(raw);
+    // Guarded, because a browser with site data switched off throws on the
+    // read rather than returning null — and this effect has no try of its own,
+    // so the throw took the whole page down. See lib/game-storage.ts.
+    const data = loadGame();
     if (!data || data.tracks.length === 0) { router.push("/"); return; }
     setTracks(data.tracks);
     setPlayers(data.players);
@@ -1627,7 +1627,7 @@ export default function GamePage() {
               <div>
                 <div className="track-reveal">
                   <p className="track-name">{currentTrack?.name}</p>
-                  <p className="track-artist">{currentTrack?.artists.join(", ")}</p>
+                  <p className="track-artist">{currentTrack?.artists?.join(", ")}</p>
                   {currentTrack?.albumName && (
                     <p style={{ fontSize: "13px", color: "#666", marginTop: "6px" }}>
                       {currentTrack.albumName}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+/**
+ * The last resort: a throw in the root layout itself, which `app/error.tsx`
+ * sits inside and therefore cannot catch.
+ *
+ * It replaces the whole document, so it has to supply `<html>` and `<body>` —
+ * and nothing it renders may rely on anything the layout would have set up
+ * (fonts, the AdSense loader, GA4). CrashScreen is written to that rule.
+ */
+
+import { CrashScreen } from "@/components/crash-screen";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, background: "#111" }}>
+        <CrashScreen error={error} reset={reset} boundary="root" />
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,7 +19,8 @@ import {
 } from "@/lib/error-messages";
 import { useErrorLocale } from "@/lib/use-error-locale";
 import { ServiceNotice } from "@/components/service-notice";
-import { buildGamePayload, GAME_STORAGE_KEY } from "@/lib/game-session";
+import { buildGamePayload } from "@/lib/game-session";
+import { saveGame } from "@/lib/game-storage";
 import { isBuzzerConfigured } from "@/lib/buzzer-client";
 import type { OpenRoom } from "@/lib/room-client";
 import { RoomPanel } from "@/components/room-panel";
@@ -277,7 +278,9 @@ export default function SetupPage() {
         },
         ...(room ? { buzzerRoom: room } : {}),
       });
-      sessionStorage.setItem(GAME_STORAGE_KEY, JSON.stringify(payload));
+      // A browser that refuses to store this has not refused the playlist, and
+      // must not be told it did. See lib/game-storage.ts.
+      if (!saveGame(payload)) throw new AppError("storage_blocked");
       trackEvent("game_started", {
         player_count: data.players.length,
         clip_duration: clipDuration,
@@ -425,7 +428,9 @@ export default function SetupPage() {
         mode: room ? "buzzer" : "party",
         ...(room ? { buzzerRoom: room } : {}),
       });
-      sessionStorage.setItem(GAME_STORAGE_KEY, JSON.stringify(payload));
+      // A browser that refuses to store this has not refused the playlist, and
+      // must not be told it did. See lib/game-storage.ts.
+      if (!saveGame(payload)) throw new AppError("storage_blocked");
       trackEvent("game_started", {
         // Phones that scanned in, plus the host, who buzzes from the game
         // screen. The typed count is 0 for every buzzer game, so reporting it
@@ -558,7 +563,9 @@ export default function SetupPage() {
         },
         ...(room ? { buzzerRoom: room } : {}),
       });
-      sessionStorage.setItem(GAME_STORAGE_KEY, JSON.stringify(payload));
+      // A browser that refuses to store this has not refused the playlist, and
+      // must not be told it did. See lib/game-storage.ts.
+      if (!saveGame(payload)) throw new AppError("storage_blocked");
       trackEvent("game_started", {
         player_count: mixedContributions.length,
         clip_duration: clipDuration,

--- a/components/crash-screen.tsx
+++ b/components/crash-screen.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+/**
+ * What a host sees when the client throws.
+ *
+ * Shared by `app/error.tsx` and `app/global-error.tsx` so the two boundaries
+ * cannot drift into two different apologies — the same reason
+ * `components/site-footer.tsx` replaced three hand-rolled footers.
+ *
+ * The bar this has to clear is Next's default, which is what the reported bug
+ * actually looked like: "Application error: a client-side exception has
+ * occurred (see the browser console for more information)". For a host with a
+ * room full of people waiting, that sentence has no author, no cause and no
+ * next step, and its only instruction is to open a developer console. Three
+ * things fix that and nothing else needs to:
+ *
+ *  - **Say it is ours.** The host's playlist is fine; they will otherwise spend
+ *    the evening swapping links, which is what the reporter did.
+ *  - **Give them the button.** "Start over" clears the stored game and returns
+ *    to setup, which is the recovery for the whole class of causes — a payload
+ *    that cannot be read is gone the moment it is dropped. "Try again" re-runs
+ *    the render for the transient half (a chunk that failed to load once).
+ *  - **Record it.** See the `client_error` event in lib/analytics.ts.
+ *
+ * Inline styles, matching app/page.tsx and app/game/page.tsx: `global-error`
+ * replaces the root layout, so nothing here may depend on a stylesheet the
+ * layout would have loaded.
+ */
+
+import { useEffect } from "react";
+import { trackEvent } from "@/lib/analytics";
+import { errorMessage } from "@/lib/error-messages";
+import { useErrorLocale } from "@/lib/use-error-locale";
+import { clearGame } from "@/lib/game-storage";
+import { CRASH_REPORT_URL, CRASH_SCREEN_UI } from "@/lib/crash-screen";
+
+export interface CrashScreenProps {
+  error: Error & { digest?: string };
+  /** Next's boundary reset. Re-renders the segment that threw. */
+  reset: () => void;
+  /** Which boundary caught it — see the `client_error` event. */
+  boundary: "route" | "root";
+}
+
+export function CrashScreen({ error, reset, boundary }: CrashScreenProps) {
+  const locale = useErrorLocale();
+  const ui = CRASH_SCREEN_UI[locale];
+
+  useEffect(() => {
+    // The device's own copy, with the digest, which is the only handle a
+    // deployed build gives you on a minified stack. Never sent to GA4.
+    console.error("[guesssong] client error", { boundary, digest: error.digest }, error);
+    trackEvent("client_error", { boundary });
+  }, [error, boundary]);
+
+  return (
+    <div
+      style={{
+        minHeight: "100dvh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "24px",
+        background: "#111",
+        color: "#f0f0f0",
+        fontFamily: "Outfit, system-ui, sans-serif",
+      }}
+    >
+      <div
+        style={{
+          background: "#1a1a1a",
+          border: "1px solid #2c2c2c",
+          borderRadius: "16px",
+          maxWidth: "460px",
+          width: "100%",
+          padding: "28px 24px 24px",
+          boxShadow: "0 24px 60px rgba(0,0,0,0.55)",
+        }}
+      >
+        <h1
+          style={{
+            margin: "0 0 12px",
+            fontFamily: "'Bebas Neue', Impact, sans-serif",
+            fontSize: "30px",
+            letterSpacing: "0.5px",
+            lineHeight: 1.15,
+            color: "#fff",
+          }}
+        >
+          {ui.title}
+        </h1>
+        <p style={{ margin: "0 0 22px", fontSize: "15px", lineHeight: 1.65, color: "#bdbdbd" }}>
+          {errorMessage("client_error", locale)}
+        </p>
+        <div style={{ display: "flex", alignItems: "center", gap: "14px", flexWrap: "wrap" }}>
+          <button
+            type="button"
+            onClick={() => {
+              // Order matters: the stored game is the most likely thing to be
+              // unreadable, so it goes before the navigation rather than after
+              // one that may never complete.
+              clearGame();
+              window.location.assign("/");
+            }}
+            style={{
+              background: "#1DB954",
+              color: "#06210f",
+              border: 0,
+              borderRadius: "999px",
+              padding: "11px 26px",
+              fontSize: "15px",
+              fontWeight: 600,
+              fontFamily: "inherit",
+              cursor: "pointer",
+            }}
+          >
+            {ui.restart}
+          </button>
+          <button
+            type="button"
+            onClick={reset}
+            style={{
+              background: "none",
+              border: "1px solid #3a3a3a",
+              borderRadius: "999px",
+              color: "#bdbdbd",
+              padding: "10px 22px",
+              fontSize: "14px",
+              fontFamily: "inherit",
+              cursor: "pointer",
+            }}
+          >
+            {ui.retry}
+          </button>
+          <a
+            href={CRASH_REPORT_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              color: "#9a9a9a",
+              fontSize: "14px",
+              textDecoration: "none",
+              borderBottom: "1px solid #3a3a3a",
+              paddingBottom: "1px",
+            }}
+          >
+            {ui.report} →
+          </a>
+        </div>
+        {error.digest && (
+          /* The one thing worth quoting in a bug report, and the only reason
+             this screen shows an identifier at all: it is what matches the
+             host's crash to a line in the deployed build. */
+          <p style={{ margin: "20px 0 0", fontSize: "12px", color: "#555" }}>
+            ref {error.digest}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/service-notice.tsx
+++ b/components/service-notice.tsx
@@ -1,15 +1,24 @@
 "use client";
 
 /**
- * A one-time popup telling a host that new playlists are not loading, shown
- * before they paste a link rather than after they press Start.
+ * A one-time popup about the shared Spotify allowance, shown before a host
+ * pastes a link rather than after they press Start.
  *
- * Driven by `GET /api/status`, which reads the same KV cooldown key the
- * admission gate in lib/playlist-cache.ts writes. That is the whole design:
- * the notice appears when Spotify starts refusing and disappears when the key
- * expires, with nobody editing anything. A hand-written banner would need
- * someone to remember to take it down the next morning, and this codebase has
- * a long record of things that depend on someone remembering.
+ * It has two states and the difference between them is the whole feature:
+ *
+ *   - **warning** — the day's allowance is nearly spent and everything still
+ *     works. This is the one that is worth having. A host reading it at eight
+ *     o'clock can load their playlist while there is allowance for it, or pick
+ *     one that has already been played; told at ten, when the refusal lands,
+ *     they have no move left. Fires at SPOTIFY_BUDGET_WARN_RATIO.
+ *   - **blocked** — new playlists are not loading. The original notice.
+ *
+ * Driven by `GET /api/status`, which reads the same KV keys the admission gate
+ * in lib/playlist-cache.ts writes. That is the whole design: the notice appears
+ * when the allowance runs down and disappears when the keys expire, with nobody
+ * editing anything. A hand-written banner would need someone to remember to
+ * take it down the next morning, and this codebase has a long record of things
+ * that depend on someone remembering.
  *
  * Renders through a portal into document.body for the reason
  * components/changelog-modal.tsx documents: the landing pages' `.fade-in`
@@ -23,6 +32,7 @@ import { errorMessage, type ErrorLocale } from "@/lib/error-messages";
 import { useErrorLocale } from "@/lib/use-error-locale";
 import {
   NOTICE_DISMISS_KEY,
+  noticeState,
   SELF_HOST_URL,
   SERVICE_NOTICE_UI,
   shouldShowNotice,
@@ -139,13 +149,15 @@ export function ServiceNotice({ locale: forced }: ServiceNoticeProps = {}) {
     };
   }, [open, close]);
 
-  if (!open || !status?.code) return null;
+  const state = noticeState(status);
+  if (!open || !state || !status?.code) return null;
 
   const ui = SERVICE_NOTICE_UI[locale];
-  // Params are passed for both codes. `spotify_cooldown` renders the seconds;
-  // `spotify_quota_exhausted` carries no {seconds} placeholder on purpose (a
-  // countdown measured in hours is a promise the app cannot keep) so the same
-  // call is correct for both. See lib/error-messages.ts.
+  // Params are passed for every code. `spotify_cooldown` renders the seconds;
+  // `spotify_quota_exhausted` and `spotify_budget_low` carry no {seconds}
+  // placeholder on purpose — a countdown measured in hours is a promise the app
+  // cannot keep, and the warning is a level with nothing to count down to — so
+  // the same call is correct for all of them. See lib/error-messages.ts.
   const body = errorMessage(status.code, locale, {
     params: { seconds: status.retryAfterSeconds },
   });
@@ -249,7 +261,7 @@ export function ServiceNotice({ locale: forced }: ServiceNoticeProps = {}) {
             lineHeight: 1.15,
           }}
         >
-          {ui.title}
+          {ui.title[state]}
         </h2>
         <p
           id="sn-body"

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -325,6 +325,28 @@ export type AnalyticsEvent =
        */
       name: "player_to_host_click";
       params: { surface: LoopSurface };
+    }
+  | {
+      /**
+       * A client-side exception reached an error boundary.
+       *
+       * Until `app/error.tsx` existed there was no boundary at all, so a throw
+       * anywhere in the tree replaced the party with Next's default
+       * "Application error" screen — and nothing anywhere recorded that it had
+       * happened. The one crash we know about arrived as an email, weeks later,
+       * from a host who had already given up.
+       *
+       * `boundary` is where it was caught, not what threw: `route` is the
+       * segment boundary (a page or one of its effects), `root` is
+       * `global-error.tsx`, which only fires when the root layout itself is the
+       * thing that broke. Deliberately no message, stack or digest — the
+       * convention this file keeps is bucketed enums, never upstream strings,
+       * and a stack frame carries pasted playlist names and query params into
+       * GA4. The digest goes to `console.error` on the device instead, which is
+       * where the person reading it already is.
+       */
+      name: "client_error";
+      params: { boundary: "route" | "root" };
     };
 
 export type AnalyticsEventName = AnalyticsEvent["name"];

--- a/lib/changelog.ts
+++ b/lib/changelog.ts
@@ -49,6 +49,31 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "1.7.4",
+    date: "2026-08-24",
+    headline:
+      "Fixed the error screen that could replace a whole game, and the site now warns you before the day's playlist allowance runs out rather than after.",
+    headlineZh:
+      "修好了會讓整場遊戲變成錯誤畫面的問題，另外網站現在會在當天歌單額度快用完之前先提醒你，而不是等到用完才說。",
+    changes: [
+      {
+        kind: "fixed",
+        text: "Pressing Start could end on \u201cApplication error: a client-side exception has occurred\u201d, with nothing to click and nothing to read. It is gone, and if anything else ever breaks that way you now get a real message and a Start over button instead of a blank page.",
+        textZh: "以前按下開始有可能整頁變成「Application error」的錯誤訊息，沒有東西可以點、也看不懂發生什麼事。這個問題已經修好了，而且之後就算真的出錯，你會看到一段看得懂的說明和一個「重新開始」按鈕，不會再是一片空白。",
+      },
+      {
+        kind: "fixed",
+        text: "If your browser blocks websites from saving data, the game used to tell you the playlist could not be loaded \u2014 so you would swap playlists all evening and never get anywhere. It now says it is your browser, and what to change.",
+        textZh: "如果你的瀏覽器不讓網站儲存資料，以前遊戲會說歌單載入失敗，害你整晚一直換歌單卻怎麼樣都開不了。現在它會直接告訴你是瀏覽器設定的問題，也會說要改哪裡。",
+      },
+      {
+        kind: "new",
+        text: "Everyone here shares one Spotify allowance, and it can run out on a busy day. When it gets close, you now see a heads-up while the site still works, so you can load your playlist before it matters. Playlists that have already been played are never affected.",
+        textZh: "這裡的每個人共用同一份 Spotify 額度，忙碌的一天有可能會用完。現在快用完的時候，你會在網站還正常運作的時候先看到提醒，可以趁還有額度的時候先把歌單載入。已經玩過的歌單完全不受影響。",
+      },
+    ],
+  },
+  {
     version: "1.7.3",
     date: "2026-08-23",
     headline:

--- a/lib/crash-screen.ts
+++ b/lib/crash-screen.ts
@@ -1,0 +1,39 @@
+/**
+ * The crash screen's strings and its one link.
+ *
+ * In `lib/` rather than beside `components/crash-screen.tsx` for the reason
+ * `lib/song-count.ts`, `lib/guides.ts` and `lib/service-notice.ts` all give: the
+ * suite only reaches `lib/`, and vitest cannot import a `.tsx` module in this
+ * project. Leaving these in the component puts the one screen a host sees when
+ * everything else has failed outside test range — which is the last place that
+ * should be true.
+ */
+
+import type { ErrorLocale } from "@/lib/error-messages";
+
+/**
+ * Where a host can say this happened to them.
+ *
+ * The label is the only part a reader sees, so a wrong href fails silently: the
+ * screen still renders and the link still looks like a link. Same hazard
+ * `SELF_HOST_URL` carries, and pinned the same way.
+ */
+export const CRASH_REPORT_URL = "https://github.com/Waynting/GuessSong/issues";
+
+export const CRASH_SCREEN_UI: Record<
+  ErrorLocale,
+  { title: string; retry: string; restart: string; report: string }
+> = {
+  en: {
+    title: "The game stopped",
+    retry: "Try again",
+    restart: "Start over",
+    report: "Report this",
+  },
+  zh: {
+    title: "遊戲中斷了",
+    retry: "再試一次",
+    restart: "重新開始",
+    report: "回報問題",
+  },
+};

--- a/lib/error-messages.ts
+++ b/lib/error-messages.ts
@@ -56,6 +56,7 @@ export type AppErrorCode =
   | "spotify_cooldown"
   | "spotify_quota_exhausted"
   | "spotify_daily_budget_spent"
+  | "spotify_budget_low"
   | "spotify_busy"
   | "spotify_not_configured"
   | "spotify_auth_failed"
@@ -90,6 +91,9 @@ export type AppErrorCode =
   // Setup screen validation
   | "players_required"
   | "mixed_min_contributors"
+  // The browser itself, not the playlist — see the note above their entries
+  | "storage_blocked"
+  | "client_error"
   // Buzzer
   | "buzzer_not_configured"
   | "buzzer_origin_blocked"
@@ -198,6 +202,24 @@ export const ERROR_MESSAGES: Record<AppErrorCode, Record<ErrorLocale, string>> =
   spotify_daily_budget_spent: {
     en: "Sorry — today's allowance is gone. GuessSong is free and every game here shares one Spotify quota, and Spotify's policy gives a project like this no way to buy a bigger one, so the site rations what it has: one busy afternoon must not leave the evening with nothing. Playlists that have already been loaded still work, and some allowance frees up every hour. GuessSong is also open source, so anyone who would rather not wait can run their own copy on their own quota. Your playlist URL is fine.",
     zh: "抱歉 — 今天的額度已經用完了。GuessSong 是免費服務，所有的遊戲共用同一份 Spotify 配額，而 Spotify 的政策不讓這樣的專案加購更多，所以網站只能把手上的額度配給著用：不能讓一個下午就把整晚的份用光。已經載入過的歌單還是可以玩，每小時也會釋出一些額度。GuessSong 也是開源的，不想等的人可以用自己的配額架一站自己跑。你的歌單連結沒有問題。",
+  },
+  /*
+   * The only code in this table that is not a refusal.
+   *
+   * Everything else here answers "why did that fail". This one fires while the
+   * site still works, at BUDGET_WARN_RATIO of the day's allowance, so a host
+   * about to run a party learns tonight is at risk at the moment they can still
+   * do something about it — load the playlist now while there is allowance, or
+   * pick one that has already been played. Told only at the refusal, that
+   * choice has already been taken away from them.
+   *
+   * It has to state that nothing is wrong yet, or it reads as the refusal and
+   * hosts leave a working site. And it carries no `{seconds}`: what is being
+   * described is a level, not a wait — there is nothing to count down to.
+   */
+  spotify_budget_low: {
+    en: "Heads up: the site is close to today's Spotify allowance. Everything still works right now, and playlists that have already been played are unaffected. If you're hosting tonight, it's worth loading your playlist soon — new ones may stop loading later this evening until some allowance frees up. GuessSong is free and open source, so you can also run your own copy on your own quota.",
+    zh: "提醒一下：網站快要用完今天的 Spotify 額度了。現在一切都還正常，已經玩過的歌單也不受影響。如果你今晚要辦活動，建議早一點把歌單載入 — 晚一點新歌單可能會載入不了，要等額度釋出。GuessSong 是免費且開源的，你也可以用自己的配額架一站自己跑。",
   },
   spotify_busy: {
     en: "Too many new playlists are being loaded across the site right now. Please try again in a minute — your playlist URL is fine.",
@@ -339,6 +361,27 @@ export const ERROR_MESSAGES: Record<AppErrorCode, Record<ErrorLocale, string>> =
   mixed_min_contributors: {
     en: "Add at least {count} players' playlists to start.",
     zh: "至少要有 {count} 個人的歌單才能開始。",
+  },
+
+  /*
+   * These two say "the browser", and they have to, because the alternative is
+   * what this replaced.
+   *
+   * A host whose browser refuses to store the game used to be told
+   * `playlist_load_failed` — "Couldn't load that playlist" — because the write
+   * sat inside the same try/catch as the fetch. That is the same mistake as
+   * telling a throttled host to check their URL was public: it names the one
+   * thing that was fine, so the host swaps playlists, reads the help page and
+   * gets nowhere. The reported symptom was exactly that. Neither code may ever
+   * mention the playlist.
+   */
+  storage_blocked: {
+    en: "Your browser is blocking this site from saving the game. Turn off private browsing, or allow site data for guessong.app, then try again.",
+    zh: "你的瀏覽器不讓這個網站儲存遊戲資料。請關閉無痕模式，或允許 guessong.app 儲存網站資料，然後再試一次。",
+  },
+  client_error: {
+    en: "The game screen hit an error and stopped. Starting over usually clears it — nothing is lost, the playlist just loads again.",
+    zh: "遊戲畫面出錯停住了。重新開始通常就會恢復，不會遺失任何東西，歌單會重新載入一次。",
   },
 
   buzzer_not_configured: {

--- a/lib/game-session.ts
+++ b/lib/game-session.ts
@@ -164,6 +164,52 @@ export function countRoundsPlayed(currentIndex: number, phase: string): number {
 }
 
 /**
+ * Read one entry of `tracks` back, repairing what can be repaired and dropping
+ * what cannot.
+ *
+ * This replaces a blind `as Track[]` cast, and the cast is what took the site
+ * down: the game page reads `t.artists[0]` in its preview-prefetch effect on
+ * mount, so a single entry without an `artists` array threw a TypeError there,
+ * and — with no error boundary anywhere in `app/` — React unmounted the whole
+ * tree and Next replaced the party with "Application error: a client-side
+ * exception has occurred". The host had done nothing wrong and had nothing to
+ * click.
+ *
+ * The split between repairing and dropping follows the same rule as the
+ * `GAME_MODES` / `PLAYLIST_SOURCES` guards above: a payload already sitting in
+ * a host's sessionStorage must keep playing across a deploy rather than fail to
+ * parse mid-party.
+ *
+ * - `id` and `name` are dropped when missing. Nothing can look up a clip for a
+ *   track with no id, and a round with no title has no answer to reveal.
+ * - `artists` and `durationMs` are repaired. An unnamed credit still plays, and
+ *   `durationMs` is only ever a matching signal for lib/preview-cache.ts, so
+ *   losing it costs one song's cover-detection rather than the song.
+ */
+function normalizeTrack(value: unknown): Track | null {
+  if (typeof value !== "object" || value === null) return null;
+  const t = value as Record<string, unknown>;
+  if (typeof t.id !== "string" || typeof t.name !== "string") return null;
+
+  const artists = Array.isArray(t.artists)
+    ? t.artists.filter((a): a is string => typeof a === "string")
+    : [];
+  const contributors = Array.isArray(t.contributors)
+    ? t.contributors.filter((c): c is string => typeof c === "string")
+    : undefined;
+
+  return {
+    ...(t as unknown as Track),
+    id: t.id,
+    name: t.name,
+    artists,
+    durationMs: typeof t.durationMs === "number" ? t.durationMs : 0,
+    createdAt: typeof t.createdAt === "string" ? t.createdAt : "",
+    ...(contributors ? { contributors } : {}),
+  };
+}
+
+/**
  * Parse a raw sessionStorage string into a GamePayload.
  * Returns null when the JSON is invalid or has no usable track list.
  * Old payloads (pre playlistSource/mode) get backward-compatible defaults.
@@ -178,8 +224,18 @@ export function parseGamePayload(raw: string): GamePayload | null {
   if (typeof data !== "object" || data === null) return null;
 
   const d = data as Record<string, unknown>;
-  const tracks = Array.isArray(d.tracks) ? (d.tracks as Track[]) : [];
-  const players = Array.isArray(d.players) ? (d.players as GamePlayer[]) : [];
+  const tracks = Array.isArray(d.tracks)
+    ? d.tracks.map(normalizeTrack).filter((t): t is Track => t !== null)
+    : [];
+  const players = Array.isArray(d.players)
+    ? d.players
+        .filter((p): p is GamePlayer => typeof p === "object" && p !== null)
+        .map((p) => ({
+          name: typeof p.name === "string" ? p.name : "",
+          score: typeof p.score === "number" ? p.score : 0,
+        }))
+        .filter((p) => p.name !== "")
+    : [];
 
   const rawMeta = d.mixedPlaylistMeta as Record<string, unknown> | undefined;
   const mixedPlaylistMeta: MixedPlaylistMeta | undefined =

--- a/lib/game-storage.ts
+++ b/lib/game-storage.ts
@@ -1,0 +1,98 @@
+/**
+ * The one way the game payload reaches sessionStorage and comes back.
+ *
+ * ## Why this is not three inline `sessionStorage` calls
+ *
+ * Storage *throws* in a locked-down browser rather than returning null —
+ * Safari with "Block All Cookies", Chrome with site data disallowed, several
+ * embedded webviews — and the throw is on the property access itself, before
+ * any method is called. `lib/host-session.ts` says so in its own header and
+ * guards every path it owns; this payload was the one that did not.
+ *
+ * That cost the site a bug report of exactly the shape the guard exists to
+ * prevent. `app/game/page.tsx` read the key unguarded inside a mount effect, so
+ * a browser that refuses storage did not bounce the host back to setup — it
+ * threw, and with no error boundary in `app/` the whole page became "Application
+ * error: a client-side exception has occurred". Meanwhile the setup page's
+ * write sat inside the same `try` as the playlist fetch, so the *other* half of
+ * the same browser setting was reported as `playlist_load_failed` and sent the
+ * host off to check a playlist that was never the problem.
+ *
+ * Both halves now answer honestly: a refused write is `false` (the caller
+ * raises `storage_blocked`), and a refused read is `null` (the caller sends the
+ * host back to setup, which is where a game that was never stored has to start).
+ *
+ * The `*From`/`*To` pair is the test seam — `tests/game-storage.test.ts` hands
+ * them a Storage that throws, which is the case no real browser here will
+ * reproduce on demand.
+ */
+
+import {
+  GAME_STORAGE_KEY,
+  parseGamePayload,
+  type GamePayload,
+} from "@/lib/game-session";
+
+/**
+ * `window.sessionStorage` when it can be touched at all, null otherwise.
+ *
+ * The `try` wraps the property access and not just the call: reading the
+ * property is itself what throws a SecurityError when a browser has site data
+ * switched off.
+ */
+function sessionStore(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+/** Returns false when the browser refused to keep it. Never throws. */
+export function saveGameTo(storage: Storage | null, payload: GamePayload): boolean {
+  if (!storage) return false;
+  try {
+    storage.setItem(GAME_STORAGE_KEY, JSON.stringify(payload));
+    return true;
+  } catch {
+    // Blocked, or over quota. Either way there is no game to navigate to, and
+    // the caller has to say so instead of pushing /game at an empty key.
+    return false;
+  }
+}
+
+/** Null for "no game here", including when the browser won't say. Never throws. */
+export function loadGameFrom(storage: Storage | null): GamePayload | null {
+  if (!storage) return null;
+  let raw: string | null;
+  try {
+    raw = storage.getItem(GAME_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  return raw ? parseGamePayload(raw) : null;
+}
+
+/** Forget the stored game. Used by the error boundary's "Start over". */
+export function clearGameFrom(storage: Storage | null): void {
+  if (!storage) return;
+  try {
+    storage.removeItem(GAME_STORAGE_KEY);
+  } catch {
+    // Nothing to do about it, and nothing depends on it having worked: the
+    // setup page overwrites the key on the next Start.
+  }
+}
+
+export function saveGame(payload: GamePayload): boolean {
+  return saveGameTo(sessionStore(), payload);
+}
+
+export function loadGame(): GamePayload | null {
+  return loadGameFrom(sessionStore());
+}
+
+export function clearGame(): void {
+  clearGameFrom(sessionStore());
+}

--- a/lib/playlist-cache.ts
+++ b/lib/playlist-cache.ts
@@ -146,6 +146,39 @@ const HOUR_REFUSED_PREFIX = "spotify:budget:refused";
 const DAILY_SPENT_KEY = "spotify:budget:spent";
 
 /**
+ * The same trick one step earlier: written when the day's spend crosses
+ * BUDGET_WARN_RATIO, read by `getSpotifyServiceStatus` in the same `mget`.
+ *
+ * The notice this drives fires while the site still works, which is the whole
+ * point — a host who learns at the refusal has already lost the choice the
+ * warning gives them. It cannot be answered by counting buckets in the status
+ * route for the reason DAILY_SPENT_KEY gives, and it must not cost a second
+ * command either, so the gate leaves this behind on the pass it was already
+ * making.
+ *
+ * Same hour-boundary TTL as the spent flag, and for the same reason: an hour
+ * rolling out of the window is the only thing that can lower the answer.
+ */
+const DAILY_NEAR_KEY = "spotify:budget:near";
+
+/**
+ * How much of the day's allowance has to be gone before hosts are warned.
+ *
+ * 0.8 of 2,000 is 1,600 loads. Against a normal day's ~2,152 cold loads that
+ * trips most evenings, which is deliberate: the warning is only worth anything
+ * on the days the limit is actually in play, and those are most of them. Set it
+ * higher to warn later and less often.
+ */
+const DEFAULT_BUDGET_WARN_RATIO = 0.8;
+
+function budgetWarnRatio(): number {
+  const configured = Number(process.env.SPOTIFY_BUDGET_WARN_RATIO);
+  return Number.isFinite(configured) && configured > 0 && configured < 1
+    ? configured
+    : DEFAULT_BUDGET_WARN_RATIO;
+}
+
+/**
  * Loads allowed upstream per rolling 24h, before we start refusing on
  * Spotify's behalf.
  *
@@ -403,6 +436,15 @@ async function claimDailyBudget(now: Date): Promise<boolean> {
       `${HOUR_BUDGET_PREFIX}:${hourBucket(now)}`,
       HOUR_BUCKET_TTL_SECONDS
     );
+
+    // `used` is already in hand from the admission check above, so the warning
+    // costs one conditional set on the crossing loads and nothing at all on the
+    // rest of the day. Counting it separately in the status route is what this
+    // exists to avoid.
+    if (used + 1 >= dailyLoadLimit() * budgetWarnRatio()) {
+      const frees = secondsToNextHour(now);
+      await store.set(DAILY_NEAR_KEY, { until: now.getTime() + frees * 1000 }, frees);
+    }
     return true;
   } catch {
     return true;
@@ -560,6 +602,7 @@ export type { SpotifyServiceStatus };
 
 const OPEN_STATUS: SpotifyServiceStatus = {
   throttled: false,
+  approachingLimit: false,
   code: null,
   retryAfterSeconds: 0,
 };
@@ -575,11 +618,13 @@ export async function getSpotifyServiceStatus(): Promise<SpotifyServiceStatus> {
   // banner on a site that is, as far as anyone can tell, fine.
   let cooldown: { until: number } | null = null;
   let spent: { until: number } | null = null;
+  let near: { until: number } | null = null;
   try {
     const store = await getKvStore();
-    [cooldown, spent] = await store.mget<{ until: number }>([
+    [cooldown, spent, near] = await store.mget<{ until: number }>([
       COOLDOWN_KEY,
       DAILY_SPENT_KEY,
+      DAILY_NEAR_KEY,
     ]);
   } catch {
     return OPEN_STATUS;
@@ -594,6 +639,7 @@ export async function getSpotifyServiceStatus(): Promise<SpotifyServiceStatus> {
   if (cooling > 0) {
     return {
       throttled: true,
+      approachingLimit: false,
       code: cooldownError(cooling).code,
       retryAfterSeconds: cooling,
     };
@@ -603,8 +649,24 @@ export async function getSpotifyServiceStatus(): Promise<SpotifyServiceStatus> {
   if (rationed > 0) {
     return {
       throttled: true,
+      approachingLimit: false,
       code: "spotify_daily_budget_spent",
       retryAfterSeconds: rationed,
+    };
+  }
+
+  // Only reached when nothing is actually refusing. A refusal outranks the
+  // warning it grew out of: "you are about to run out" is the wrong sentence to
+  // show someone who already has, and `approachingLimit` stays false above so
+  // no caller has to decide which of two live states to render.
+  if (remainingOf(near) > 0) {
+    return {
+      throttled: false,
+      approachingLimit: true,
+      code: "spotify_budget_low",
+      // Nothing to wait for — the site works. See the message's own note on why
+      // it carries no countdown.
+      retryAfterSeconds: 0,
     };
   }
 

--- a/lib/service-notice.ts
+++ b/lib/service-notice.ts
@@ -20,6 +20,32 @@ import type { SpotifyServiceStatus } from "@/types/service-status";
 export const NOTICE_DISMISS_KEY = "guesssong_notice_dismissed";
 
 /**
+ * The two things this notice can be, and nothing else.
+ *
+ * `blocked` is the original: pressing Start would be refused right now.
+ * `warning` fires while the site still works, once the day's Spotify allowance
+ * is nearly spent. They are one component and one dismissal because they are
+ * one piece of news at two stages, but they are emphatically not one *sentence*
+ * — a warning that reads like a refusal sends a host away from a site that
+ * would have worked for them, which is worse than not warning at all.
+ */
+export type NoticeState = "blocked" | "warning";
+
+/**
+ * What, if anything, there is to say. Null when the site is simply fine.
+ *
+ * `throttled` is checked first and `approachingLimit` is never set alongside it
+ * (lib/playlist-cache.ts guarantees that), so the ranking here is belt and
+ * braces rather than a live decision: a host who is being refused must not be
+ * told they are about to be.
+ */
+export function noticeState(status: SpotifyServiceStatus | null): NoticeState | null {
+  if (!status?.code) return null;
+  if (status.throttled) return "blocked";
+  return status.approachingLimit ? "warning" : null;
+}
+
+/**
  * Keyed by the *code*, not a boolean.
  *
  * A dismissal is scoped to the thing that was dismissed. `spotify_cooldown`
@@ -27,13 +53,22 @@ export const NOTICE_DISMISS_KEY = "guesssong_notice_dismissed";
  * materially different news, and a host who waved away the first one has not
  * been told the second. Storing a bare flag would collapse them and hide the
  * more serious message behind a dismissal of the lesser one.
+ *
+ * The warning joins that scheme for free, and gets the property that matters
+ * most from it: dismissing `spotify_budget_low` at eight o'clock does not
+ * suppress the refusal at ten, because that is a different code.
  */
 export function shouldShowNotice(
   status: SpotifyServiceStatus | null,
   dismissedCode: string | null
 ): boolean {
-  if (!status?.throttled || !status.code) return false;
-  return status.code !== dismissedCode;
+  // Read `code` off the argument rather than asserting `status` is non-null
+  // after the noticeState call. The assertion was sound only because
+  // noticeState returns null on a null status, which is a coupling that would
+  // rot silently the first time that function grows a branch.
+  const code = status?.code;
+  if (!code || !noticeState(status)) return false;
+  return code !== dismissedCode;
 }
 
 /**
@@ -48,18 +83,36 @@ export function shouldShowNotice(
  */
 export const SELF_HOST_URL = "https://github.com/Waynting/GuessSong";
 
+/**
+ * The title is per state and everything else is not, which is the whole shape
+ * of the difference. "New playlists aren't loading" is false during a warning —
+ * they are loading, that is the point of warning early — and a host who reads
+ * the wrong one of these two headlines makes exactly the wrong decision about
+ * their evening.
+ */
 export const SERVICE_NOTICE_UI: Record<
   ErrorLocale,
-  { title: string; dismiss: string; close: string; repo: string }
+  {
+    title: Record<NoticeState, string>;
+    dismiss: string;
+    close: string;
+    repo: string;
+  }
 > = {
   en: {
-    title: "New playlists aren't loading right now",
+    title: {
+      blocked: "New playlists aren't loading right now",
+      warning: "Close to today's playlist allowance",
+    },
     dismiss: "Got it",
     close: "Dismiss notice",
     repo: "Run your own copy",
   },
   zh: {
-    title: "現在新歌單載入不了",
+    title: {
+      blocked: "現在新歌單載入不了",
+      warning: "今天的歌單額度快用完了",
+    },
     dismiss: "知道了",
     close: "關閉公告",
     repo: "自己架一站",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guesssong",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/tests/crash-screen.test.ts
+++ b/tests/crash-screen.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { CRASH_REPORT_URL, CRASH_SCREEN_UI } from "@/lib/crash-screen";
+import { SELF_HOST_URL } from "@/lib/service-notice";
+import { ERROR_MESSAGES } from "@/lib/error-messages";
+
+/**
+ * The screen a host sees when everything else has failed. It is the last place
+ * a broken string should be able to hide, and the hardest to notice by hand:
+ * nobody visits it on purpose.
+ */
+describe("CRASH_SCREEN_UI", () => {
+  const KEYS = ["title", "retry", "restart", "report"] as const;
+
+  it("carries both languages, and they differ", () => {
+    for (const key of KEYS) {
+      expect(CRASH_SCREEN_UI.en[key].trim()).not.toBe("");
+      expect(CRASH_SCREEN_UI.zh[key].trim()).not.toBe("");
+      expect(CRASH_SCREEN_UI.en[key]).not.toBe(CRASH_SCREEN_UI.zh[key]);
+    }
+  });
+
+  /**
+   * `/zh` is written natively rather than translated, so an English string
+   * leaking through is a visible defect. Same rule tests/service-notice.test.ts
+   * and tests/site-policy.test.ts pin.
+   */
+  it("keeps the Chinese strings free of ASCII letters", () => {
+    for (const key of KEYS) {
+      expect(CRASH_SCREEN_UI.zh[key]).not.toMatch(/[A-Za-z]/);
+    }
+  });
+
+  /**
+   * The two buttons do different things — one clears the stored game and goes
+   * home, the other re-renders in place — so they must not read as the same
+   * offer. A host who cannot tell them apart retries the broken thing forever.
+   */
+  it("does not let the two actions read as the same button", () => {
+    for (const locale of ["en", "zh"] as const) {
+      expect(CRASH_SCREEN_UI[locale].restart).not.toBe(CRASH_SCREEN_UI[locale].retry);
+    }
+  });
+});
+
+describe("CRASH_REPORT_URL", () => {
+  /**
+   * A wrong href fails silently: the screen still renders, the link still looks
+   * like a link, and it lands on a 404 — for the one reader motivated enough to
+   * tell us something broke. It shipped wrong once, pointing at
+   * `Waynting/spotify_guess_web` (the local directory name) rather than the
+   * actual repo, so this pins it against the URL that is already known good.
+   */
+  it("points at the same repo as the self-host link", () => {
+    expect(CRASH_REPORT_URL.startsWith(SELF_HOST_URL)).toBe(true);
+    expect(CRASH_REPORT_URL).toBe("https://github.com/Waynting/GuessSong/issues");
+  });
+});
+
+describe("the crash screen's message", () => {
+  /**
+   * The screen renders `client_error` as its body. Pinned here as well as in
+   * tests/error-messages.test.ts because this is the callsite: a code renamed
+   * out from under the component would still typecheck against a different
+   * member of the union and quietly print the wrong sentence.
+   */
+  it("has a body in both languages", () => {
+    expect(ERROR_MESSAGES.client_error.en.trim()).not.toBe("");
+    expect(ERROR_MESSAGES.client_error.zh.trim()).not.toBe("");
+  });
+
+  /**
+   * The host is looking at a blank-page failure with a room waiting. The one
+   * thing the message has to do is tell them the way out, and the button is
+   * labelled with `restart` — so the sentence has to describe that action.
+   */
+  it("tells the host that starting over is the way out", () => {
+    expect(ERROR_MESSAGES.client_error.en).toMatch(/starting over/i);
+    expect(ERROR_MESSAGES.client_error.zh).toMatch(/重新開始/);
+  });
+});

--- a/tests/error-messages.test.ts
+++ b/tests/error-messages.test.ts
@@ -108,6 +108,41 @@ describe("the message table", () => {
     }
   });
 
+  /**
+   * The two codes that are about the *browser*, not the playlist and not the
+   * quota. This is the reported bug, pinned: a host whose browser refuses to
+   * store the game was shown `playlist_load_failed` — "Couldn't load that
+   * playlist" — because the write sat inside the same try/catch as the fetch,
+   * so they spent the evening swapping links that were never the problem and
+   * reading a help page that could not help them. Same class of mistake as
+   * telling a throttled host to check their URL was public, and a translation
+   * is exactly where it comes back.
+   */
+  it("never sends a browser failure looking for a playlist problem", () => {
+    for (const code of ["storage_blocked", "client_error"] as const) {
+      expect(ERROR_MESSAGES[code].en, `${code}.en blames the playlist`).not.toMatch(
+        /playlist (url|link)|public|spotify/i
+      );
+      expect(ERROR_MESSAGES[code].zh, `${code}.zh blames the playlist`).not.toMatch(
+        /公開|連結/
+      );
+    }
+  });
+
+  /**
+   * `spotify_budget_low` is the one entry here that is not a refusal: it fires
+   * while the site still works, so a host can act while acting is still worth
+   * something. If it reads like the refusal it predicts, it drives them away
+   * from a site that would have worked for them — strictly worse than staying
+   * quiet. Both languages have to say the site is still up.
+   */
+  it("makes the budget warning say nothing is broken yet", () => {
+    expect(ERROR_MESSAGES.spotify_budget_low.en).toMatch(/still works/i);
+    expect(ERROR_MESSAGES.spotify_budget_low.zh).toMatch(/都還正常/);
+    // A level, not a wait. See the {seconds} placeholder pin above.
+    expect(placeholders(ERROR_MESSAGES.spotify_budget_low.en)).toEqual([]);
+  });
+
   it("covers every code the buzzer Worker can send", () => {
     // The Worker ships its own copy of lib/buzzer-protocol.ts and cannot import
     // this table, so nothing but this test connects the two.

--- a/tests/game-session.test.ts
+++ b/tests/game-session.test.ts
@@ -231,3 +231,78 @@ describe("countRoundsPlayed", () => {
     expect(countRoundsPlayed(15, "revealed")).toBe(16);
   });
 });
+
+/**
+ * The track list used to be cast straight out of JSON with `as Track[]`, so
+ * anything malformed reached the render. The game page dereferences
+ * `t.artists[0]` in its preview-prefetch effect on mount, which made one bad
+ * entry a TypeError there — and with no error boundary in `app/` at the time,
+ * the whole page became "Application error: a client-side exception has
+ * occurred". These pin the repair-or-drop split that replaced the cast.
+ */
+describe("parseGamePayload track validation", () => {
+  const good = {
+    id: "t1",
+    name: "Song",
+    artists: ["Artist"],
+    durationMs: 200_000,
+    createdAt: "2026-08-24T00:00:00.000Z",
+  };
+
+  function parseTracks(tracks: unknown[]) {
+    return parseGamePayload(
+      JSON.stringify({ tracks, players: [], playlistName: "P", clipDuration: 15 })
+    );
+  }
+
+  it("repairs a missing artists array rather than dropping the song", () => {
+    const parsed = parseTracks([{ ...good, artists: undefined }]);
+    expect(parsed?.tracks).toHaveLength(1);
+    expect(parsed?.tracks[0].artists).toEqual([]);
+    // The exact call the game page makes on mount.
+    expect(() => parsed?.tracks.map((t) => t.artists[0] ?? "")).not.toThrow();
+  });
+
+  it("drops non-string entries from artists", () => {
+    const parsed = parseTracks([{ ...good, artists: ["A", null, 7, "B"] }]);
+    expect(parsed?.tracks[0].artists).toEqual(["A", "B"]);
+  });
+
+  it("defaults a missing durationMs to 0 rather than undefined", () => {
+    const parsed = parseTracks([{ ...good, durationMs: "long" }]);
+    expect(parsed?.tracks[0].durationMs).toBe(0);
+  });
+
+  it("drops a track with no id or no name — nothing can play or reveal it", () => {
+    const parsed = parseTracks([
+      { ...good, id: undefined },
+      { ...good, name: undefined },
+      null,
+      "not a track",
+      good,
+    ]);
+    expect(parsed?.tracks).toHaveLength(1);
+    expect(parsed?.tracks[0].id).toBe("t1");
+  });
+
+  it("keeps the fields it does not police", () => {
+    const parsed = parseTracks([{ ...good, albumName: "Album", popularity: 90 }]);
+    expect(parsed?.tracks[0].albumName).toBe("Album");
+    expect(parsed?.tracks[0].popularity).toBe(90);
+  });
+
+  it("drops a malformed player rather than putting a blank row on the scoreboard", () => {
+    const parsed = parseGamePayload(
+      JSON.stringify({
+        tracks: [good],
+        players: [{ name: "Alice", score: 3 }, { score: 1 }, null, { name: "Bob" }],
+        playlistName: "P",
+        clipDuration: 15,
+      })
+    );
+    expect(parsed?.players).toEqual([
+      { name: "Alice", score: 3 },
+      { name: "Bob", score: 0 },
+    ]);
+  });
+});

--- a/tests/game-storage.test.ts
+++ b/tests/game-storage.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearGameFrom,
+  loadGameFrom,
+  saveGameTo,
+} from "@/lib/game-storage";
+import { buildGamePayload, GAME_STORAGE_KEY } from "@/lib/game-session";
+import type { Track } from "@/types";
+
+function track(over: Partial<Track> = {}): Track {
+  return {
+    id: "t1",
+    name: "Song",
+    artists: ["Artist"],
+    durationMs: 200_000,
+    createdAt: "2026-08-24T00:00:00.000Z",
+    ...over,
+  };
+}
+
+function payload() {
+  return buildGamePayload({
+    tracks: [track()],
+    players: [{ name: "Alice", score: 0 }],
+    playlistName: "Party",
+    clipDuration: 15,
+    playlistSource: "own",
+    mode: "party",
+  });
+}
+
+/** A Storage that works. */
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k: string) => map.get(k) ?? null,
+    key: (i: number) => [...map.keys()][i] ?? null,
+    removeItem: (k: string) => void map.delete(k),
+    setItem: (k: string, v: string) => void map.set(k, v),
+  };
+}
+
+/**
+ * A Storage that throws on every method, which is what Safari with "Block All
+ * Cookies" and several embedded webviews actually do. This is the case no
+ * browser on a developer's desk reproduces on demand, and the one that took the
+ * game page down.
+ */
+function blockedStorage(): Storage {
+  const boom = () => {
+    throw new DOMException("The operation is insecure.", "SecurityError");
+  };
+  return {
+    length: 0,
+    clear: boom,
+    getItem: boom,
+    key: boom,
+    removeItem: boom,
+    setItem: boom,
+  } as unknown as Storage;
+}
+
+describe("saveGameTo", () => {
+  it("stores the payload under the shared key", () => {
+    const store = memoryStorage();
+    expect(saveGameTo(store, payload())).toBe(true);
+    expect(store.getItem(GAME_STORAGE_KEY)).toContain("Song");
+  });
+
+  it("reports false instead of throwing when storage is blocked", () => {
+    expect(saveGameTo(blockedStorage(), payload())).toBe(false);
+  });
+
+  it("reports false when there is no storage at all", () => {
+    expect(saveGameTo(null, payload())).toBe(false);
+  });
+});
+
+describe("loadGameFrom", () => {
+  it("round-trips a payload", () => {
+    const store = memoryStorage();
+    saveGameTo(store, payload());
+    expect(loadGameFrom(store)?.tracks[0].name).toBe("Song");
+  });
+
+  it("returns null instead of throwing when storage is blocked", () => {
+    // The regression under test: this read lived unguarded in the game page's
+    // mount effect, so the throw escaped React and Next replaced the party with
+    // "Application error: a client-side exception has occurred".
+    expect(() => loadGameFrom(blockedStorage())).not.toThrow();
+    expect(loadGameFrom(blockedStorage())).toBeNull();
+  });
+
+  it("returns null for an empty store and for junk", () => {
+    const store = memoryStorage();
+    expect(loadGameFrom(store)).toBeNull();
+    store.setItem(GAME_STORAGE_KEY, "{not json");
+    expect(loadGameFrom(store)).toBeNull();
+  });
+});
+
+describe("clearGameFrom", () => {
+  it("removes the key", () => {
+    const store = memoryStorage();
+    saveGameTo(store, payload());
+    clearGameFrom(store);
+    expect(loadGameFrom(store)).toBeNull();
+  });
+
+  it("does not throw when storage is blocked", () => {
+    expect(() => clearGameFrom(blockedStorage())).not.toThrow();
+    expect(() => clearGameFrom(null)).not.toThrow();
+  });
+});

--- a/tests/playlist-cache.test.ts
+++ b/tests/playlist-cache.test.ts
@@ -22,7 +22,16 @@ const kv = vi.hoisted(() => {
   const mem = new Map<string, { value: unknown; expiresAt: number }>();
   const writes: Array<{ key: string; value: unknown; ttlSeconds: number }> = [];
   const flags = { failReads: false, failWrites: false };
-  return { mem, writes, flags };
+  /**
+   * Every read the store is asked for, counted (`kv.writes` already records
+   * the other half). Several invariants in
+   * lib/playlist-cache.ts and lib/preview-cache.ts are cost claims ("one KV
+   * read", "no counter read to compose a log line"), and a cost claim that
+   * nothing measures is the kind that regresses in a refactor without a single
+   * test going red.
+   */
+  const counts = { reads: 0 };
+  return { mem, writes, flags, counts };
 });
 
 vi.mock("@/lib/kv", () => ({
@@ -33,12 +42,14 @@ vi.mock("@/lib/kv", () => ({
   hourBucket: (at: Date = new Date()) => at.toISOString().slice(0, 13),
   getKvStore: async () => ({
     async get(key: string) {
+      kv.counts.reads++;
       if (kv.flags.failReads) throw new Error("kv unavailable");
       const entry = kv.mem.get(key);
       if (!entry || Date.now() > entry.expiresAt) return null;
       return entry.value;
     },
     async mget(keys: string[]) {
+      kv.counts.reads++;
       if (kv.flags.failReads) throw new Error("kv unavailable");
       return keys.map((key) => {
         const entry = kv.mem.get(key);
@@ -104,6 +115,7 @@ const upstreamCalls = () => upstream().mock.calls.length;
 beforeEach(() => {
   kv.mem.clear();
   kv.writes.length = 0;
+  kv.counts.reads = 0;
   kv.flags.failReads = false;
   kv.flags.failWrites = false;
   __resetInFlightForTests();
@@ -549,6 +561,7 @@ describe("getSpotifyServiceStatus", () => {
   it("reports open when nothing is parked", async () => {
     await expect(getSpotifyServiceStatus()).resolves.toEqual({
       throttled: false,
+      approachingLimit: false,
       code: null,
       retryAfterSeconds: 0,
     });
@@ -742,6 +755,80 @@ describe("rolling 24h upstream budget", () => {
     const status = await getSpotifyServiceStatus();
     expect(status).toMatchObject({ throttled: true, code: "spotify_daily_budget_spent" });
     expect(status.retryAfterSeconds).toBeGreaterThan(0);
+  });
+
+  /**
+   * The warning, and the reason it exists at all: a host who is told at the
+   * refusal has already lost the choice of loading their playlist while there
+   * was still allowance for it. At a ceiling of 3 the 0.8 ratio trips on the
+   * third load — the last one that succeeds.
+   */
+  it("warns while the site still works, before anything is refused", async () => {
+    for (let i = 0; i < 2; i++) await loadPlaylist(uniqueUrl(i));
+    await expect(getSpotifyServiceStatus()).resolves.toMatchObject({
+      throttled: false,
+      approachingLimit: false,
+      code: null,
+    });
+
+    await loadPlaylist(uniqueUrl(2));
+
+    const status = await getSpotifyServiceStatus();
+    expect(status).toMatchObject({
+      throttled: false,
+      approachingLimit: true,
+      code: "spotify_budget_low",
+    });
+    // A level, not a wait. The message carries no {seconds} for that reason.
+    expect(status.retryAfterSeconds).toBe(0);
+  });
+
+  it("is retunable without a deploy", async () => {
+    process.env.SPOTIFY_BUDGET_WARN_RATIO = "0.99";
+    try {
+      // 3 * 0.99 = 2.97, so two loads no longer reach it where 0.8 would have.
+      for (let i = 0; i < 2; i++) await loadPlaylist(uniqueUrl(i));
+      await expect(getSpotifyServiceStatus()).resolves.toMatchObject({
+        approachingLimit: false,
+      });
+    } finally {
+      delete process.env.SPOTIFY_BUDGET_WARN_RATIO;
+    }
+  });
+
+  /**
+   * The refusal replaces the warning rather than sitting alongside it. Telling
+   * a host "you are close to the limit" once they are past it says the site
+   * still works, which is the one thing it does not do.
+   */
+  it("stops warning once it is actually refusing", async () => {
+    for (let i = 0; i < 3; i++) await loadPlaylist(uniqueUrl(i));
+    await expect(getSpotifyServiceStatus()).resolves.toMatchObject({
+      approachingLimit: true,
+    });
+
+    await loadPlaylist(uniqueUrl(9)).catch(() => {});
+
+    await expect(getSpotifyServiceStatus()).resolves.toMatchObject({
+      throttled: true,
+      approachingLimit: false,
+      code: "spotify_daily_budget_spent",
+    });
+  });
+
+  /**
+   * The status route's whole cost claim is one KV read, and the warning must
+   * not have quietly turned that into twenty-four. Reading it is one more key
+   * in the `mget` the notice already spends.
+   */
+  it("costs the notice no extra KV reads", async () => {
+    for (let i = 0; i < 3; i++) await loadPlaylist(uniqueUrl(i));
+    const before = kv.counts.reads;
+    await getSpotifyServiceStatus();
+    // One `mget`, exactly as before the warning existed. Answering it by
+    // summing the day's hourly buckets here would have made the notice more
+    // expensive than the gate it reports on.
+    expect(kv.counts.reads - before).toBe(1);
   });
 
   /**

--- a/tests/service-notice.test.ts
+++ b/tests/service-notice.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect } from "vitest";
 import {
   NOTICE_DISMISS_KEY,
+  noticeState,
   SELF_HOST_URL,
   SERVICE_NOTICE_UI,
   shouldShowNotice,
@@ -10,23 +11,34 @@ import type { SpotifyServiceStatus } from "@/types/service-status";
 
 const OPEN: SpotifyServiceStatus = {
   throttled: false,
+  approachingLimit: false,
   code: null,
   retryAfterSeconds: 0,
 };
 const BLIP: SpotifyServiceStatus = {
   throttled: true,
+  approachingLimit: false,
   code: "spotify_cooldown",
   retryAfterSeconds: 90,
 };
 const QUOTA: SpotifyServiceStatus = {
   throttled: true,
+  approachingLimit: false,
   code: "spotify_quota_exhausted",
   retryAfterSeconds: 48_513,
 };
 const RATIONED: SpotifyServiceStatus = {
   throttled: true,
+  approachingLimit: false,
   code: "spotify_daily_budget_spent",
   retryAfterSeconds: 1_800,
+};
+/** Nothing is refusing yet — the day's allowance is just running down. */
+const NEAR: SpotifyServiceStatus = {
+  throttled: false,
+  approachingLimit: true,
+  code: "spotify_budget_low",
+  retryAfterSeconds: 0,
 };
 
 describe("shouldShowNotice", () => {
@@ -73,19 +85,97 @@ describe("shouldShowNotice", () => {
   it("stays hidden if throttled is set without a code", () => {
     expect(
       shouldShowNotice(
-        { throttled: true, code: null, retryAfterSeconds: 60 },
+        { throttled: true, approachingLimit: false, code: null, retryAfterSeconds: 60 },
+        null
+      )
+    ).toBe(false);
+  });
+
+  /**
+   * The warning fires while the site still works, which is the entire point:
+   * told only at the refusal, a host has already lost the choice of loading
+   * their playlist while there was allowance for it.
+   */
+  it("shows the warning before anything is refusing", () => {
+    expect(shouldShowNotice(NEAR, null)).toBe(true);
+    expect(noticeState(NEAR)).toBe("warning");
+  });
+
+  /**
+   * Dismissal is keyed by code, so waving away the eight o'clock warning does
+   * not silence the ten o'clock refusal. Getting this wrong would make the
+   * warning strictly worse than not warning at all.
+   */
+  it("does not let a dismissed warning mask the refusal it predicted", () => {
+    expect(shouldShowNotice(NEAR, "spotify_budget_low")).toBe(false);
+    expect(shouldShowNotice(RATIONED, "spotify_budget_low")).toBe(true);
+    expect(shouldShowNotice(QUOTA, "spotify_budget_low")).toBe(true);
+  });
+
+  it("stays hidden when approachingLimit is set without a code", () => {
+    expect(
+      shouldShowNotice(
+        { throttled: false, approachingLimit: true, code: null, retryAfterSeconds: 0 },
         null
       )
     ).toBe(false);
   });
 });
 
+describe("noticeState", () => {
+  it("is null when there is nothing to say", () => {
+    expect(noticeState(null)).toBeNull();
+    expect(noticeState(OPEN)).toBeNull();
+  });
+
+  it("calls every refusal blocked, whatever refused", () => {
+    expect(noticeState(BLIP)).toBe("blocked");
+    expect(noticeState(QUOTA)).toBe("blocked");
+    expect(noticeState(RATIONED)).toBe("blocked");
+  });
+
+  /**
+   * A live refusal outranks the warning it grew out of. "You are about to run
+   * out" is the wrong headline for someone who already has, and it would tell
+   * them the site still works when it does not.
+   */
+  it("prefers blocked when a status somehow claims both", () => {
+    expect(
+      noticeState({ ...RATIONED, approachingLimit: true })
+    ).toBe("blocked");
+  });
+});
+
 describe("SERVICE_NOTICE_UI", () => {
+  const LABELS = ["dismiss", "close", "repo"] as const;
+  const STATES = ["blocked", "warning"] as const;
+
   it("carries both languages, and they differ", () => {
-    for (const key of ["title", "dismiss", "close", "repo"] as const) {
+    for (const key of LABELS) {
       expect(SERVICE_NOTICE_UI.en[key].trim()).not.toBe("");
       expect(SERVICE_NOTICE_UI.zh[key].trim()).not.toBe("");
       expect(SERVICE_NOTICE_UI.en[key]).not.toBe(SERVICE_NOTICE_UI.zh[key]);
+    }
+    for (const state of STATES) {
+      expect(SERVICE_NOTICE_UI.en.title[state].trim()).not.toBe("");
+      expect(SERVICE_NOTICE_UI.zh.title[state].trim()).not.toBe("");
+      expect(SERVICE_NOTICE_UI.en.title[state]).not.toBe(
+        SERVICE_NOTICE_UI.zh.title[state]
+      );
+    }
+  });
+
+  /**
+   * The two headlines have to be different sentences, not one reused. "New
+   * playlists aren't loading" is false during a warning — they are loading,
+   * which is why there is still time to act — and a host who reads it walks
+   * away from a site that would have worked for them.
+   */
+  it("does not reuse the refusal headline for the warning", () => {
+    for (const locale of ["en", "zh"] as const) {
+      expect(SERVICE_NOTICE_UI[locale].title.warning).not.toBe(
+        SERVICE_NOTICE_UI[locale].title.blocked
+      );
     }
   });
 
@@ -95,8 +185,11 @@ describe("SERVICE_NOTICE_UI", () => {
    * pins for the footer.
    */
   it("keeps the Chinese strings free of ASCII letters", () => {
-    for (const key of ["title", "dismiss", "close", "repo"] as const) {
+    for (const key of LABELS) {
       expect(SERVICE_NOTICE_UI.zh[key]).not.toMatch(/[A-Za-z]/);
+    }
+    for (const state of STATES) {
+      expect(SERVICE_NOTICE_UI.zh.title[state]).not.toMatch(/[A-Za-z]/);
     }
   });
 

--- a/types/service-status.ts
+++ b/types/service-status.ts
@@ -9,10 +9,26 @@ import type { AppErrorCode } from "@/lib/error-messages";
  * none of which belongs in a browser bundle.
  */
 export interface SpotifyServiceStatus {
+  /** Pressing Start right now would be refused. */
   throttled: boolean;
   /**
+   * The day's Spotify allowance is nearly spent, but nothing is refusing yet.
+   *
+   * Deliberately a second boolean rather than a level or a percentage. A number
+   * would invite the notice to render it, and "1,614 of 2,000" is a fact about
+   * our KV buckets, not about whether this host's party is at risk — the only
+   * question the page is entitled to ask. It also keeps the threshold a server
+   * concern, retunable from an env var without shipping a client.
+   *
+   * Never true at the same time as `throttled`: a live refusal outranks the
+   * warning it grew out of, so callers never have to rank two states.
+   */
+  approachingLimit: boolean;
+  /**
    * The exact code a host pressing Start would get right now, so the notice
-   * and the error can never contradict each other. Null when nothing is wrong.
+   * and the error can never contradict each other — or, when only
+   * `approachingLimit` is set, `spotify_budget_low`, which is the one code here
+   * that describes a level rather than a refusal. Null when nothing is wrong.
    */
   code: AppErrorCode | null;
   /** Honest seconds, straight from the stored `until`. Zero when open. */


### PR DESCRIPTION
A host wrote in: the site loads, they paste a playlist, they press Start, and the page becomes

> Application error: a client-side exception has occurred while loading www.guessong.app (see the browser console for more information).

Chrome and Safari both. Several different public playlists. They read every troubleshooting page on the site and found nothing — which is the part worth sitting with, because there was nothing to find.

`POST /api/playlist` was answering 200 with a valid track list throughout (checked against production with five public playlists). The failure was entirely client-side, and the reason it could take the whole page down is that **`app/` had no error boundary anywhere in it**. Any throw, from any component or effect, unmounted the tree and fell through to Next's default screen. Nothing recorded it either: the first anyone heard was the email.

## What was throwing

Two reachable throws on the path from Start to `/game`:

1. **`parseGamePayload` cast `d.tracks` with `as Track[]`** — a blind cast in a module whose every other field goes through a guard. `app/game/page.tsx` dereferences `t.artists[0]` in its preview-prefetch effect on mount, so one entry without an `artists` array was a `TypeError` inside an effect with no `try` of its own. Reproduced against the production build; it renders the reported sentence exactly.

2. **`app/game/page.tsx:215` read `sessionStorage` unguarded.** Storage *throws* rather than returning null in a locked-down browser (Safari with "Block All Cookies", several embedded webviews), and it throws on the property access itself. `lib/host-session.ts` has documented this since it was written and guards everything it owns; the game payload was the one path that did not.

And the detail that explains "I tried different playlists and read every possible problem": all three `setItem` call sites sat inside the same `try` as the playlist fetch, so a browser refusing storage surfaced as **"Couldn't load that playlist."** Same class of mistake as the message that used to tell throttled hosts to check their URL was public — it names the one thing that was fine.

Worth noting for triage: "Chrome and Safari both" is one engine, not two. On iOS both are WebKit, which points at an iPhone and is why this never reproduced in desktop Chromium.

## What changed

- **`app/error.tsx` + `app/global-error.tsx`** → `components/crash-screen.tsx`. Bilingual, says the site broke rather than the playlist, **Start over** clears the stored game and returns to setup, **Try again** re-renders, and Next's `digest` prints as a quotable reference. Fires a new bucketed `client_error` event — no message, stack or digest, because stack frames carry pasted playlist URLs into GA4.
- **`parseGamePayload` validates.** `normalizeTrack` repairs what a game can play without (`artists` → `[]`, `durationMs` → `0`) and drops only what nothing can play (no `id`, no `name`). Same repair-or-drop rule `GAME_MODES` follows: a payload sitting in a host's sessionStorage at deploy time has to keep playing.
- **`lib/game-storage.ts`** is now the only path to the payload, guarded on both sides. A refused write raises `storage_blocked`, deliberately kept out of `isDeterministicPlaylistFailure` since the same URL works once the setting changes.

## The notice now warns before it refuses

1.7.2 put a notice in front of the host, but only once the allowance was already spent — by which point the only thing left to tell them is to come back tomorrow.

`GET /api/status` now answers with `approachingLimit` as well as `throttled`. The `warning` state fires at `SPOTIFY_BUDGET_WARN_RATIO` (new, default 0.8) of `SPOTIFY_MAX_LOADS_PER_DAY` and says the site still works; `blocked` is the existing refusal notice, unchanged. A host reading the warning at eight o'clock can load their playlist while there is allowance for it, or pick one that is already cached.

Three properties, all tested:

- **It costs nothing extra.** `claimDailyBudget` already has the day's `used` in hand on every cold load, so the threshold is a conditional `set` on the crossing loads and nothing on the rest; `getSpotifyServiceStatus` reads the flag as one more key in the `mget` it already spends. The suite counts the reads — summing 24 hourly buckets in the status route would make the notice more expensive than the gate it reports on.
- **A refusal outranks the warning it grew out of.** `throttled` and `approachingLimit` are never both true.
- **The two headlines are different sentences.** "New playlists aren't loading" is false during a warning, and a host who reads it walks away from a site that would have worked for them. Dismissal stays keyed by error code, so waving away `spotify_budget_low` at eight does not silence `spotify_daily_budget_spent` at ten.

## Verification

- Root suite **567 passed / 31 files**; worker suite **17 passed**. `tsc --noEmit` clean, `next lint` clean.
- Build route table invariants hold: `/icon` and `/opengraph-image` still `○`, `/icons/[size]` still `●` with all three sizes, `/game` still `○`.
- Original crash reproduced against the production build, then confirmed fixed.
- Storage-blocked path reproduced with `sessionStorage` overridden to throw: now reports the browser, not the playlist.
- Error boundary confirmed catching a real throw (temporary throw injected, built, verified, reverted).
- Warning popup rendered and screenshotted against a local build with in-process KV.
- Happy path replayed end to end: paste playlist → Start → game loads, no console errors.

## Review

Pre-landing review: 2 informational, both auto-fixed.

- `lib/service-notice.ts` — non-null assertion `status!.code` was sound only via coupling to `noticeState`'s null handling → read `code` off the optional chain directly.
- `components/crash-screen.tsx` — the report link pointed at `Waynting/spotify_guess_web` (the local directory name); the repo is `Waynting/GuessSong`, so the one link a frustrated host would click 404'd. Moved to `lib/crash-screen.ts` and pinned against `SELF_HOST_URL`.

Noted, not fixed: `app/global-error.tsx` hardcodes `<html lang="en">` while the body can render Chinese. Only reachable when the root layout itself throws, and locale resolves in an effect so first paint is English regardless.

Adversarial pass found nothing surviving. Wire compatibility checked both directions for a rolling deploy: old client + new server ignores `approachingLimit` and degrades to 1.7.3 behaviour; new client + old server reads it as `undefined` and returns no notice.

## Documentation

- `CLAUDE.md`: two new invariant sections — "A client-side throw must never be a dead end" and "The site notice warns before it refuses".
- `README.md`: new "When the client throws" and "The site notice" sections. Also fixes three things that were wrong independently of this work — `/api/status` and `SPOTIFY_MAX_LOADS_PER_DAY` were missing from the route and environment tables entirely, and the test counts read 17 files / 273 cases against an actual 31 / 567.
- `.env.example`: the three Spotify budget knobs and `PREVIEW_MAX_LOOKUPS_PER_MINUTE` documented; dropped the note about "the 3 built-in trial playlists", which have not existed since 1.5.0.
- Both changelogs updated, version bumped to 1.7.4.

## Known gaps

- **The reported crash is fixed by construction, not by reproducing that host's exact failure.** Both candidate paths reproduce and are fixed, but which one they hit is unknown, and a third cause reaching the same screen is not ruled out — a chunk that fails to load mid-navigation would look identical. `client_error` exists so the next one is a number rather than an email.
- `app/error.tsx` cannot catch a throw during a server render, and neither boundary catches an unhandled promise rejection. Neither is reachable on the path this fixes.
- **The 0.8 warn ratio has never run against real traffic.** 1,600 of 2,000 against a normal day's ~2,152 cold loads should trip most evenings. If it turns out to trip at lunchtime daily it becomes wallpaper; `SPOTIFY_BUDGET_WARN_RATIO` is retunable from Vercel without a deploy for exactly that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
