### PR TITLE
v1.7.5 fix: the clip that plays the wrong song

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,98 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.5] - 2026-08-25
+
+A player wrote in: *"it was playing the wrong audio for my playlist."*
+
+Two independent causes, and neither is the one the report sounds like. The
+clip and the answer card can disagree because the clip arrived late, or
+because the clip was never the right recording in the first place.
+
+### Fixed
+
+- **A preview that resolves after the host has moved on no longer plays**
+  (`app/game/page.tsx`). `playClip` captured `tracks[currentIndex]`, awaited
+  `fetchPreview`, and then assigned `audio.src` and flipped the phase with no
+  re-check — and the "Skip Track" button is rendered *by that very await*, 1500ms
+  in. So a host who got bored of "Finding audio…" and skipped got round N's clip
+  under round N+1's card, which is the report almost exactly. A `roundTokenRef`
+  generation counter is captured before every await and compared after it;
+  anything that no longer matches is dropped, though its answer is still cached
+  because that is keyed by track id. `handleAudioError`'s repair path had the
+  same hole — its phase guard was read *before* the await.
+
+  The round does not have to end for this to bite: "Reveal Answer" is rendered
+  by the same loading state and only moves the phase, so the clip could start
+  underneath an answer card the host had just put up, tearing the scoring
+  buttons off screen. `playClip` has one caller, the waiting-phase Play button,
+  so a resolution landing in any other phase is now refused outright. The
+  repair path takes the same guard, and **Quit** now ends the round properly —
+  quitting during "Finding audio…" used to leave the clip playing over the setup
+  page with nothing able to stop it, because the element the pause went through
+  had already been unmounted.
+
+- **A tribute act is no longer counted as the artist it is imitating**
+  (`lib/preview-cache.ts`). `artistMatches` tested whole-token containment, so
+  `"Hello Adele Tribute"` read as Adele — and that credit is the *second* result
+  the live iTunes API returns for "Hello Adele". A tribute recording carrying
+  the exact title therefore landed in the strongest tier and won on running
+  time. Credits are now split into the acts they name (`&`, `,`, `feat`, `with`,
+  `x`, …) and one has to name every act the other does. `"Marshmello & Noah
+  Cyrus"` still matches Marshmello; `"The Beatles"` still matches `"Beatles"`.
+  Recorded as a known gap since 1.2.0.
+
+- **A remaster keeps its own recording instead of being left to the clock.**
+  Spotify stores `"Karma Police - Remastered 2011"`; iTunes returns the same
+  recording as plain `"Karma Police"`. Exact comparison matched neither, the
+  pick fell through to the artist tier, and running time alone cannot tell a
+  remaster from the album track beside it — it resolved to *Lucky*. A
+  qualifier-stripped title tier now sits between "same artist and title" and
+  "same artist".
+
+- **An artist-less lookup is held to the running time.** With no artist the
+  query degrades to the bare title and the guarded follow-up is skipped as a
+  duplicate, which quietly left the *unguarded* half as the only thing that ran:
+  a title-only search taking upstream's best-ranked answer with nothing tying it
+  to the request, cached as `found` for a year. It now demands the clock when
+  the caller sent one, and is unchanged when they sent neither.
+
+### Changed
+
+- **Both preview routes clamp `track` and `artist`** (`PREVIEW_FIELD_MAX`, 300).
+  The matching above is regex work on strings that arrive straight off the wire
+  from an unauthenticated caller, and two of those regexes are super-linear on
+  pathological input — 16k spaces measured at 141ms in a single credit split,
+  once per candidate per tier. Spotify's own fields are far under the cap.
+  Clamped by code point rather than `slice`, because half a surrogate pair makes
+  `encodeURIComponent` throw and that throw is inside the batch's `Promise.all`.
+- `pickCandidate` judges each candidate once and the tiers read the verdicts.
+  The tier loop re-filters per tier and the same questions appear in several
+  tiers, so upstream's strings were being re-parsed for answers that cannot
+  change — up to ~150 redundant credit splits per track on the hottest path in
+  the app. Behaviour is identical; `tests/preview.test.ts` covers the ordering.
+
+### Known gaps
+
+- **Entries written by the old picker are still served.** Positive results are
+  held a year under an unversioned key, and `&refresh=1` re-confirms the stored
+  `itunesTrackId` rather than re-picking, so this release reaches only tracks
+  nobody has played yet. Worse for this particular bug: a wrong-but-playable URL
+  never fires the `<audio>` error that triggers refresh at all. Re-picking them
+  needs the picker-generation stamp described at `lib/preview-cache.ts:127`, and
+  its admission budget, which is not built.
+- **The round guard is tested; its wiring is not.** The rule moved to
+  `lib/round-token.ts` for the reason `lib/room-poll.ts` and `lib/song-count.ts`
+  did — the suite reaches `lib/` and cannot import a `.tsx` module — and
+  `begin()` hands back its own comparison so the two halves cannot be written
+  apart. What no test can still reach is whether the component *calls* it:
+  `retireRound()` is the single teardown, but a fifth round-ending path that
+  forgets it would fail silently.
+- **CJK is one signal deep.** For 小幸運 / 田馥甄 the live API translates *both*
+  the title and the credit, so running time is the only thing left and the
+  correct track sits 768ms from a sibling. It picks correctly today because the
+  right recording matches almost exactly, but nothing else is holding it up.
+
 ## [1.7.4] - 2026-08-24
 
 A host wrote in: the site loads, they paste a playlist, they press Start, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,12 @@ because the clip was never the right recording in the first place.
   `fetchPreview`, and then assigned `audio.src` and flipped the phase with no
   re-check — and the "Skip Track" button is rendered *by that very await*, 1500ms
   in. So a host who got bored of "Finding audio…" and skipped got round N's clip
-  under round N+1's card, which is the report almost exactly. A `roundTokenRef`
-  generation counter is captured before every await and compared after it;
-  anything that no longer matches is dropped, though its answer is still cached
-  because that is keyed by track id. `handleAudioError`'s repair path had the
+  under round N+1's card, which is the report almost exactly. The generation
+  counter behind the fix is `lib/round-token.ts` — in `lib/` because the suite
+  reaches there and cannot import a `.tsx` module, and shaped so `begin()` hands
+  back its own comparison rather than leaving a caller to write the second half
+  of a two-step rule. Anything that comes back to a round that has moved on is
+  dropped, though its answer is still cached, because that is keyed by track id. `handleAudioError`'s repair path had the
   same hole — its phase guard was read *before* the await.
 
   The round does not have to end for this to bite: "Reveal Answer" is rendered

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ There *is* server-side storage, but it is deliberately narrow: a KV layer (`lib/
 |---|---|
 | `POST /api/playlist` | `{url}` → playlist name + tracks, via Spotify **Client Credentials** flow (`lib/spotify.ts`). Rejects Spotify editorial playlists (IDs starting `37i9` return 404 for new apps). |
 | `GET /api/preview` | Track/artist/id → 30s preview URL (iTunes, then Deezer). No auth required. KV-cached by track id, including negative results. `&refresh=1` re-resolves a URL that stopped playing, on its own much tighter limit. |
-| `POST /api/preview/batch` | `{tracks:[{id,name,artist}]}` → the same lookup for a whole game in one request. |
+| `POST /api/preview/batch` | `{tracks:[{id,name,artist,durationMs?}]}` → the same lookup for a whole game in one request. `durationMs` is optional so an older client still resolves; without it the pick falls back to matching on names alone. |
 | `POST /api/room` | Creates a Mixed Playlist Mode room; returns room code, host token, expiry. |
 | `POST /api/room/[code]/submit` | A player submits their playlist URL to the room. |
 | `GET /api/room/[code]/status` | Poll for who has submitted so far. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,13 +93,23 @@ The same three layers, so they read the same way: cache → global budget (`PREV
 
 **The cooldown is memoized in module scope, and it must not go back to a KV read per track.** It is a site-wide, minute-scale signal that `askUpstream` consults once per source *per track*, so a cold 25-song game spent up to 50 reads learning the same two answers — more commands than the batch's own writes. A known-future `until` is trusted without re-reading at all; "not cooling" is held only `COOLDOWN_MEMO_MS`, because that is the answer that spends upstream calls, and the in-flight map is what makes the first wave of a batch share one read instead of each worker issuing its own. `startCooldown` primes the memo, so within an instance a 403 parks the source immediately; across instances a cooldown is joined up to `COOLDOWN_MEMO_MS` late, which is deliberately far below `MIN_COOLDOWN_SECONDS`.
 
-Four things here are easy to undo by accident:
+Seven things here are easy to undo by accident:
 
 - **The title-only queries verify the artist; the ones that carried it upstream must not.** Each source is asked progressively looser questions and the last drops the artist, so upstream ranks by popularity alone and returns the best-known song with that title — iTunes answers "Hello" with Pinkfong's nursery rhyme and "Alone" with Heart. Accepting one caches the wrong recording as `found` for a year, which refresh never re-picks, and the clip then contradicts the answer card. Those queries require the candidate to be tied to the request by *either* a matching credit or a matching running time, and otherwise hand over to the next source. Applying the same check to the artist-carrying queries looks like an obvious tightening and is a catalogue-wide outage for CJK: iTunes returns 小幸運 as "A Little Happiness" by "Hebe Tien" where Spotify says 田馥甄. `artistMatches` is only ever a veto where upstream had no artist signal of its own.
+
+  **A caller that sent no artist at all is the third case, and it used to fall through both.** With no artist the first query has already degraded to the bare title, so the guarded follow-up is byte-identical and is skipped as a duplicate — which left the *unguarded* half as the only thing that ran. `titleOnly` carries `requireVerified: Boolean(query.durationMs)`: demand the clock when the caller sent one, keep the old behaviour when they sent neither, because manufacturing a week-long `absent` for a track that may well have a clip is the worse failure.
+
+- **`artistMatches` compares the acts a credit names, never substrings.** Plain containment let "Hello Adele Tribute" read as Adele, and a tribute act titled exactly right is what a popularity-ranked search surfaces — confirmed live as the *second* iTunes result for "Hello Adele" — so it landed in the strongest tier and won on running time. `creditParts` splits on how both platforms bill a collaboration and one credit has to name every act the other does, which keeps "Marshmello & Noah Cyrus" matching Marshmello. Two boundaries in `CREDIT_SEPARATOR` are load-bearing: alphabetic separators need `\b` or "Charli XCX" splits on its own x, and a leading "the" comes off because iTunes bills "The Beatles" where Spotify says "Beatles". CJK keeps the plain substring, having no spaces to anchor on.
+
+- **`QUALIFIER_SUFFIX` is anchored far more tightly than it looks like it needs to be, and loosening it reopens the bug it fixed.** Spotify stores "Karma Police - Remastered 2011" where iTunes has plain "Karma Police", so a qualifier-stripped `looseName` tier sits between "same artist and title" and "same artist" — without it a remaster matches no tier and the clock picks among the artist's own album tracks. But `[-([]` followed by a lazy reach for the keyword truncates at the *first* hyphen, which stripped "Hip-Hop Is Dead (Remastered)" to "Hip" and outranked a candidate whose running time agreed to the millisecond: a new wrong-clip path opened by the fix for wrong clips. The `\b` around the alternation is the same story one size down — without it "live" fires inside "Alive" and "mix" inside "Remix". `looseName` is deliberately **not** shared with `lib/mixed-playlist.ts`'s `fingerprint()`: that one normalises through `[^a-z0-9]`, which takes 小幸運 to the empty string and would switch this tier off for the catalogue it was added to protect.
+
+  The tier order in `pickCandidate` is pinned by `tests/preview.test.ts` and is not arbitrary. The duration tier stays *above* the bare-title tiers: an exact title whose running time is 52s out is a cover, and the recording asked for is the one whose clock agrees. Each candidate is scored once and the tiers read the verdicts, because the tier loop re-filters per tier and re-parsing upstream's strings for an answer that cannot change is regex work on the hottest path in the app.
 
 - **`absent` and `unavailable` are not the same null, and collapsing them is a real bug that shipped.** `absent` is a fact about the recording — nothing has a clip — and is cached a week. `unavailable` is a fact about *us*: throttled, out of budget, or the request never got through. The old route mapped every failure onto `previewUrl: null` and cached it for seven days, so one throttled minute at peak marked a slice of the catalogue silent for a week, and it never reproduced locally because a laptop's own IP is never the one being throttled. Only a clean, complete reply from upstream may produce `absent`; everything else is `unavailable`, cached 90 seconds. A wrong `absent` lasts a week and is invisible, a wrong `unavailable` costs one retry. **The client half has the same rule** (`lib/preview-client.ts`, and `previewCache` in the game page stores settled answers only).
 - **iTunes signals throttling with `403`, not 429, and Deezer puts its quota error in the body of a `200`.** Reading only 429, or only the status, is how a refusal gets classified as "no result" in the first place.
 - **The cache key is deliberately unversioned**, unlike `lib/playlist-cache.ts`'s. The record is a strict superset of the `{previewUrl}` shape that shipped before it, so legacy entries still read as valid hits. Bumping a version would cold-start every entry in production simultaneously — precisely the upstream burst the module exists to prevent. For the same reason, legacy nulls are read as `absent` even though some are poisoned by the old bug: they age out within a week, and re-resolving all of them at once is the stampede that poisoned them.
+
+- **Both preview routes clamp `track`/`artist` through `clampPreviewField`, and they must agree or one key holds two answers.** The matching above is regex work on strings an unauthenticated caller hands over, and two of those regexes are super-linear on pathological input — a run of 16k spaces measured at 141ms in one credit split, once per candidate per tier. `PREVIEW_FIELD_MAX` (300, in `types/preview.ts`) bounds the input at the boundary rather than defending in every consumer, and Spotify's own fields sit far under it, so nothing real is truncated. **Clamp by code point, never `slice`**: UTF-16 units cut a surrogate pair in half, a lone high surrogate makes `encodeURIComponent` throw `URIError`, and that throw happens inside the batch's `Promise.all` — one emoji landing on the boundary costs all sixty tracks their previews and answers the bare 500 with no `code` that this project has been bitten by before.
 
 Positive entries are held a year, because a recording does not change. What does change is the URL — the clips sit on a CDN that rotates them — so the entry has to be *repairable* rather than merely expiring: the stored `itunesTrackId` lets `&refresh=1` re-resolve with one `lookup?id=` call instead of the five-call search fan-out, and the game page fires it from the `<audio>` element's `error` event, once per track. Drop the refresh path and the year-long TTL becomes a year of dead URLs.
 
@@ -222,6 +232,51 @@ cardinality-and-user-input rule the rest of that file keeps. The digest goes to
 `console.error` and onto the crash screen, where the person who can quote it
 already is.
 
+## A round's async work must not land on the next round
+
+`lib/round-token.ts` is the rule that stops one round's pending work from
+playing under the next round's card. A player reported "it was playing the wrong
+audio for my playlist" and this was half the cause; the other half is the
+picker, above.
+
+The game page holds **one** `<audio>` element and one set of phase state across
+every round, so anything that awaits mid-round — resolving a preview, repairing
+a rotted URL — can come back after the host has pressed Skip Track, Reveal
+Answer or Quit. `playClip` renders the "Skip Track" button *during* its own
+await, 1500ms in, which makes a host advancing while a preview resolves the
+ordinary case rather than a corner one.
+
+- **The rule lives in `lib/`, not in the component.** Same reason
+  `lib/room-poll.ts` and `lib/song-count.ts` do: the suite reaches `lib/` and
+  vitest cannot import a `.tsx` module here, so a rule left in
+  `app/game/page.tsx` is a rule with no test. It was written inline first, under
+  a comment conceding exactly that.
+- **`begin()` returns its own comparison, and that shape is the point.**
+  Capture-then-compare is a two-step rule whose steps can be forgotten
+  independently; handing the compare back from the capture means a caller that
+  remembered one has necessarily got the other. Call it *before* the await.
+- **`retireRound()` is the single round teardown, and a new round-ending path
+  must go through it.** It stops the clip, bumps the token, hands the `<audio>`
+  element's `src` back, and clears the loading affordances — four things whose
+  ordering nothing in the suite can reach, because the guard lives in a
+  component the tests cannot import. `nextTrack`, `endGame` and Quit all call
+  it; a fifth path that forgets the bump fails silently, which is the bug this
+  exists to prevent.
+- **A stale answer is dropped from the round but still cached.** `previewCache`
+  is keyed by track id, so a resolution that came back to the wrong round is
+  still worth keeping — the host who skipped past that track may come back to
+  it.
+- **The phase must be re-read after the await, not only before it.** Reveal
+  moves the phase without ending the round, so a guard read before the await
+  cannot speak for where the host is now: without the re-check the clip starts
+  under the answer card the host has just put up and tears the scoring buttons
+  off screen. `playClip` has exactly one caller — the waiting-phase Play button
+  — so a resolution landing in any other phase can never legitimately start a
+  clip.
+- **`releaseClip` uses `removeAttribute("src")`, not `src = ""`.** An empty
+  string resolves against the document and leaves the element holding the page's
+  own URL.
+
 ## The site notice warns before it refuses
 
 `components/service-notice.tsx` has two states and the earlier one is the
@@ -281,7 +336,7 @@ Every surface name is declared once in `lib/loop-links.ts` and derived from ther
 
 ## Types
 
-`types/index.ts` contains only the `Track` interface — the shape stored in sessionStorage and returned by `/api/playlist`. Shared game types (`GamePayload`, `GamePlayer`, `GameMode`) live in `lib/game-session.ts`; room types and constants (`ROOM_TTL_SECONDS`, `ROOM_MAX_SUBMISSIONS`) live in `types/room.ts`; preview wire types and `PREVIEW_BATCH_MAX` live in `types/preview.ts`, kept out of `lib/preview-cache.ts` so the browser bundle doesn't pull in `lib/kv.ts` and the Upstash client; the game page defines its own local `Phase` type.
+`types/index.ts` contains only the `Track` interface — the shape stored in sessionStorage and returned by `/api/playlist`. Shared game types (`GamePayload`, `GamePlayer`, `GameMode`) live in `lib/game-session.ts`; room types and constants (`ROOM_TTL_SECONDS`, `ROOM_MAX_SUBMISSIONS`) live in `types/room.ts`; preview wire types and the two input caps (`PREVIEW_BATCH_MAX`, `PREVIEW_FIELD_MAX` with its `clampPreviewField`) live in `types/preview.ts`, kept out of `lib/preview-cache.ts` so the browser bundle doesn't pull in `lib/kv.ts` and the Upstash client; the game page defines its own local `Phase` type.
 
 When adding a value to a union that `parseGamePayload` reads, extend that union's allow-list array alongside it (`GAME_MODES`, `PLAYLIST_SOURCES`). Both lines are guards rather than ternaries precisely so a forgotten entry is a value that reads back as the default instead of a member that silently changes behaviour.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A local party music guessing game powered by Spotify playlists. Live at **[guess
 
 No login, no accounts. The host pastes a public Spotify playlist URL, everyone guesses out loud, and the host awards points.
 
-Current version: **1.1.0** — see [CHANGELOG.md](./CHANGELOG.md).
+Current version: **1.7.5** — see [CHANGELOG.md](./CHANGELOG.md).
 
 ## How It Works
 
@@ -184,7 +184,7 @@ components/                  Buzzer button + host panel, room panel, mixed colle
                              crash screen, ui/ (shadcn primitives)
 lib/                         All shared logic — see "Architecture" below
 worker/                      Cloudflare Worker + BuzzerRoom Durable Object
-tests/                       31 Vitest files, 567 cases
+tests/                       32 Vitest files, 591 cases
 types/                       Track, room, preview, and service-status wire types
 ```
 
@@ -195,8 +195,8 @@ Every route is IP rate limited (`lib/rate-limit.ts`) with a fixed window; limits
 | Route | Method | Purpose | Limit |
 |---|---|---|---|
 | `/api/playlist` | POST | `{url}` → playlist name + tracks, via Spotify Client Credentials. Editorial playlists (IDs starting `37i9`) are rejected — they 404 for new apps. | 30 / 10 min |
-| `/api/preview` | GET | `?track=&artist=&id=` → `{previewUrl, status}` where status is `found` / `absent` / `unavailable`. `&refresh=1` re-resolves a URL that stopped playing. | 300 / 10 min (refresh: 30) |
-| `/api/preview/batch` | POST | `{tracks:[{id,name,artist}]}` (max 60) → previews for a whole game in one request. | 20 / 10 min |
+| `/api/preview` | GET | `?track=&artist=&id=` → `{previewUrl, status}` where status is `found` / `absent` / `unavailable`. `&refresh=1` re-resolves a URL that stopped playing. `track` and `artist` are trimmed and clamped to 300 code points. | 300 / 10 min (refresh: 30) |
+| `/api/preview/batch` | POST | `{tracks:[{id,name,artist,durationMs?}]}` (max 60) → previews for a whole game in one request. Same 300-code-point clamp on `name` and `artist`. | 20 / 10 min |
 | `/api/room` | POST | Optional `{code}` → `{roomCode, hostToken, expiresAt}`. Creates the Mixed Playlist mailbox. | 10 / 10 min |
 | `/api/room/[code]/submit` | POST | `{playerName, playlistUrl}` → `{ok, trackCount}`. | 20 / 10 min |
 | `/api/room/[code]/status` | GET | Who has submitted so far (host polls every 4s). | 200 / 10 min |
@@ -214,6 +214,10 @@ Every route is IP rate limited (`lib/rate-limit.ts`) with a fixed window; limits
 Spotify deprecated `preview_url` in Nov 2024 and now returns `null` for **every** track on Client Credentials — measured 0/20 across four markets — so `Track` carries no `previewUrl` field at all and every clip the game plays is resolved by this app. On mount the game page prefetches the whole game with one `POST /api/preview/batch`; anything unresolved falls back to `GET /api/preview` lazily when the host presses Play. Both search the iTunes Search API first, then Deezer, and neither needs credentials.
 
 Choosing *which* result to play takes two signals, because neither survives every case on its own. Credits are routinely translated — iTunes returns 盧廣仲 as "Crowd Lu", 小幸運 as "A Little Happiness" — while a cover shares the original's title by definition, so on a CJK track the only string that lines up often belongs to the wrong recording. Running time is translated by nobody and agrees with Spotify to within a millisecond or two, which is exactly what a re-recording does not do. So the two check each other, and the loosest queries — the title-only ones, where upstream was handed no artist to rank by and answers "Hello" with Pinkfong's nursery rhyme rather than Adele's — are only accepted when one of them verifies. Everything else is handed to the next source.
+
+Three details of that matching are load-bearing, and each one was a wrong clip before it existed. Credits are compared as the *acts they name* (split on `&`, `,`, `feat`, `with`, `x`, …) rather than as substrings, so "Marshmello & Noah Cyrus" still matches Marshmello but "Hello Adele Tribute" no longer passes as Adele — a tribute act carrying the exact title is the second result the live iTunes API returns for that search. Titles are compared again with the qualifiers one platform adds and the other does not stripped off ("Karma Police - Remastered 2011" against plain "Karma Police"), because otherwise a remaster matches no tier at all and the pick falls to a clock that cannot tell it from the album track beside it. And a lookup that carried no artist upstream is held to the running time when the caller sent one, rather than taking whatever upstream ranked first.
+
+The other way the clip and the card can disagree is timing, and it has nothing to do with matching. Resolving a preview takes long enough that the game page renders a **Skip Track** button *during* the wait, so a host who skips or reveals while one is in flight is the ordinary case. `lib/round-token.ts` stamps a generation before every await; anything that comes back to a round that has moved on is dropped rather than played, though its answer is still cached under the track id for whenever the host reaches it.
 
 Preview results are three-way, not two-way: `found`, `absent` (nothing has a clip — cached a week), and `unavailable` (we were throttled or the request never got through — cached 90 seconds). Collapsing those two nulls is a real bug that shipped once: one throttled minute marked a slice of the catalogue silent for a week.
 
@@ -262,7 +266,7 @@ Two hand-written changelogs, and a release updates both: [`CHANGELOG.md`](./CHAN
 ## Testing
 
 ```bash
-npm test              # 31 files, 567 cases — vitest, jsdom
+npm test              # 32 files, 591 cases — vitest, jsdom
 cd worker && npm test # Durable Object tests inside workerd
 ```
 

--- a/app/api/preview/batch/route.ts
+++ b/app/api/preview/batch/route.ts
@@ -19,6 +19,7 @@ import { errorResponse } from "@/lib/api-error";
 import { getPreviews, type PreviewQuery } from "@/lib/preview-cache";
 import { enforceRateLimit } from "@/lib/rate-limit";
 import {
+  clampPreviewField,
   PREVIEW_BATCH_MAX,
   type PreviewBatchResponse,
   type PreviewResult,
@@ -48,7 +49,7 @@ function parseTracks(body: unknown): PreviewQuery[] | null {
   const queries: PreviewQuery[] = [];
   for (const raw of tracks as BatchRequestTrack[]) {
     const id = typeof raw?.id === "string" ? raw.id.trim() : "";
-    const name = typeof raw?.name === "string" ? raw.name.trim() : "";
+    const name = typeof raw?.name === "string" ? clampPreviewField(raw.name) : "";
     // An id is required here, unlike on the GET: the response is a map keyed by
     // it, so an entry without one has nowhere to be returned to.
     if (!id || !name) return null;
@@ -58,7 +59,7 @@ function parseTracks(body: unknown): PreviewQuery[] | null {
     queries.push({
       id,
       track: name,
-      artist: typeof raw?.artist === "string" ? raw.artist.trim() : "",
+      artist: typeof raw?.artist === "string" ? clampPreviewField(raw.artist) : "",
       ...(Number.isFinite(duration) && duration > 0 ? { durationMs: duration } : {}),
     });
   }

--- a/app/api/preview/route.ts
+++ b/app/api/preview/route.ts
@@ -18,7 +18,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getPreview } from "@/lib/preview-cache";
 import { enforceRateLimit } from "@/lib/rate-limit";
-import type { PreviewResult } from "@/types/preview";
+import { clampPreviewField, type PreviewResult } from "@/types/preview";
 
 /** Roughly one lookup per unique track; the client also caches per session. */
 const PREVIEW_LIMIT = 300;
@@ -38,8 +38,8 @@ export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   // Trimmed to match POST /api/preview/batch. Untrimmed, the same track through
   // the two routes can pick different recordings and write both under one key.
-  const track = (searchParams.get("track") ?? "").trim();
-  const artist = (searchParams.get("artist") ?? "").trim();
+  const track = clampPreviewField(searchParams.get("track") ?? "");
+  const artist = clampPreviewField(searchParams.get("artist") ?? "");
   const id = searchParams.get("id") ?? "";
   const refresh = searchParams.get("refresh") === "1";
   const duration = Number(searchParams.get("durationMs"));

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/game-session";
 import { loadGame } from "@/lib/game-storage";
 import { fetchPreview, fetchPreviewBatch } from "@/lib/preview-client";
+import { createRoundToken } from "@/lib/round-token";
 import { isPreviewSettled, type PreviewBatchTrack } from "@/types/preview";
 import { BuzzerHostPanel, type BuzzerControls } from "@/components/buzzer-host-panel";
 import { LoopQr } from "@/components/loop-qr";
@@ -153,7 +154,15 @@ export default function GamePage() {
   // Read by the buzz handler, which must not re-subscribe on every phase change.
   const phaseRef = useRef<Phase>("waiting");
   phaseRef.current = phase;
-  const loadingSkipTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /**
+   * Which round the host is looking at. See lib/round-token.ts for the rule and
+   * for why it is not written inline here.
+   *
+   * playClip renders the "Skip Track" button *during* its own await, 1500ms in,
+   * so a host advancing while a preview resolves is the ordinary case rather
+   * than a corner one.
+   */
+  const roundsRef = useRef(createRoundToken());
   /**
    * Only ever holds *settled* answers — a found URL, or a confirmed null for a
    * song nothing has a clip for. An "unavailable" is never written here: it
@@ -278,6 +287,45 @@ export default function GamePage() {
   }, []);
 
   /**
+   * Hand back the clip the element is holding, so a round cannot inherit the
+   * previous round's URL. `handleAudioError` already documented this as
+   * something that happens between rounds; until now nothing did it, and the
+   * only reason a stale src was never heard is that the replay controls happen
+   * not to render outside "playing"/"guessing" — one render condition away from
+   * being audible. Round teardown only: reveal() also stops the clip, and replay
+   * has to keep working after it.
+   *
+   * removeAttribute rather than `src = ""`, which resolves against the document
+   * and would leave the element holding the page's own URL.
+   */
+  const releaseClip = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.removeAttribute("src");
+    audio.load();
+  }, []);
+
+  /**
+   * End the round the host is looking at: stop the clip, retire everything
+   * still in flight for it, hand the element back, and clear the affordances
+   * that belong to a round being loaded.
+   *
+   * One function rather than three lines at each call site, because the failure
+   * mode of forgetting the token bump is precisely the bug this exists to fix,
+   * and a fourth round-ending path is exactly the kind of thing that gets added
+   * later. Nothing can test that ordering — the guard lives in a component the
+   * vitest suite cannot reach — so it has to be impossible to get wrong instead.
+   */
+  const retireRound = useCallback(() => {
+    stopClip();
+    roundsRef.current.bump();
+    releaseClip();
+    setPreviewLoading(false);
+    setNoAudio(false);
+    setLoadingSkipVisible(false);
+  }, [stopClip, releaseClip]);
+
+  /**
    * Start (or restart) the progress bar and the end-of-clip deadline for
    * however much of the clip is left. Called once when a clip starts, and again
    * on every resume.
@@ -362,6 +410,7 @@ export default function GamePage() {
     const audio = audioRef.current;
     const track = tracks[currentIndex];
     if (!audio || !track) return;
+    const stillThisRound = roundsRef.current.begin();
 
     // Whatever the prefetch resolved. There is no Spotify URL to prefer here:
     // preview_url has been null for every track since Nov 2024, so the clip
@@ -376,7 +425,11 @@ export default function GamePage() {
     if (!previewUrl && cached === undefined) {
       setPreviewLoading(true);
       setLoadingSkipVisible(false);
-      loadingSkipTimerRef.current = setTimeout(() => setLoadingSkipVisible(true), 1500);
+      // Held in a local rather than a ref on purpose. Two rounds' resolutions
+      // can be in flight at once, and a shared ref would already belong to the
+      // round that replaced us — clearing it would take the next host's Skip
+      // button away instead of our own.
+      const skipTimer = setTimeout(() => setLoadingSkipVisible(true), 1500);
 
       const result = await fetchPreview({
         id: track.id,
@@ -384,14 +437,33 @@ export default function GamePage() {
         artist: track.artists[0] ?? "",
         durationMs: track.durationMs,
       });
-      previewUrl = result.previewUrl;
-      missReason = result.status === "unavailable" ? "unavailable" : "absent";
+      clearTimeout(skipTimer);
+      // Keyed by track id, so it is worth keeping whichever round we came back
+      // to — the host who skipped past this track may still come back to it.
       // Settled answers only — see previewCache's declaration.
       if (isPreviewSettled(result.status)) previewCache.current[track.id] = result.previewUrl;
 
-      if (loadingSkipTimerRef.current) clearTimeout(loadingSkipTimerRef.current);
+      // The host moved on while we were asking. Everything past here writes to
+      // state and to an element that now belong to somebody else's round.
+      if (!stillThisRound()) return;
+
+      // Past the token check this is still our round, so the loading
+      // affordances are ours to put away — including on the reveal path just
+      // below, which returns without ever starting a clip. Doing it any earlier
+      // would let an abandoned round switch off a *new* round's spinner.
       setLoadingSkipVisible(false);
       setPreviewLoading(false);
+
+      // The round does not have to *end* for the answer to be stale. "Reveal
+      // Answer" is rendered by this very loading state, and reveal() only moves
+      // the phase — so without this the clip started under the answer card the
+      // host had just put up, tearing the scoring buttons off screen. playClip
+      // has exactly one caller, the waiting-phase Play button, so a resolution
+      // landing in any other phase can never legitimately start a clip.
+      if (phaseRef.current !== "waiting") return;
+
+      previewUrl = result.previewUrl;
+      missReason = result.status === "unavailable" ? "unavailable" : "absent";
     }
 
     if (!previewUrl) {
@@ -435,11 +507,29 @@ export default function GamePage() {
     if (phaseRef.current !== "playing" && phaseRef.current !== "guessing") return;
     if (refreshedTracks.current.has(track.id)) return;
     refreshedTracks.current.add(track.id);
+    const stillThisRound = roundsRef.current.begin();
 
     const result = await fetchPreview(
       { id: track.id, name: track.name, artist: track.artists[0] ?? "", durationMs: track.durationMs },
       { refresh: true }
     );
+
+    // Same rule as playClip, and the reason the phase guard above is not enough:
+    // it was read before the await. A repair that lands after the host has moved
+    // on would put the previous round's clip on this round's card.
+    if (!stillThisRound()) {
+      if (result.previewUrl) previewCache.current[track.id] = result.previewUrl;
+      return;
+    }
+    // The guard above the await is read before it, so it cannot speak for where
+    // the host is now. Reveal moves the phase without ending the round, and a
+    // repair can land up to UPSTREAM_TIMEOUT_MS later: without this it either
+    // starts the clip under the answer card, or — on the failure branch — puts
+    // the phase back to "waiting" and takes the whole scoring card with it.
+    if (phaseRef.current !== "playing" && phaseRef.current !== "guessing") {
+      if (result.previewUrl) previewCache.current[track.id] = result.previewUrl;
+      return;
+    }
 
     if (!result.previewUrl) {
       // Nothing left to try. Put the round into the state a track with no clip
@@ -540,7 +630,7 @@ export default function GamePage() {
   }
 
   function nextTrack() {
-    stopClip();
+    retireRound();
     buzzerControlsRef.current?.next();
     trackEvent("round_completed", {
       round_index: currentIndex + 1,
@@ -576,14 +666,11 @@ export default function GamePage() {
       setAlbumPointsAwarded(false);
       setSourcePointsAwarded(false);
       setAlbumHintShown(false);
-      setPreviewLoading(false);
-      setNoAudio(false);
-      setLoadingSkipVisible(false);
     }
   }
 
   function endGame() {
-    stopClip();
+    retireRound();
     trackGameFinished();
     setPhase("finished");
   }
@@ -1443,7 +1530,7 @@ export default function GamePage() {
               </button>
             )}
             <button
-              onClick={() => { stopClip(); router.push("/"); }}
+              onClick={() => { retireRound(); router.push("/"); }}
               style={{
                 background: "none",
                 border: "1px solid #2a2a2a",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,7 +128,7 @@ So each cache is four layers, and they read the same way on purpose:
 | Called once per | playlist | **track** |
 | Cold 50-song game | 1 load | **50 lookups, up to 5 calls each** |
 | Budget env var | `SPOTIFY_MAX_LOADS_PER_MINUTE` (40) | `PREVIEW_MAX_LOOKUPS_PER_MINUTE` (120) |
-| Positive TTL | 6h (1h if sampled) | 1 year |
+| Positive TTL | 24h (1h if sampled) | 1 year |
 | Negative TTL | 10 min | 1 week (`absent`) / **90s** (`unavailable`) |
 
 **Every layer fails open.** Losing the safety net must mean "back to how it was",

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -271,13 +271,27 @@ outlive a full game. Buzzer rooms are a different system with a sliding timeout.
 
 ### "A clip plays but the answer card disagrees"
 
-A wrong recording was cached as correct. Positive preview entries are held a
-**year**, and `&refresh=1` repairs rotted URLs, not wrong songs. The matching
-rules are in `lib/preview-cache.ts` — see the 1.2.0 changelog entry for why the
-tier list is ordered the way it is. Fixing one means invalidating that track's
-key, not bumping the cache version: a version bump cold-starts every entry in
-production simultaneously, which is the upstream stampede the module exists to
-prevent.
+Two causes, and they are told apart by whether it is reproducible. Ask the host
+whether they skipped or revealed while it said "Finding audio…".
+
+**If it only happened once, on a round they advanced past:** the preview
+resolved after the host had moved on and landed on the round in front of it.
+`lib/round-token.ts` stamps a generation before every await and
+`retireRound()` bumps it, so this is fixed as of 1.7.5 — but a round-ending
+path added later that forgets to call `retireRound()` brings it straight back,
+and nothing in the suite can catch that (the guard lives in
+`app/game/page.tsx`, which vitest cannot import). Check the call sites first.
+
+**If the same track is wrong every time:** a wrong recording was cached as
+correct. Positive preview entries are held a **year**, and `&refresh=1` repairs
+rotted URLs, not wrong songs — worse, a wrong-but-playable URL never fires the
+`<audio>` error that triggers refresh at all. The matching rules are in
+`lib/preview-cache.ts`; the 1.2.0 changelog entry has the original tier
+reasoning and 1.7.5 has the three corrections layered on it (credits compared as
+acts, a qualifier-stripped title tier, artist-less lookups held to the running
+time). Fixing one means invalidating that track's key, not bumping the cache
+version: a version bump cold-starts every entry in production simultaneously,
+which is the upstream stampede the module exists to prevent.
 
 ---
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -35,7 +35,7 @@ No `.github/workflows`. Nothing runs the suite before a merge. Before opening a
 pull request:
 
 ```bash
-npm test              # 351 tests, ~1.5s
+npm test              # 32 files, 591 tests, ~1.5s
 npx tsc --noEmit
 npx eslint app lib components
 npm run build         # see the warning below

--- a/lib/changelog.ts
+++ b/lib/changelog.ts
@@ -49,6 +49,31 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "1.7.5",
+    date: "2026-08-25",
+    headline:
+      "Fixed the clip playing a different song from the one on the answer card \u2014 both the late-arriving kind and the wrong-recording kind.",
+    headlineZh:
+      "修好了播出來的音樂跟答案卡上的歌對不起來的問題，包含「慢一步才播出來」和「一開始就抓錯錄音」兩種狀況。",
+    changes: [
+      {
+        kind: "fixed",
+        text: "If you got tired of waiting on \u201cFinding audio\u2026\u201d and pressed Skip Track or Reveal Answer, the clip that was still loading could start playing on the next song, or on top of the answer you had just revealed. It is now dropped instead.",
+        textZh: "如果你等「Finding audio…」等到不耐煩，按了跳過或直接公布答案，那首還在載入的音樂有可能會接著在下一首播出來，或是蓋在你剛公布的答案上。現在它會直接被丟掉，不會再亂播。",
+      },
+      {
+        kind: "fixed",
+        text: "Songs with very common titles could play a tribute band or karaoke version instead of the real recording, which then contradicted the answer card. The check that matches the artist no longer counts a name like \u201cHello Adele Tribute\u201d as Adele.",
+        textZh: "歌名很菜市場的歌，以前有可能播出致敬樂團或卡拉 OK 版本，而不是原本那個錄音，跟答案卡對不起來。現在比對歌手的方式改過了，像「Hello Adele Tribute」這種名字不會再被當成 Adele。",
+      },
+      {
+        kind: "fixed",
+        text: "Remastered and live-tagged tracks could end up playing a different song from the same album. The title is now matched with those tags taken off, so the remaster finds its own recording.",
+        textZh: "標了 Remastered 或 Live 的歌，以前有可能播成同一張專輯裡的另一首。現在比對歌名的時候會先把這些標籤拿掉，重製版就能找回自己那個錄音。",
+      },
+    ],
+  },
+  {
     version: "1.7.4",
     date: "2026-08-24",
     headline:

--- a/lib/preview-cache.ts
+++ b/lib/preview-cache.ts
@@ -553,25 +553,110 @@ function normalizeName(value: string): string {
 }
 
 /**
+ * How both platforms bill a collaboration. Splitting on these is what tells a
+ * guest credit apart from a longer name that merely contains the one asked for:
+ * "Marshmello & Noah Cyrus" names Marshmello, "Hello Adele Tribute" does not
+ * name Adele. Alphabetic separators need whole-word boundaries, or "Charli XCX"
+ * splits on its own x.
+ */
+const CREDIT_SEPARATOR = /\s*(?:[&,/+;×·]|\b(?:feat|ft|featuring|with|vs|versus|and|x)\b\.?)\s*/i;
+
+/**
+ * The acts one credit string names, normalised.
+ *
+ * A leading "the" comes off because the two platforms disagree about it —
+ * iTunes bills "The Beatles" where Spotify says "Beatles" — and that disagreement
+ * used to be absorbed by the containment this replaces.
+ */
+function creditParts(value: string): string[] {
+  const parts = value
+    // Collapsed first, and not only for tidiness: CREDIT_SEPARATOR is `\s*…\s*`
+    // around a group that cannot match a space, so a run of n spaces makes the
+    // engine restart at every offset — O(n²). The routes clamp the input too;
+    // this makes the function safe on its own terms.
+    .replace(/\s+/g, " ")
+    .split(CREDIT_SEPARATOR)
+    .map((part) => normalizeName(part).replace(/^the /, ""))
+    .filter(Boolean);
+  return parts.length > 0 ? parts : [normalizeName(value)].filter(Boolean);
+}
+
+/**
  * Whether two credit strings name the same act.
  *
  * Loose in one direction on purpose: iTunes credits "Marshmello & Noah Cyrus"
- * where Spotify's first artist is just "Marshmello", so containment counts. On
- * whole-token boundaries only, or "Sia" would match "Sian Evans" — except for
- * CJK, which has no spaces to anchor on and falls back to a plain substring.
+ * where Spotify's first artist is just "Marshmello", so one credit naming every
+ * act the other does counts. It compares the acts rather than the raw strings,
+ * because plain containment also let "Hello Adele Tribute" pass as Adele — and
+ * a tribute band is exactly what a popularity-ranked search surfaces, titled
+ * exactly right, landing in the *strongest* tier. Confirmed live: that credit
+ * is the second result iTunes returns for "Hello Adele". CJK keeps the plain
+ * substring, having no spaces to anchor on.
  *
  * What it cannot do is see through translation: Spotify's 田馥甄 is iTunes'
  * "Hebe Tien", and no string comparison bridges that. That limit is the whole
  * reason this is only ever a *requirement* on title-only queries, never a
  * filter on the ones that already carried the artist upstream.
  */
-function artistMatches(candidate: string | undefined, wanted: string): boolean {
+function artistMatches(
+  candidate: string | undefined,
+  wanted: string,
+  /** The `wanted` side, already split. Invariant across a pick — see pickCandidate. */
+  askedCredits?: string[]
+): boolean {
   const a = normalizeName(candidate ?? "");
   const b = normalizeName(wanted);
   if (!a || !b) return false;
   if (a === b) return true;
   if (CJK.test(a) || CJK.test(b)) return a.includes(b) || b.includes(a);
-  return ` ${a} `.includes(` ${b} `) || ` ${b} `.includes(` ${a} `);
+  const credited = creditParts(candidate ?? "");
+  const asked = askedCredits ?? creditParts(wanted);
+  const names = (billing: string[], acts: string[]) => acts.every((act) => billing.includes(act));
+  return names(credited, asked) || names(asked, credited);
+}
+
+const FEAT_PARENTHETICAL = /[([]feat\.?[^)\]]*[)\]]/gi;
+
+/** Tags a platform appends to a title without changing which recording it is. */
+const QUALIFIER = "remaster(?:ed)?|live|version|edit|mix|mono|stereo|deluxe|explicit";
+
+/**
+ * Either a trailing " - Qualifier…", which is how Spotify writes it, or a
+ * bracketed group containing one, which is how iTunes does.
+ *
+ * Anchored far more tightly than it first appears to need, because the loose
+ * form was wrong in the one direction that mattered. `[-([]` followed by `.*?`
+ * reaching for the keyword truncates at the *first* hyphen in the title, so
+ * "Hip-Hop Is Dead (Remastered)" stripped to "Hip" — and with the loose tier
+ * sitting above the artist tier, that collapse outranked a candidate whose
+ * running time agreed to the millisecond. A new wrong-clip path, opened by the
+ * fix for wrong clips. The \b around the alternation is the same story one
+ * size down: without it "live" fires inside "Alive" and "mix" inside "Remix".
+ */
+const QUALIFIER_SUFFIX = new RegExp(
+  `\\s+[-–—]\\s+[^()\\[\\]]*\\b(?:${QUALIFIER})\\b.*$` +
+    `|\\s*[([][^)\\]]*\\b(?:${QUALIFIER})\\b[^)\\]]*[)\\]]`,
+  "gi"
+);
+
+/**
+ * The title with the qualifiers one platform adds and the other does not.
+ *
+ * Spotify stores "Karma Police - Remastered" where iTunes has "Karma Police
+ * (Remastered)" and, for the same recording, plain "Karma Police". An exact
+ * comparison drops all of those out of the tier that already knows the artist,
+ * which leaves the pick to the clock — and the clock cannot tell a remaster
+ * from the sibling album track next to it.
+ *
+ * Close to lib/mixed-playlist.ts's fingerprint() and deliberately not shared
+ * with it, in two ways that matter. It strips `explicit`, which that one does
+ * not; and it normalises through normalizeName's Unicode alphabet rather than
+ * fingerprint's `[^a-z0-9]`, because the ASCII form takes "小幸運" to the empty
+ * string — which would turn the tier below off for the exact catalogue it was
+ * added to protect. Syncing the two by hand is how that gets undone.
+ */
+function looseName(value: string): string {
+  return normalizeName(value.replace(FEAT_PARENTHETICAL, "").replace(QUALIFIER_SUFFIX, ""));
 }
 
 interface PickOptions {
@@ -630,34 +715,59 @@ function pickCandidate(
   // typographic apostrophe ("Don't" vs "Don’t") or a stray double space defeat
   // the strongest signal in the list, in a way the artist check is immune to.
   const wantedTitle = normalizeName(track);
-  const sameTitle = (c: Candidate) => normalizeName(c.trackName ?? "") === wantedTitle;
-  const sameArtist = (c: Candidate) => artistMatches(c.artistName, artist);
-  const drift = (c: Candidate) =>
-    durationMs && c.durationMs ? Math.abs(c.durationMs - durationMs) : Infinity;
+  const wantedLoose = looseName(track);
+  // Split once. It is the same string for every candidate, and this runs inside
+  // a filter that the tier loop may walk several times.
+  const askedCredits = creditParts(artist);
 
-  // Four tiers, not six. A finer "…and the running time agrees" tier above
-  // each of the first two would never change the outcome: its members all sit
-  // inside the tolerance while every other member of the tier below sits
-  // outside it, so the closest-drift tie-break already elects the same
-  // candidate. Spelling them out anyway would be code no test could reach.
-  const tiers: Array<(c: Candidate) => boolean> = [
-    (c) => sameArtist(c) && sameTitle(c),
-    sameArtist,
+  // Each candidate is judged once and carries its own verdicts from there. The
+  // tier loop below re-filters the list per tier, and the same three questions
+  // appear in more than one tier — asking upstream's strings again each time is
+  // regex work on the hottest path in the app, for an answer that cannot change.
+  // The empty guard on `looseOk` matters: a title made entirely of qualifiers
+  // strips to "", and without it every candidate that did would match all others.
+  const scored = playable.map((c) => ({
+    c,
+    artistOk: artistMatches(c.artistName, artist, askedCredits),
+    titleOk: normalizeName(c.trackName ?? "") === wantedTitle,
+    looseOk: wantedLoose.length > 0 && looseName(c.trackName ?? "") === wantedLoose,
+    drift: durationMs && c.durationMs ? Math.abs(c.durationMs - durationMs) : Infinity,
+  }));
+  type Scored = (typeof scored)[number];
+
+  // No "…and the running time agrees" tier above any of these: its members
+  // would all sit inside the tolerance while every other member of the tier
+  // below sat outside it, so the closest-drift tie-break already elects the
+  // same candidate. A *title* refinement is not redundant that way, because
+  // drift is what breaks the tie and drift knows nothing about titles.
+  const tiers: Array<(s: Scored) => boolean> = [
+    (s) => s.artistOk && s.titleOk,
+    // The right artist, and the right title once the qualifiers are off. Above
+    // the artist alone because otherwise a remaster-tagged title matches no
+    // tier at all and the clock chooses among an artist's own album tracks —
+    // which is how "Karma Police - Remastered" resolves to Lucky.
+    (s) => s.artistOk && s.looseOk,
+    (s) => s.artistOk,
     // Artist unverifiable — a translated credit. The clock is all that is left,
-    // and it is the tier that rescues CJK tracks from their own covers.
-    (c) => drift(c) <= DURATION_TOLERANCE_MS,
+    // and it is the tier that rescues CJK tracks from their own covers. It
+    // stays *above* the bare title on purpose: an exact title whose running
+    // time is 52s out is a cover, and the recording asked for is the one whose
+    // clock agrees. tests/preview.test.ts pins that ordering.
+    (s) => s.drift <= DURATION_TOLERANCE_MS,
     // Below here nothing ties the result to what was asked for, which is what
     // `requireVerified` refuses on a query that carried no artist upstream.
-    ...(options.requireVerified ? [] : [sameTitle, () => true]),
+    ...(options.requireVerified
+      ? []
+      : [(s: Scored) => s.titleOk, (s: Scored) => s.looseOk, () => true]),
   ];
 
   let match: Candidate | undefined;
   for (const inTier of tiers) {
-    const members = playable.filter(inTier);
+    const members = scored.filter(inTier);
     if (members.length === 0) continue;
     // `<` keeps the earlier candidate on a tie, so an all-unknown tier falls
     // back to the order upstream ranked them in.
-    match = members.reduce((best, c) => (drift(c) < drift(best) ? c : best));
+    match = members.reduce((best, s) => (s.drift < best.drift ? s : best)).c;
     break;
   }
 
@@ -859,9 +969,18 @@ async function askUpstream(query: QueryTarget): Promise<Resolution> {
   // the answer against. Without one it is also byte-identical to the query
   // above it, so the old flat list spent a second upstream call re-asking a
   // question it had just had answered.
+  // With no artist, the query above has already degraded to the bare title and
+  // the guarded follow-up is skipped as a duplicate — which quietly left the
+  // *unguarded* half as the only thing that ran, so a title-only search took
+  // upstream's best-ranked answer with nothing tying it to the request at all.
+  // The clock is the one check still available. Demand it when the caller sent
+  // one; when they did not, keep the old behaviour rather than manufacturing a
+  // week-long `absent` for a track that may well have a clip.
+  const titleOnly: SourceQuery = { q: track, requireVerified: Boolean(query.durationMs) };
+
   const viaItunes = await ask(
     "itunes",
-    [{ q: withArtist }, ...(artist ? [{ q: track, requireVerified: true }] : [])],
+    artist ? [{ q: withArtist }, { q: track, requireVerified: true }] : [titleOnly],
     ({ q, requireVerified }) => queryItunes(q, query, { requireVerified })
   );
   if (viaItunes) return viaItunes;
@@ -883,7 +1002,7 @@ async function askUpstream(query: QueryTarget): Promise<Resolution> {
           { q: withArtist },
           { q: track, requireVerified: true },
         ]
-      : [{ q: track }],
+      : [titleOnly],
     ({ q, requireVerified }) => queryDeezer(q, query, { requireVerified })
   );
   if (viaDeezer) return viaDeezer;

--- a/lib/round-token.ts
+++ b/lib/round-token.ts
@@ -1,0 +1,40 @@
+/**
+ * The rule that stops one round's async work from landing on the next round.
+ *
+ * It lives here rather than in `app/game/page.tsx` for the reason
+ * `lib/room-poll.ts` and `lib/song-count.ts` do: the suite reaches `lib/` and
+ * cannot import a `.tsx` module, so a rule left in the component is a rule with
+ * no test. This one was written there first, under a comment conceding exactly
+ * that — which is the argument for moving it, not for keeping it.
+ *
+ * The game page holds one `<audio>` element and one set of phase state across
+ * every round. Anything that awaits mid-round — resolving a preview, repairing
+ * a rotted URL — can come back after the host has pressed Skip Track or Reveal
+ * Answer, and whatever it writes then belongs to a round that is no longer on
+ * screen. That is round N's clip playing under round N+1's card, which is the
+ * bug this exists to prevent.
+ *
+ * `begin()` is called before the await and hands back the predicate that
+ * answers it. Capture-then-compare is a two-step rule and either step can be
+ * forgotten independently; returning the compare from the capture means a
+ * caller that remembered one has necessarily got the other.
+ */
+export interface RoundToken {
+  /** Retire the round on screen. Everything begun before this is now stale. */
+  bump(): void;
+  /** Call before an await. The result reports whether the round still owns it. */
+  begin(): () => boolean;
+}
+
+export function createRoundToken(): RoundToken {
+  let current = 0;
+  return {
+    bump() {
+      current += 1;
+    },
+    begin() {
+      const mine = current;
+      return () => mine === current;
+    },
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "guesssong",
-  "version": "1.6.0",
+  "version": "1.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "guesssong",
-      "version": "1.6.0",
+      "version": "1.7.5",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-label": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guesssong",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/tests/preview.test.ts
+++ b/tests/preview.test.ts
@@ -3,7 +3,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 import { GET } from "@/app/api/preview/route";
 import { POST } from "@/app/api/preview/batch/route";
-import type { PreviewResult, PreviewStatus } from "@/types/preview";
+import {
+  clampPreviewField,
+  PREVIEW_FIELD_MAX,
+  type PreviewResult,
+  type PreviewStatus,
+} from "@/types/preview";
 
 /**
  * Two things every test here is really about.
@@ -436,6 +441,451 @@ describe("a wrong recording is never accepted for a right title", () => {
     expect(await resultOf(res)).toEqual({ previewUrl: null, status: "absent" });
     expect(probe.itunesTerms()).toEqual(["Song"]);
     expect(probe.deezerTerms()).toEqual(["Song"]);
+  });
+});
+
+/**
+ * The two ways a candidate got tied to the request by a string that did not
+ * actually name it, both measured against the live iTunes API.
+ */
+describe("a credit has to name the act, not merely contain it", () => {
+  it("does not count a tribute act as the artist it is imitating", async () => {
+    // "Hello Adele Tribute" is the second result the real API returns for
+    // "Hello Adele". Whole-token containment read it as Adele, which put a
+    // tribute recording in the *strongest* tier holding the exact title — and
+    // the closest-drift tie-break then handed it the round.
+    installTermMock({
+      itunes: {
+        "Hello Adele": itunesResults(
+          {
+            trackName: "Hello",
+            artistName: "Hello Adele Tribute",
+            previewUrl: "https://itunes.example/tribute.m4a",
+            trackTimeMillis: 295502,
+          },
+          {
+            trackName: "Hello",
+            artistName: "Adele",
+            previewUrl: "https://itunes.example/adele.m4a",
+            trackTimeMillis: 296000,
+          }
+        ),
+      },
+    });
+
+    const res = await GET(
+      request({ track: "Hello", artist: "Adele", durationMs: "295502", id: "tribute-1" })
+    );
+
+    expect(await previewUrlFrom(res)).toBe("https://itunes.example/adele.m4a");
+  });
+
+  it("still counts a comma-billed collaborator as the same artist", async () => {
+    // The guest credit the check has to keep letting through, in the separator
+    // that is easiest to lose when containment is replaced by act matching.
+    installTermMock({
+      itunes: {
+        "One Kiss Calvin Harris": itunesResult(
+          "One Kiss",
+          "Calvin Harris, Dua Lipa",
+          "https://itunes.example/onekiss.m4a"
+        ),
+      },
+    });
+
+    const res = await GET(request({ track: "One Kiss", artist: "Calvin Harris", id: "credit-1" }));
+
+    expect(await previewUrlFrom(res)).toBe("https://itunes.example/onekiss.m4a");
+  });
+
+  it("ignores a leading The, which the two platforms disagree about", async () => {
+    installTermMock({
+      itunes: {
+        "Come Together Beatles": itunesResult(
+          "Come Together",
+          "The Beatles",
+          "https://itunes.example/beatles.m4a"
+        ),
+      },
+    });
+
+    const res = await GET(request({ track: "Come Together", artist: "Beatles", id: "credit-2" }));
+
+    expect(await previewUrlFrom(res)).toBe("https://itunes.example/beatles.m4a");
+  });
+
+  it("does not split an artist name on a separator letter of its own", async () => {
+    // The word boundaries on the alphabetic separators, which are the whole
+    // reason "x" is safe to treat as one. Drop them and "Charli XCX" becomes
+    // ["charli", "c"], which a tribute credit is then a superset of — the exact
+    // false positive this describe block exists to close, reintroduced.
+    installTermMock({
+      itunes: {
+        "Boom Clap Charli XCX": itunesResults(
+          {
+            trackName: "Boom Clap",
+            artistName: "Charli XCX Tribute",
+            previewUrl: "https://itunes.example/trib.m4a",
+            trackTimeMillis: 169000,
+          },
+          {
+            trackName: "Boom Clap",
+            artistName: "Charli XCX",
+            previewUrl: "https://itunes.example/real.m4a",
+            trackTimeMillis: 170000,
+          }
+        ),
+      },
+    });
+
+    const res = await GET(
+      request({ track: "Boom Clap", artist: "Charli XCX", durationMs: "169000", id: "sep-x" })
+    );
+
+    expect(await previewUrlFrom(res)).toBe("https://itunes.example/real.m4a");
+  });
+
+  it("counts a feat.-billed credit as the same artist", async () => {
+    // Both candidates carry the title, so the credit is what decides rather
+    // than the bare-title tier underneath it.
+    installTermMock({
+      itunes: {
+        "Work Rihanna": itunesResults(
+          {
+            trackName: "Work",
+            artistName: "Work Song Karaoke",
+            previewUrl: "https://itunes.example/karaoke.m4a",
+          },
+          {
+            trackName: "Work",
+            artistName: "Rihanna feat. Drake",
+            previewUrl: "https://itunes.example/work.m4a",
+          }
+        ),
+      },
+    });
+
+    const res = await GET(request({ track: "Work", artist: "Rihanna", id: "sep-feat" }));
+
+    expect(await previewUrlFrom(res)).toBe("https://itunes.example/work.m4a");
+  });
+
+  it("does not let a credit made only of separators match every artist", async () => {
+    // Artists named "X" exist. It splits to nothing, and `[].every(...)` is
+    // true — so without creditParts' fallback this candidate is billed as
+    // whoever you asked for, and its better running time wins the top tier.
+    installTermMock({
+      itunes: {
+        "Hello Adele": itunesResults(
+          {
+            trackName: "Hello",
+            artistName: "X",
+            previewUrl: "https://itunes.example/x.m4a",
+            trackTimeMillis: 295502,
+          },
+          {
+            trackName: "Hello",
+            artistName: "Adele",
+            previewUrl: "https://itunes.example/adele.m4a",
+            trackTimeMillis: 296502,
+          }
+        ),
+      },
+    });
+
+    const res = await GET(
+      request({ track: "Hello", artist: "Adele", durationMs: "295502", id: "sep-empty" })
+    );
+
+    expect(await previewUrlFrom(res)).toBe("https://itunes.example/adele.m4a");
+  });
+});
+
+describe("a qualifier one platform adds is not a different recording", () => {
+  it("keeps a remaster with its own song instead of leaving it to the clock", async () => {
+    // Spotify stores the remaster tag; iTunes returns the same recording under
+    // the plain title. The exact comparison then matched nothing, the pick fell
+    // through to the artist tier, and running time alone cannot tell a remaster
+    // from the album track sitting next to it.
+    installTermMock({
+      itunes: {
+        "Karma Police - Remastered 2011 Radiohead": itunesResults(
+          {
+            trackName: "Lucky",
+            artistName: "Radiohead",
+            previewUrl: "https://itunes.example/lucky.m4a",
+            trackTimeMillis: 262500, // 500ms out — inside the window
+          },
+          {
+            trackName: "Karma Police",
+            artistName: "Radiohead",
+            previewUrl: "https://itunes.example/karma.m4a",
+            trackTimeMillis: 261000, // 2s out — further away, and the right song
+          }
+        ),
+      },
+    });
+
+    const res = await GET(
+      request({
+        track: "Karma Police - Remastered 2011",
+        artist: "Radiohead",
+        durationMs: "263000",
+        id: "loose-1",
+      })
+    );
+
+    expect(await previewUrlFrom(res)).toBe("https://itunes.example/karma.m4a");
+  });
+
+  it("strips a feat. parenthetical the other platform leaves off", async () => {
+    // The higher-traffic of looseName's two passes: Spotify stores the credit
+    // in the title where iTunes returns the plain one. The right answer carries
+    // the *worse* running time, so the loose title is what elects it.
+    installTermMock({
+      itunes: {
+        "Sunflower (feat. Swae Lee) Post Malone": itunesResults(
+          {
+            trackName: "Circles",
+            artistName: "Post Malone",
+            previewUrl: "https://itunes.example/circles.m4a",
+            trackTimeMillis: 158100,
+          },
+          {
+            trackName: "Sunflower",
+            artistName: "Post Malone",
+            previewUrl: "https://itunes.example/sunflower.m4a",
+            trackTimeMillis: 155000,
+          }
+        ),
+      },
+    });
+
+    const res = await GET(
+      request({
+        track: "Sunflower (feat. Swae Lee)",
+        artist: "Post Malone",
+        durationMs: "158000",
+        id: "loose-feat",
+      })
+    );
+
+    expect(await previewUrlFrom(res)).toBe("https://itunes.example/sunflower.m4a");
+  });
+
+  it("strips only at a qualifier, never at the first hyphen in the title", async () => {
+    // "Hip-Hop Is Dead (Remastered)" once stripped to "Hip", which then matched
+    // any other Hip-something by the same artist — and because the loose tier
+    // outranks the artist tier, that beat the candidate whose running time
+    // agreed exactly. A wrong clip introduced by the fix for wrong clips.
+    installTermMock({
+      itunes: {
+        "Hip-Hop Is Dead - Remastered Nas": itunesResults(
+          {
+            trackName: "Hip-Hop (Live)",
+            artistName: "Nas",
+            previewUrl: "https://itunes.example/hiphop-live.m4a",
+            trackTimeMillis: 190000,
+          },
+          {
+            trackName: "Hip-Hop Is Dead",
+            artistName: "Nas",
+            previewUrl: "https://itunes.example/hiphop-is-dead.m4a",
+            trackTimeMillis: 240000,
+          }
+        ),
+      },
+    });
+
+    const res = await GET(
+      request({
+        track: "Hip-Hop Is Dead - Remastered",
+        artist: "Nas",
+        durationMs: "240000",
+        id: "loose-hyphen",
+      })
+    );
+
+    expect(await previewUrlFrom(res)).toBe("https://itunes.example/hiphop-is-dead.m4a");
+  });
+
+  it("does not match two titles that both strip to nothing", async () => {
+    // looseName("(Live)") is "", and so is looseName("(Remastered)"). Without
+    // the empty guard the remaster joins the loose tier and wins outright, a
+    // hundred seconds of drift notwithstanding.
+    installTermMock({
+      itunes: {
+        "(Live) Foo": itunesResults(
+          {
+            trackName: "(Remastered)",
+            artistName: "Foo",
+            previewUrl: "https://itunes.example/rem.m4a",
+            trackTimeMillis: 100000,
+          },
+          {
+            trackName: "Something Else",
+            artistName: "Foo",
+            previewUrl: "https://itunes.example/else.m4a",
+            trackTimeMillis: 199900,
+          }
+        ),
+      },
+    });
+
+    const res = await GET(
+      request({ track: "(Live)", artist: "Foo", durationMs: "200000", id: "loose-empty" })
+    );
+
+    expect(await previewUrlFrom(res)).toBe("https://itunes.example/else.m4a");
+  });
+});
+
+describe("an artist-less lookup still answers to something", () => {
+  it("holds it to the clock, which is the only check it has left", async () => {
+    // Nothing carried an artist upstream and nothing can check the answer
+    // against one, so this query used to take whatever upstream ranked first —
+    // and cache it as `found` for a year.
+    installTermMock({
+      itunes: {
+        Hello: itunesResults({
+          trackName: "Hello",
+          artistName: "Pinkfong",
+          previewUrl: "https://itunes.example/pinkfong.m4a",
+          trackTimeMillis: 96000,
+        }),
+      },
+    });
+
+    const res = await GET(request({ track: "Hello", durationMs: "295502", id: "noartist-1" }));
+
+    expect(await resultOf(res)).toEqual({ previewUrl: null, status: "absent" });
+  });
+
+  it("resolves when the running time does agree", async () => {
+    installTermMock({
+      itunes: {
+        Hello: itunesResults({
+          trackName: "Hello",
+          artistName: "Adele",
+          previewUrl: "https://itunes.example/adele.m4a",
+          trackTimeMillis: 295502,
+        }),
+      },
+    });
+
+    const res = await GET(request({ track: "Hello", durationMs: "295502", id: "noartist-2" }));
+
+    expect(await previewUrlFrom(res)).toBe("https://itunes.example/adele.m4a");
+  });
+
+  it("still answers when no running time was sent either", async () => {
+    // Nothing to verify against in either direction. Refusing here would
+    // manufacture a week-long `absent` for a track that may well have a clip,
+    // which is the more expensive of the two mistakes and the harder to see.
+    installTermMock({
+      itunes: { Hello: itunesResult("Hello", "Pinkfong", "https://itunes.example/pinkfong.m4a") },
+    });
+
+    const res = await GET(request({ track: "Hello", id: "noartist-3" }));
+
+    expect(await previewUrlFrom(res)).toBe("https://itunes.example/pinkfong.m4a");
+  });
+
+  it("holds a Deezer answer to the clock too, not just an iTunes one", async () => {
+    // Deezer is the last source before the answer settles as `absent` for a
+    // week, and its arm of the artist-less query is a separate line of code.
+    installTermMock({
+      deezer: {
+        Hello: {
+          data: [
+            {
+              preview: "https://deezer.example/pinkfong.mp3",
+              id: 1,
+              title: "Hello",
+              artist: { name: "Pinkfong" },
+              duration: 96,
+            },
+          ],
+        },
+      },
+    });
+
+    const res = await GET(request({ track: "Hello", durationMs: "295502", id: "dz-noartist-1" }));
+
+    expect(await resultOf(res)).toEqual({ previewUrl: null, status: "absent" });
+  });
+
+  it("accepts a Deezer answer whose whole-second clock agrees", async () => {
+    // Deezer reports seconds, so 295 against 295502ms is 502ms of quantisation
+    // drift. Inside the tolerance, and it must not read as a mismatch.
+    installTermMock({
+      deezer: {
+        Hello: {
+          data: [
+            {
+              preview: "https://deezer.example/adele.mp3",
+              id: 2,
+              title: "Hello",
+              artist: { name: "Adele" },
+              duration: 295,
+            },
+          ],
+        },
+      },
+    });
+
+    const res = await GET(request({ track: "Hello", durationMs: "295502", id: "dz-noartist-2" }));
+
+    expect(await previewUrlFrom(res)).toBe("https://deezer.example/adele.mp3");
+  });
+});
+
+/**
+ * lib/preview-cache.ts matches on these strings with regexes that are
+ * super-linear on pathological input, and both routes take them straight off
+ * the wire from an unauthenticated caller. enforceRateLimit fails open by
+ * design, so it is not a second line of defence here.
+ */
+describe("a field the caller controls is clamped before it reaches a regex", () => {
+  const pathological = "a" + " ".repeat(16000) + "b";
+
+  it("caps a field at PREVIEW_FIELD_MAX", () => {
+    expect(clampPreviewField("  " + "a".repeat(5000) + "  ")).toHaveLength(PREVIEW_FIELD_MAX);
+  });
+
+  it("clamps what the GET route sends upstream", async () => {
+    const probe = installTermMock({});
+
+    await GET(request({ track: pathological, artist: "Artist", id: "clamp-1" }));
+
+    expect(probe.itunesTerms().length).toBeGreaterThan(0);
+    for (const term of probe.itunesTerms()) {
+      expect(term.length).toBeLessThanOrEqual(PREVIEW_FIELD_MAX * 2 + 1);
+    }
+  });
+
+  it("does not cut a surrogate pair in half", async () => {
+    // A lone high surrogate makes encodeURIComponent throw, and the throw is
+    // inside the batch's Promise.all — one emoji on the boundary took all sixty
+    // tracks down with it, as a bare 500.
+    installTermMock({});
+
+    const res = await POST(
+      batchRequest([{ id: "clamp-3", name: "a".repeat(PREVIEW_FIELD_MAX - 1) + "😀", artist: "A" }])
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it("clamps the batch route the same way, or one key holds two answers", async () => {
+    const probe = installTermMock({});
+
+    await POST(batchRequest([{ id: "clamp-2", name: pathological, artist: "Artist" }]));
+
+    expect(probe.itunesTerms().length).toBeGreaterThan(0);
+    for (const term of probe.itunesTerms()) {
+      expect(term.length).toBeLessThanOrEqual(PREVIEW_FIELD_MAX * 2 + 1);
+    }
   });
 });
 

--- a/tests/round-token.test.ts
+++ b/tests/round-token.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { createRoundToken } from "@/lib/round-token";
+
+/**
+ * The guard behind app/game/page.tsx's "wrong audio" fix. The component half
+ * cannot be tested — vitest's include is tests/**\/*.test.ts and there is no
+ * React renderer here — so the rule itself is what gets pinned.
+ */
+describe("a resolution that lands after the host has moved on is dropped", () => {
+  it("rejects a result begun before the round was retired", () => {
+    const rounds = createRoundToken();
+    const stillMine = rounds.begin();
+    rounds.bump();
+    expect(stillMine()).toBe(false);
+  });
+
+  it("accepts a result whose round is still the one on screen", () => {
+    const rounds = createRoundToken();
+    expect(rounds.begin()()).toBe(true);
+  });
+
+  it("lets only the current round win when two are in flight", () => {
+    const rounds = createRoundToken();
+    const first = rounds.begin();
+    rounds.bump();
+    const second = rounds.begin();
+    expect([first(), second()]).toEqual([false, true]);
+  });
+
+  it("stays rejected however many rounds go by", () => {
+    // The comparison is identity, not "is the previous one" — a host who skips
+    // four times while one lookup is in flight must not have it come back true.
+    const rounds = createRoundToken();
+    const stillMine = rounds.begin();
+    for (let i = 0; i < 4; i++) rounds.bump();
+    expect(stillMine()).toBe(false);
+  });
+
+  it("gives each round its own answer", () => {
+    const a = createRoundToken();
+    const b = createRoundToken();
+    const inA = a.begin();
+    b.bump();
+    expect(inA()).toBe(true);
+  });
+});

--- a/types/preview.ts
+++ b/types/preview.ts
@@ -58,3 +58,30 @@ export interface PreviewBatchResponse {
  * knows will be refused.
  */
 export const PREVIEW_BATCH_MAX = 60;
+
+/**
+ * Ceiling on one `track` or `artist` string.
+ *
+ * Spotify's own fields sit far under this, so nothing real is truncated. It is
+ * here because lib/preview-cache.ts matches on these strings with regexes that
+ * are super-linear on pathological input — a run of spaces costs the credit
+ * splitter O(n²), measured at 141ms for 16k of them — and both preview routes
+ * take them straight off the wire. Bounding the input is the cheap half; the
+ * regexes are the expensive half to reason about, and the string is the part
+ * a caller controls. Same idea as PREVIEW_BATCH_MAX one line up: a cap at the
+ * boundary rather than a defence in every consumer.
+ */
+export const PREVIEW_FIELD_MAX = 300;
+
+/**
+ * Trim, then clamp. Both routes must agree, or one key holds two answers.
+ *
+ * By code point, not by `slice`. UTF-16 units cut a surrogate pair in half, and
+ * a lone high surrogate makes `encodeURIComponent` throw `URIError` — which in
+ * lib/preview-cache.ts happens inside the batch's `Promise.all`, so one emoji
+ * landing on the boundary cost all sixty tracks their previews and answered the
+ * bare 500 with no `code` that this project has been bitten by before.
+ */
+export function clampPreviewField(value: string): string {
+  return Array.from(value.trim()).slice(0, PREVIEW_FIELD_MAX).join("");
+}


### PR DESCRIPTION
## Summary

A player reported *"it was playing the wrong audio for my playlist."* There were
two independent causes, and neither is the one the report sounds like. The clip
and the answer card can disagree because the clip arrived late, or because it
was never the right recording.

**The late clip** (`73451b3`, `791a8df`) — `playClip` captured
`tracks[currentIndex]`, awaited `fetchPreview`, then assigned `audio.src` and
flipped the phase with no re-check. The "Skip Track" button is rendered *by that
await*, 1500ms in, so a host who tired of "Finding audio…" and skipped got round
N's clip under round N+1's card. The round does not even have to end: "Reveal
Answer" sits in the same loading state and only moves the phase, so the clip
could start underneath an answer the host had just given. Both `playClip` and
the refresh path now check round *and* phase after the await. The rule itself
moved to `lib/round-token.ts`, because the suite reaches `lib/` and cannot
import a `.tsx` module — the same reason `lib/room-poll.ts` and
`lib/song-count.ts` live there.

**The wrong recording** (`e2971e4`) — three picker bugs, each measured against
the live iTunes API rather than inferred:
- `"Hello Adele Tribute"` is the *second* result for "Hello Adele", and
  whole-token containment read it as Adele — so a tribute recording holding the
  exact title landed in the strongest tier and won on running time. Open as a
  known gap since 1.2.0.
- Spotify stores `"Karma Police - Remastered 2011"`; iTunes returns the same
  recording as plain `"Karma Police"`. Neither matched, the pick fell to the
  artist tier, and running time cannot tell a remaster from the album track
  beside it — it resolved to *Lucky*.
- With no artist the query degrades to the bare title and the guarded follow-up
  is skipped as a duplicate, leaving the *unguarded* half as the only thing that
  ran: upstream's top hit, tied to nothing, cached as `found` for a year.

**Input clamping** (`7ea71f6`) — the matching above is regex work on strings
that arrive straight off the wire from an unauthenticated caller, and two of
those regexes are super-linear on pathological input (16k spaces measured at
141ms per credit split, once per candidate per tier). Both preview routes now
clamp `track` and `artist` to `PREVIEW_FIELD_MAX`, by code point rather than
`slice` — half a surrogate pair makes `encodeURIComponent` throw, inside the
batch's `Promise.all`.

**Deliberately not changed:** the tier order. `tests/preview.test.ts` pins that
a running time outranks a bare title, because an exact title 52s off the clock
is a cover and the recording asked for is the one whose clock agrees. An earlier
draft of this branch reordered them and broke that test; the current order is
the considered one.

## Test Coverage

Tests: **567 → 591 (+24)**, 32 files.

Every new behaviour is pinned by a test that was verified to **fail without the
fix** — not merely to pass with it. Mutation-checked individually: the tribute
credit, the `\b` separator boundaries, `creditParts`' empty fallback, the
qualifier over-strip, the route clamp, and the surrogate slice.

Not covered: whether `app/game/page.tsx` *calls* the round token correctly.
`vitest.config.ts` includes only `tests/**/*.test.ts` and there is no React
renderer here, so the rule is tested in `lib/` and the wiring is enforced by
construction — `retireRound()` is the single teardown.

## Pre-Landing Review

6 reviewers (testing, maintainability, security, performance, design, red team),
**26 findings, 5 critical** — 23 fixed in-branch, 3 recorded rather than fixed.

The two that mattered most were both self-inflicted and caught before landing:
- **`reveal()` never bumped the round token**, and "Reveal Answer" is rendered
  by the loading state itself — the same wrong-audio bug through the other door.
- **The new qualifier-strip regex truncated at the first hyphen**:
  `looseName("Hip-Hop Is Dead (Remastered)")` returned `"hip"`, and with the
  loose tier above the artist tier that collapse *outranked* a candidate whose
  running time agreed to the millisecond. A new wrong-clip path opened by the
  fix for wrong clips. Anchored properly and pinned by a regression test.

Also fixed: `handleAudioError` missing the same phase guard; the Quit button
leaving a clip playing over the setup page through an unmounted element; a
write-only ref; a stale comment claiming parity with `mixed-playlist.ts`'s
`fingerprint()` that was never true; a `/g` flag making a shared regex stateful
for `.test()`; and per-candidate work recomputed once per tier.

**Recorded, not fixed** (all in `CHANGELOG.md` "Known gaps"):
- Entries written by the old picker are still served — year-long TTL,
  unversioned key, and `&refresh=1` re-confirms the stored `itunesTrackId`
  rather than re-picking. Worse for this bug specifically: a wrong-but-playable
  URL never fires the `<audio>` error that triggers refresh at all. **So this PR
  reaches only tracks nobody has played yet.** Re-picking them needs the
  picker-generation stamp described at `lib/preview-cache.ts:127` and its own
  admission budget.
- A caller-supplied `durationMs` with an empty artist can now reach a 7-day
  `absent` where before it would have taken any playable result. Judged the
  smaller half of a door that is already open (the caller picks its own cache
  key and metadata), and left alone rather than changing the module's
  `absent`/`unavailable` semantics inside a bug fix.
- CJK is one signal deep: for 小幸運 / 田馥甄 the API translates *both* title and
  credit, so running time is all that is left and the correct track sits 768ms
  from a sibling. Correct today; nothing else is holding it up.

## Design Review

Design review (lite): 3 findings — 3 fixed, 0 skipped. One was the critical
`reveal()` race above. No visual changes in this PR.

## Eval Results

No prompt-related files changed — evals skipped.

## Plan Completion

No plan file detected.

## Verification

`npm test` 591 passing · `npm run lint` clean · `npm run build` compiles, and
the route table still shows `/icon` and `/opengraph-image` as `○` with
`/icons/[size]` as `●` (the static-generation invariant in CLAUDE.md).

All five commits typecheck independently, so the branch stays bisectable.

## Documentation

Two commits: `8420b4b` (the release's own doc updates) and `ff5ffb5` (two stale
claims an independent review pass caught).

- **CLAUDE.md** — new section **A round's async work must not land on the next
  round**: why the rule lives in `lib/`, why `begin()` hands back its own
  comparison, `retireRound()` as the single teardown, and why the phase must be
  re-read *after* the await. The preview hazard list grew from four bullets to
  seven, covering `artistMatches`, `QUALIFIER_SUFFIX`'s anchoring and the field
  clamp both routes must agree on.
- **README.md** — `Current version` was still **1.1.0** (nothing tests that
  line; `tests/changelog.test.ts` pins only `lib/changelog.ts`). Test counts
  31/567 → 32/591. Both preview route rows now state the 300-code-point clamp.
- **docs/architecture.md** — playlist cache positive TTL said **6h**;
  `HIT_TTL_SECONDS` is 24h, and CLAUDE.md already said so.
- **docs/operations.md** — the pre-PR checklist promised **351 tests**. §5 "A
  clip plays but the answer card disagrees" assumed a single cause; it now
  splits by whether the symptom reproduces — a late-landing preview versus a
  wrong recording cached for a year.

The version, TTL and test-count errors were pre-existing drift this release did
not cause.

### Documentation debt

- ⚠️ **README still documents Trial mode and the Built-in playlist source**,
  both removed from the code in 1.5.0 (`GAME_MODES = ["party", "buzzer"]`,
  `PLAYLIST_SOURCES = ["own", "mixed"]`). Left alone here: deleting table rows
  and a feature bullet is a judgment call, not a factual correction.
