### PR TITLE
v1.8.0 feat(guides): six new guides to answer the second AdSense low-value-content refusal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,96 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-08-30
+
+AdSense refused the site a second time under **缺乏價值的內容** (Low value
+content) — the same code as 2026-08-21, now with the 1.7.0 compliance work
+already live. So compliance was never the gap.
+
+What the live site actually looks like to a reviewer was measured rather than
+assumed: 17 indexable URLs, guides rendering 1,130–1,480 words each, policy
+pages linked from `components/site-footer.tsx` on every page, `ads.txt`
+agreeing with `NEXT_PUBLIC_ADSENSE_CLIENT_ID`, canonicals and `Article`
+JSON-LD present, nothing content-shaped in `app/robots.ts`. All of that is
+fine and none of it was worth redoing.
+
+The gap is **editorial volume**, and the benchmark that matters is the one for
+tool and utility sites rather than for blogs: a tool site is expected to carry
+its own supporting library, because a reviewer samples the tool page and will
+not accept UI as the site. Eight articles sits below that band. Fourteen is
+inside it.
+
+### Added
+
+- **Six guides, taking `lib/guides.ts` from eight to fourteen.** Each is
+  1,045–1,373 words of source prose and declared once, as the module's header
+  requires — the route, the `/guides` index, `app/sitemap.ts` and the sibling
+  "read next" links all derive from the entry rather than being hand-synced.
+
+  | Slug | Category |
+  |---|---|
+  | `guess-the-song-game-rules` | Playing |
+  | `music-quiz-round-ideas` | Hosting |
+  | `music-quiz-over-video-call` | Hosting |
+  | `music-quiz-for-large-groups` | Hosting |
+  | `songs-with-no-preview-clip` | Troubleshooting |
+  | `music-quiz-licensing-and-previews` | Troubleshooting |
+
+  Two of them are the ones this project can write and nobody else can.
+  `songs-with-no-preview-clip` is `lib/preview-cache.ts`'s hazard list turned
+  outward — the remaster suffix, the differently-credited artist, the rotated
+  CDN URL, and the `absent`/`unavailable` collapse that marked a slice of the
+  catalogue silent for a week — written for the host who sees one quiet track
+  and assumes a bug. `music-quiz-over-video-call` is the audio problem stated
+  properly: voice processing dismantles music by design, and network delay
+  makes first-to-answer a measurement of connection quality, which retires the
+  base game's central rule rather than merely inconveniencing it. That is what
+  "information gain" has to mean here; eight more listicles would have been
+  the thin filler the rejection is about.
+
+### Changed
+
+- **The eight existing guides' `related` arrays were rewired so every new
+  article has an inbound link from an established one**, not only from its
+  five siblings. `tests/guides.test.ts` asserts each guide has *an* inbound
+  link, which the six would have satisfied by pointing at each other — and
+  that is exactly the shape Google reaches last. The rewiring keeps the count
+  at three per guide, so nothing about the rendered block changes.
+- **`HOME_GUIDES` in `app/page.tsx` takes a fourth slot**, and the comment now
+  says why: the homepage is the highest-authority page on the site and the
+  only inbound link that reliably gets a new article crawled. The count was
+  previously written into the comment beside it ("not all eight"), which went
+  stale the moment a guide was added — it is stated as a rule now instead of a
+  number.
+- **`tests/guides.test.ts` now pins that list too.** Nothing covered it, and
+  its `.filter(Boolean)` makes a typo indistinguishable from a deliberately
+  retired guide: the card just stops rendering. That is the silent-drift class
+  every other assertion in the file exists to catch, on the one link that gets
+  a new article crawled. Read as source text, because the suite cannot import
+  a `.tsx` module here — the same technique the "wires each page to its own
+  slug" assertion already uses.
+
+### Known gaps
+
+- **The re-review is still filed by hand**, and this is the second time that
+  has been the last mile. AdSense allows a limited number of appeals before
+  the cooldown between them lengthens, so this one should not be spent early:
+  the research is consistent that publishing and applying the same day is its
+  own failure, and the 1.7.0 appeal was filed against pages Google had barely
+  seen. Give the six articles two weeks to be crawled — confirm in Search
+  Console that they are indexed, not merely submitted — and file after that.
+- **A `site:guessong.app` query on 2026-08-30 returned only `/` and `/about`.**
+  Search-API `site:` results are not authoritative and this is not proof the
+  guides are unindexed, but it is the one signal that would explain a refusal
+  of a site whose content is genuinely there. Search Console's Pages report is
+  the instrument that answers it, and it is the thing to open before appealing
+  again.
+- **The tool page itself was left alone.** The tool-site guidance is explicit
+  that reviewers sample it directly and that UI-only pages sink an application;
+  `/` currently renders ~750 words plus an FAQ, which is adequate rather than
+  strong. If a third refusal arrives with fourteen indexed guides behind it,
+  the homepage is the next lever, not more articles.
+
 ## [1.7.5] - 2026-08-25
 
 A player wrote in: *"it was playing the wrong audio for my playlist."*

--- a/app/guides/guess-the-song-game-rules/page.tsx
+++ b/app/guides/guess-the-song-game-rules/page.tsx
@@ -1,0 +1,215 @@
+import type { Metadata } from "next";
+import { GuideShell, guideMetadata } from "@/app/guides/guide-shell";
+
+const SLUG = "guess-the-song-game-rules";
+
+export const metadata: Metadata = guideMetadata(SLUG);
+
+export default function Page() {
+  return (
+    <GuideShell slug={SLUG}>
+      <p>
+        “Guess the song” is not one game. It is a family of games that share a clip of
+        music and disagree about everything else — who is allowed to answer, when they are
+        allowed to answer, and what counts as having answered. Most arguments at a quiz
+        night are not about music. They are about one of those three questions, asked for
+        the first time in the middle of a round.
+      </p>
+      <p>
+        So here is the base game written out properly, then the nine variants worth
+        knowing, then the four house rules that stop the arguments before they start.
+      </p>
+
+      <h2>The base game</h2>
+      <p>
+        One person hosts and does not play. Everyone else sits where they can hear. The
+        host plays a short clip from a random song — five to thirty seconds, chosen in
+        advance — and the room shouts the title. First correct answer takes the points.
+        The host is the judge and the judge is final.
+      </p>
+      <p>That is genuinely all of it. The scoring most groups converge on:</p>
+      <ul>
+        <li>
+          <strong>3 points for the title.</strong> This is the game. It should be worth
+          enough that nothing else can overtake it.
+        </li>
+        <li>
+          <strong>1 point for the album.</strong> A bonus for the person who knows the
+          record rather than the single. Awarded on top of the title point, to whoever
+          says it first — not necessarily the same person.
+        </li>
+        <li>
+          <strong>Nothing for the artist.</strong> Counter-intuitive, and the single most
+          common house-rule addition. It is worth resisting: the artist is usually easier
+          than the title, so paying for it rewards the guess people were going to make
+          anyway and slows the round down while everyone lists names.
+        </li>
+      </ul>
+      <p>
+        More on why those particular numbers, and what happens to a room when they are
+        wrong, in{" "}
+        <a href="/guides/music-quiz-scoring-rules">scoring a music quiz</a>.
+      </p>
+
+      <h2>Why shouting beats typing</h2>
+      <p>
+        Almost every digital version of this game asks players to type the answer. It is
+        the obvious design and it is worse than shouting, for three reasons that only show
+        up once real people are playing.
+      </p>
+      <p>
+        Typing turns a social game into fourteen people looking at their own phones.
+        Autocorrect converts near-misses into wrong answers and correct answers into
+        nonsense. And exact string matching cannot tell that “Bohemian Rhapsody”,
+        “bohemian rapsody” and “the Bohemian Rhapsody one” are the same answer, so the
+        game either rejects people who knew it or accepts people who did not.
+      </p>
+      <p>
+        A human host resolves all three instantly and for free. The cost is that you need
+        a host, which is why the base game has one.
+      </p>
+
+      <h2>Nine variants</h2>
+      <p>
+        Each of these changes exactly one of the three questions — who answers, when, or
+        what counts. Mixing two at once usually produces a mess, so introduce them one at
+        a time.
+      </p>
+
+      <h3>1. Buzzers</h3>
+      <p>
+        Instead of shouting, players buzz and the first buzz gets the floor. Fixes the
+        chronic problem of the base game: in a loud room, the loudest voice wins ties, and
+        the loudest voice is a personality trait rather than a skill. Costs you the
+        overlapping chaos that makes shouting fun. Best for competitive groups and for any
+        game where the result is meant to be taken seriously.
+      </p>
+
+      <h3>2. Written rounds</h3>
+      <p>
+        Everyone writes their answer down and they are all revealed at the end of the
+        round. Nobody is knocked out by being slow, so a room of very unequal knowledge
+        stays engaged. It is also the only variant that works reliably over a{" "}
+        <a href="/guides/music-quiz-over-video-call">video call</a>, where audio delay
+        makes “first to answer” meaningless. Slower, and much less loud.
+      </p>
+
+      <h3>3. Teams</h3>
+      <p>
+        Two to five people per team, one nominated shouter. Halves the number of
+        answering units, which is what makes a large room workable at all — see{" "}
+        <a href="/guides/music-quiz-for-large-groups">running a quiz for twenty people or
+        more</a>. Also quietly solves the confidence problem: people who would never shout
+        alone will happily tell their team.
+      </p>
+
+      <h3>4. Finish the lyric</h3>
+      <p>
+        The host stops the clip mid-line and the room completes it. Tests a completely
+        different kind of knowledge from title recall — people who are bad at names are
+        often excellent at this — so it is the best single round to add if one player
+        keeps winning everything.
+      </p>
+
+      <h3>5. Speed round</h3>
+      <p>
+        Very short clips, no album points, no discussion, next song the instant someone is
+        right or five seconds pass. Run six or eight of these back to back as a finale.
+        The point is not difficulty, it is tempo: it makes the end of the night feel
+        different from the middle of it.
+      </p>
+
+      <h3>6. Whose playlist is it?</h3>
+      <p>
+        Every player submits their own music, the pool is shuffled together, and the
+        question becomes “who in this room put this on a playlist”. The best variant in
+        the family, because the answer is about the people in the room rather than about
+        pop music, so knowing less music costs you almost nothing.{" "}
+        <a href="/guides/mixed-playlist-mode-guide">How to run it, and how to read the
+        results.</a>
+      </p>
+
+      <h3>7. Humming and a cappella</h3>
+      <p>
+        No recording at all: one player hums or sings a song and the rest guess.
+        Requires nothing, works in a car, and is the only variant on this list that
+        survives a dead phone battery. Also much harder than it sounds — most people
+        cannot hum a song they know perfectly well.
+      </p>
+
+      <h3>8. Song association</h3>
+      <p>
+        The host says a word and players take turns singing a line containing it. No
+        repeats, no hesitating; last person still going wins. Barely a quiz, closer to a
+        party game, and unusually good with a group where some people know nothing about
+        current music — everyone has a few hundred song lines in them.
+      </p>
+
+      <h3>9. Blind decade</h3>
+      <p>
+        Nobody names the song. Everyone writes down the year, or the decade, and the
+        closest guess scores. Turns unfamiliar music into a playable round, which means
+        you can finally use the playlist nobody in the room knows.
+      </p>
+
+      <div className="callout">
+        <p className="callout-title">Adding a variant mid-game</p>
+        <p>
+          Announce it before the clip, not after. A rule introduced after a song has
+          played is a rule that changes who won that song, and the room will notice even
+          if nobody says anything.
+        </p>
+      </div>
+
+      <h2>The four house rules worth deciding in advance</h2>
+      <p>
+        These are the actual sources of every argument. Deciding them takes thirty seconds
+        at the start and saves you the same conversation four times.
+      </p>
+      <ol>
+        <li>
+          <strong>Partial titles.</strong> Does “Bohemian” get “Bohemian Rhapsody”? The
+          workable rule is that a partial counts if it could not be any other song, and
+          the host decides on the spot. Most groups are far more generous than they expect
+          to be, and the game is better for it.
+        </li>
+        <li>
+          <strong>Phones.</strong> Either everyone can look things up or nobody can. The
+          middle position — technically banned, quietly tolerated — is the worst one,
+          because it punishes the honest. Most groups ban them; a group with a big
+          knowledge gap sometimes plays with them on for everyone.
+        </li>
+        <li>
+          <strong>Shouting over the clip.</strong> Decide whether the music stops on the
+          first answer or plays out. Stopping is faster and more competitive. Playing out
+          means the person who was two seconds behind still gets to enjoy the song, which
+          matters more than it sounds at a party.
+        </li>
+        <li>
+          <strong>The host.</strong> One person, all night, not playing — or rotating
+          every ten songs so everyone gets to play. Rotating is fairer and slower.
+          Whichever you choose, say so at the start, because a host who was expecting to
+          rotate and does not will spend the evening feeling like the help.
+        </li>
+      </ol>
+
+      <h2>What the rules cannot fix</h2>
+      <p>
+        A game where one person wins every round is not a rules problem, and no scoring
+        variant will rescue it. It is almost always a playlist problem — the music is from
+        one person’s era, or one person’s genre, and everyone else is guessing.{" "}
+        <a href="/guides/best-playlists-for-a-guess-the-song-game">
+          Choosing a playlist that spreads the knowledge around
+        </a>{" "}
+        does more for a close game than every rule on this page put together.
+      </p>
+      <p>
+        The second most common failure is a difficulty setting nobody adjusted.{" "}
+        <a href="/guides/clip-length-and-difficulty">
+          Clip length is the dial for that
+        </a>
+        , and it is meant to be moved during the night rather than chosen once.
+      </p>
+    </GuideShell>
+  );
+}

--- a/app/guides/music-quiz-for-large-groups/page.tsx
+++ b/app/guides/music-quiz-for-large-groups/page.tsx
@@ -1,0 +1,196 @@
+import type { Metadata } from "next";
+import { GuideShell, guideMetadata } from "@/app/guides/guide-shell";
+
+const SLUG = "music-quiz-for-large-groups";
+
+export const metadata: Metadata = guideMetadata(SLUG);
+
+export default function Page() {
+  return (
+    <GuideShell slug={SLUG}>
+      <p>
+        A music quiz that works beautifully for eight people does not scale to thirty by
+        adding twenty-two more chairs. It breaks — reliably, in the same three places —
+        and the breakages are structural rather than a matter of the host trying harder.
+      </p>
+      <p>
+        The good news is that all three have the same fix, and it is not the one most
+        hosts reach for first.
+      </p>
+
+      <h2>What actually breaks</h2>
+      <p>
+        <strong>Nobody can hear who answered.</strong> With eight people, one voice is
+        distinguishable from the rest. With twenty-five, four people shout the same title
+        within half a second and the host is guessing at the order. Every award becomes a
+        small injustice, and after the fourth one the room stops treating the score as
+        real.
+      </p>
+      <p>
+        <strong>Most people never answer at all.</strong> This is the killer. In a big
+        room, the same five or six confident people take almost everything, and the other
+        twenty spend the night as an audience. They are not bored of the music — they are
+        bored because they have no route into the game.
+      </p>
+      <p>
+        <strong>The scoreboard becomes admin.</strong> Twenty-five individual scores is a
+        spreadsheet, not a party. Reading it aloud takes ninety seconds and nobody can
+        hold their own position in their head, so nobody knows whether they are doing
+        well, and the whole competitive frame quietly stops working.
+      </p>
+
+      <h2>The fix is teams, and it is not close</h2>
+      <p>
+        Hosts usually try to fix the first problem — buzzers, hands up, a strict
+        one-at-a-time rule. It helps a little and does nothing about the other two.
+      </p>
+      <p>
+        Teams fix all three at once. They reduce twenty-five answering voices to five,
+        which makes the host’s job possible again. They give the quiet twenty a place to
+        contribute where the stakes are a conversation with three people rather than a
+        declaration to the entire room. And five scores is a scoreboard a person can hold
+        in their head.
+      </p>
+      <p>The sizing that works:</p>
+      <ul>
+        <li>
+          <strong>13–20 people: teams of three or four.</strong> Four to five teams. Small
+          enough that everybody in a team speaks.
+        </li>
+        <li>
+          <strong>20–35 people: teams of four or five.</strong> Five to seven teams. Past
+          seven teams you are back to a scoreboard nobody can follow.
+        </li>
+        <li>
+          <strong>35+: teams of five or six, and shorter rounds.</strong> Also a second
+          host, purely to watch one half of the room.
+        </li>
+      </ul>
+      <p>
+        <strong>Never go above six per team.</strong> At seven, the quietest two stop
+        talking even within their own team, which reproduces the original problem one
+        level down.
+      </p>
+
+      <div className="callout">
+        <p className="callout-title">Split people up, do not let them self-select</p>
+        <p>
+          Teams that form themselves are teams of friends who arrived together, which
+          concentrates the music knowledge and defeats the point. Count off around the
+          room — one, two, three, four, one, two — and let the arbitrariness do the work.
+          It is also the fastest way to get a room of people who half know each other
+          talking.
+        </p>
+      </div>
+
+      <h2>One nominated voice per team</h2>
+      <p>
+        Each team picks one person who is allowed to call out the answer. Everyone else
+        talks to their own table. This is the rule that makes a big room quiet enough to
+        run, and it has a second effect worth knowing about: it converts the loudest
+        person in each team from an advantage into a job, which is a much better use of
+        them.
+      </p>
+      <p>
+        Rotate the nominated voice every few rounds. Otherwise you have rebuilt the
+        original problem at team scale — five confident people playing, twenty listening.
+      </p>
+
+      <h2>Scoring changes for a big room</h2>
+      <p>
+        The standard structure — three points for the title, one for the album — still
+        works, but two adjustments matter more at scale than they do at a table of eight.
+        The reasoning behind the base numbers is in{" "}
+        <a href="/guides/music-quiz-scoring-rules">scoring a music quiz</a>.
+      </p>
+      <ul>
+        <li>
+          <strong>Announce scores every round, briefly.</strong> Five team totals, ten
+          seconds. Not a leaderboard read-out — just enough that every table knows whether
+          they are in it. A room that does not know the score is a room that is no longer
+          playing.
+        </li>
+        <li>
+          <strong>Keep the gaps small and the rounds many.</strong> Big rooms need more
+          frequent scoring events, not bigger ones. Twelve small rounds hold a crowd far
+          better than four large ones, because the reset comes often enough that a bad
+          patch does not end anybody’s night.
+        </li>
+      </ul>
+
+      <h2>Two logistics problems that only exist at scale</h2>
+      <p>
+        <strong>Everyone needs to hear the same thing at the same time.</strong> One
+        laptop speaker does not cover thirty people. If you cannot get the audio to the
+        back of the room, the back of the room is not playing — and they will be polite
+        about it rather than tell you. Test from the furthest seat before you start, not
+        from where you are standing.
+      </p>
+      <p>
+        <strong>Sight lines to the host matter more than you think.</strong> The host is
+        the judge, so every team needs to be able to see who is being awarded points. A
+        long room with the host at one end produces a far-end table that has stopped
+        believing in the scoring by round three.
+      </p>
+
+      <h2>Rounds that scale, and rounds that do not</h2>
+      <p>
+        Anything decided by speed gets worse as the room grows, because more people racing
+        means more ties and more disputed calls. Anything written gets better, because it
+        removes the race entirely.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Round</th>
+            <th>At 25+ people</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Written answers</strong></td>
+            <td>Best format available. Every team plays every song; no ties to arbitrate.</td>
+          </tr>
+          <tr>
+            <td><strong>Finish the lyric</strong></td>
+            <td>Excellent. A whole table can work on it together, out loud.</td>
+          </tr>
+          <tr>
+            <td><strong>Whose playlist is it?</strong></td>
+            <td>
+              Strong, but sample fewer songs per person or the pool gets unwieldy —{" "}
+              <a href="/guides/mixed-playlist-mode-guide">see the guide</a>.
+            </td>
+          </tr>
+          <tr>
+            <td><strong>First to shout</strong></td>
+            <td>Use sparingly, and only with nominated voices. Chaos otherwise.</td>
+          </tr>
+          <tr>
+            <td><strong>Speed round</strong></td>
+            <td>Only as a finale, only written. Live shouting at this size is unjudgeable.</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Twelve round formats and what each one does to a room are in{" "}
+        <a href="/guides/music-quiz-round-ideas">the round ideas guide</a>. If your group
+        is at the other end of the scale, the failure modes invert completely —{" "}
+        <a href="/guides/party-games-for-small-groups">
+          small groups have an elimination problem rather than a participation one
+        </a>
+        .
+      </p>
+
+      <h2>The one thing worth over-preparing</h2>
+      <p>
+        Have more songs ready than you need, and know which ones you would cut. A big room
+        runs faster than a small one — teams answer in parallel, so the same number of
+        songs takes less time — and a host who runs out of material at a party of thirty
+        cannot quietly improvise the way they could at a table of eight. Prepare for a
+        night that is thirty per cent shorter than you planned, and keep the wildcard
+        round in your pocket for when it is not.
+      </p>
+    </GuideShell>
+  );
+}

--- a/app/guides/music-quiz-licensing-and-previews/page.tsx
+++ b/app/guides/music-quiz-licensing-and-previews/page.tsx
@@ -1,0 +1,207 @@
+import type { Metadata } from "next";
+import { GuideShell, guideMetadata } from "@/app/guides/guide-shell";
+
+const SLUG = "music-quiz-licensing-and-previews";
+
+export const metadata: Metadata = guideMetadata(SLUG);
+
+export default function Page() {
+  return (
+    <GuideShell slug={SLUG}>
+      <p>
+        Almost nobody running a music quiz in their living room needs to think about
+        licensing. Almost everybody running one in a pub, a classroom, an office or a
+        club already has the question answered for them by somebody else. The awkward
+        cases sit between those two, and the useful thing is knowing which one you are in
+        before you plan a night around it.
+      </p>
+
+      <div className="callout">
+        <p className="callout-title">This is orientation, not legal advice</p>
+        <p>
+          Music licensing is national law plus private contract, and both differ by
+          country and change over time. What follows is a map of the questions and who
+          answers them, so you know what to ask. For anything with money or a venue
+          attached, ask the venue and the relevant collecting society in your country.
+        </p>
+      </div>
+
+      <h2>The three separate questions</h2>
+      <p>
+        People collapse these into one and then get confused, because the answers point in
+        different directions.
+      </p>
+      <ol>
+        <li>
+          <strong>Is this a public performance?</strong> Playing recorded music to a
+          gathering that is not your household or close social circle is generally treated
+          as a public performance in most jurisdictions, and public performance is
+          licensed.
+        </li>
+        <li>
+          <strong>Who holds that licence?</strong> Almost always the venue, not you. Pubs,
+          bars, restaurants, hotels, schools, gyms and most workplaces hold blanket
+          licences from collecting societies precisely so that the people inside them do
+          not have to think about this.
+        </li>
+        <li>
+          <strong>Do the terms of the service you are using allow it?</strong> A separate
+          question, governed by a contract rather than by copyright law, and the one people
+          almost never check.
+        </li>
+      </ol>
+      <p>
+        Question three is the one worth reading the rest of this page for, because it is
+        where the answer is least intuitive.
+      </p>
+
+      <h2>Where the collecting societies come in</h2>
+      <p>
+        Recorded music generally carries two rights that need clearing for public
+        performance: the composition and the recording. In most countries one or two
+        organisations collect for these on behalf of rights holders and sell blanket
+        licences that cover a venue’s whole catalogue use.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Where</th>
+            <th>Who to ask</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>United Kingdom</strong></td>
+            <td>PPL PRS (a joint licence covering both rights)</td>
+          </tr>
+          <tr>
+            <td><strong>United States</strong></td>
+            <td>ASCAP, BMI, SESAC, GMR — compositions; recordings differ by use</td>
+          </tr>
+          <tr>
+            <td><strong>Elsewhere</strong></td>
+            <td>
+              Nearly every country has an equivalent. Search for your country plus
+              “performing rights organisation”.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        The practical shape of this: <strong>if you are a guest in a licensed venue, the
+        licence is theirs and you are covered by it.</strong> If you are the venue — you
+        are running a quiz night in a space you operate, or charging admission — the
+        question is yours and you should be talking to the society directly rather than
+        reading a page like this one.
+      </p>
+
+      <h2>Private gatherings</h2>
+      <p>
+        A quiz at home for friends is the case everybody actually has, and it is the
+        uncontroversial one: playing music at a private social gathering in your own home
+        is not what public performance licensing is aimed at. Nobody is coming for your
+        living room.
+      </p>
+      <p>
+        The edges get blurrier as the gathering gets less private — a large party in a
+        rented hall, a charity fundraiser, a public event advertised to strangers. The
+        useful test is not headcount, it is whether the group is meaningfully a private
+        social circle. If you are advertising it, charging for it, or holding it in a
+        space you booked, treat it as public and ask the venue what they hold.
+      </p>
+
+      <h2>What a thirty-second preview actually is</h2>
+      <p>
+        Here is the part that is specific to how these apps work, and where the common
+        assumption is wrong in both directions.
+      </p>
+      <p>
+        Music services publish short promotional clips through their public search APIs —
+        Apple and Deezer both do, and Spotify used to. These exist to let you preview
+        something before deciding to listen to it, and the API terms typically permit
+        using them for that <em>promotional</em> purpose, often with conditions attached:
+        attribution, links back to the store, no downloading or redistributing the file,
+        no building something that substitutes for the service itself.
+      </p>
+      <p>
+        Two things follow, and they are the useful ones:
+      </p>
+      <ul>
+        <li>
+          <strong>A preview clip is not a licence to perform the song publicly.</strong>{" "}
+          The API terms and the performance right are unrelated questions. Using a legally
+          obtained clip in a licensed venue is fine; using one at a public event with no
+          licence is not made fine by the clip having come from an official API.
+        </li>
+        <li>
+          <strong>Nor is a short clip automatically fair use or fair dealing.</strong>{" "}
+          “Under thirty seconds is allowed” is folklore. There is no duration below which
+          use is automatically permitted, in any major jurisdiction. Short clips are
+          usually fine in practice for reasons that have nothing to do with a magic number.
+        </li>
+      </ul>
+      <p>
+        The reason games are built on preview APIs rather than on full tracks is more
+        mundane than either: previews are what a service will actually hand to an
+        application without a user login and a commercial agreement.{" "}
+        <a href="/guides/why-spotify-previews-disappeared">
+          What happened when one of them stopped.
+        </a>
+      </p>
+
+      <h2>Three situations, three answers</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>You are</th>
+            <th>What to do</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>At home with friends</strong></td>
+            <td>Nothing. Play the game.</td>
+          </tr>
+          <tr>
+            <td><strong>In a pub, office, school or gym</strong></td>
+            <td>
+              Ask whoever runs the space whether they hold a music licence. They almost
+              certainly do, and it is a thirty-second conversation.
+            </td>
+          </tr>
+          <tr>
+            <td><strong>Running a public or ticketed event</strong></td>
+            <td>
+              Contact the collecting society for your country before you plan the night.
+              This is the case where getting it wrong has a cost.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Two things that are not the same as licensing</h2>
+      <p>
+        <strong>Streaming service terms of use.</strong> Consumer subscriptions are
+        generally personal-use only, which is a contractual restriction between you and
+        the service. Businesses playing music are usually expected to use a commercial
+        background-music service instead. This is separate from performance licensing and
+        both can apply at once.
+      </p>
+      <p>
+        <strong>Recording or streaming your quiz.</strong> A quiz night posted to a video
+        platform is a different use again, with its own rules, and it is where automated
+        content matching will find you regardless of anything on this page. If you are
+        recording, assume the music in it is a problem and plan around that.
+      </p>
+      <p>
+        With the paperwork question parked, the rest is just running a good night —{" "}
+        <a href="/guides/how-to-host-a-music-quiz-night">how to host a music quiz night</a>{" "}
+        covers the mechanics, and if your quiz is remote rather than in a room,{" "}
+        <a href="/guides/music-quiz-over-video-call">
+          the video-call guide
+        </a>{" "}
+        deals with a completely different set of problems.
+      </p>
+    </GuideShell>
+  );
+}

--- a/app/guides/music-quiz-over-video-call/page.tsx
+++ b/app/guides/music-quiz-over-video-call/page.tsx
@@ -1,0 +1,189 @@
+import type { Metadata } from "next";
+import { GuideShell, guideMetadata } from "@/app/guides/guide-shell";
+
+const SLUG = "music-quiz-over-video-call";
+
+export const metadata: Metadata = guideMetadata(SLUG);
+
+export default function Page() {
+  return (
+    <GuideShell slug={SLUG}>
+      <p>
+        A music quiz over a video call fails in a specific, predictable way, and it is
+        almost never the quiz’s fault. It is the audio. The host presses play, the room
+        hears something that sounds like a radio underwater, and half the guesses are
+        wrong for reasons that have nothing to do with knowing the song.
+      </p>
+      <p>
+        Two things cause it, both fixable in under a minute once you know what they are.
+        Then there is a third problem — delay — which is not fixable at all, and which
+        means one rule of the in-person game has to be thrown away.
+      </p>
+
+      <h2>Problem one: voice processing is destroying the music</h2>
+      <p>
+        Every video-call platform runs aggressive processing on your microphone by
+        default: noise suppression, echo cancellation, automatic gain control. All three
+        exist to make a human voice intelligible in a bad room, and all three are actively
+        hostile to music.
+      </p>
+      <p>
+        Noise suppression treats sustained non-speech sound as noise, which is a fair
+        description of a cymbal, a synth pad or a bassline. Automatic gain control ducks
+        the volume the moment anyone speaks. Echo cancellation removes whatever it thinks
+        it has heard before, which includes the loop the song is built on.
+      </p>
+      <p>
+        So if you play music into your microphone — phone speaker pointed at a laptop, or
+        just the song playing in the room — the platform will systematically dismantle it.
+        The music arrives thin, wobbly and missing exactly the parts people recognise
+        songs by.
+      </p>
+
+      <div className="callout">
+        <p className="callout-title">Never hold a phone up to the microphone</p>
+        <p>
+          It is the first thing everyone tries and the worst available option. It stacks
+          every processing artefact on top of room reverb and the phone speaker’s own
+          limits. If you take one thing from this page, take this one.
+        </p>
+      </div>
+
+      <h2>Problem two: you are sharing video, not audio</h2>
+      <p>
+        Screen sharing does not share sound unless you explicitly tell it to, and the
+        checkbox is easy to miss because it appears in the share dialog rather than in
+        settings. What each platform calls it:
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Platform</th>
+            <th>What to enable</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Zoom</strong></td>
+            <td>
+              In the share window: <em>Share sound</em>, then choose <em>High fidelity
+              music mode</em> in its dropdown. Also turn on <em>Original sound for
+              musicians</em> in audio settings.
+            </td>
+          </tr>
+          <tr>
+            <td><strong>Google Meet</strong></td>
+            <td>
+              Share a <em>Chrome tab</em> rather than a window or the whole screen, and
+              tick <em>Also share tab audio</em>. Only tab sharing carries audio.
+            </td>
+          </tr>
+          <tr>
+            <td><strong>Discord</strong></td>
+            <td>
+              Screen share carries application audio on desktop. Raise the server or
+              channel bitrate if you can; Discord is the most forgiving of these for
+              music.
+            </td>
+          </tr>
+          <tr>
+            <td><strong>Teams</strong></td>
+            <td>
+              <em>Include computer sound</em> in the share tray. It is off by default and
+              resets between calls.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Sharing computer sound rather than microphone sound also bypasses problem one
+        entirely: the audio never goes through the voice pipeline, so nothing suppresses
+        it. This is the whole fix, and it is why browser-based games are much easier to
+        run over a call than anything playing out of a speaker in your room.
+      </p>
+
+      <h2>Problem three: delay, which you cannot fix</h2>
+      <p>
+        Everyone on the call hears the clip at a slightly different moment, and the spread
+        is not small — comfortably enough to decide a race. Someone on hotel wifi may be
+        a second or more behind someone on fibre. Nothing you configure changes this;
+        it is the network.
+      </p>
+      <p>
+        Which means <strong>first-to-shout does not work over a video call</strong>. It is
+        not slightly unfair, it is measuring connection quality. Any competitive format
+        that resolves ties by speed is broken here.
+      </p>
+      <p>Three formats that survive it:</p>
+      <ul>
+        <li>
+          <strong>Written rounds.</strong> Everyone writes their answers privately —
+          paper, notes app, a private message to the host — and they are revealed at the
+          end of the round. Nobody is racing anybody, so latency stops mattering
+          completely. This is the default for remote play and it should be.
+        </li>
+        <li>
+          <strong>Teams in breakout rooms.</strong> Play the clip to everyone, then send
+          teams to breakouts for ninety seconds to agree an answer. Slower, and much more
+          social — the discussion is the entertainment, not the guessing.
+        </li>
+        <li>
+          <strong>Second-device buzzers.</strong> Players buzz on their own phone against
+          a shared clock rather than through the call. Still imperfect, because the audio
+          arrived at different times, but far closer than shouting into a microphone.
+        </li>
+      </ul>
+      <p>
+        More on why format choice matters more than difficulty in{" "}
+        <a href="/guides/guess-the-song-game-rules">the rules and variants guide</a>.
+      </p>
+
+      <h2>A pre-call checklist</h2>
+      <ol>
+        <li>
+          <strong>Test with one person before everyone arrives.</strong> Five minutes
+          earlier, one friend, one song. Every problem on this page is obvious within ten
+          seconds of a real test and invisible without one.
+        </li>
+        <li>
+          <strong>Ask everyone to use headphones.</strong> Not for their benefit — for
+          yours. Speakers mean the song comes back into their microphones and gets
+          re-transmitted a beat late, which is what turns a clean clip into a smear.
+        </li>
+        <li>
+          <strong>Mute the room by default.</strong> Guessing happens in the chat or on
+          paper. Fifteen open microphones on a call is not a quiz, it is a noise floor.
+        </li>
+        <li>
+          <strong>Use longer clips than you would in person.</strong> Add five to ten
+          seconds. Compressed audio over a call is genuinely harder to identify than the
+          same clip in a room, and you are compensating for the medium rather than making
+          it easier.
+        </li>
+        <li>
+          <strong>Have the answers where you can see them.</strong> You cannot read the
+          room over a call, so you cannot tell whether silence means thinking or means
+          your audio dropped. Being ready to move on quickly is the substitute.
+        </li>
+      </ol>
+
+      <h2>What to do when the audio fails mid-game</h2>
+      <p>
+        It will, once. The recovery is to stop immediately rather than play three more
+        songs hoping it settles: re-share, confirm with one person that they can hear it,
+        then replay the song you lost. A round played through broken audio is a round
+        everybody scores badly on for no reason, and it takes the energy out of the rest
+        of the night far more than a two-minute pause does.
+      </p>
+      <p>
+        If the clip itself is missing rather than the audio route being wrong — one song
+        silent, the rest fine — that is a different problem with a different fix, covered
+        in{" "}
+        <a href="/guides/songs-with-no-preview-clip">
+          why one song has no clip when the rest of the playlist does
+        </a>
+        .
+      </p>
+    </GuideShell>
+  );
+}

--- a/app/guides/music-quiz-round-ideas/page.tsx
+++ b/app/guides/music-quiz-round-ideas/page.tsx
@@ -1,0 +1,167 @@
+import type { Metadata } from "next";
+import { GuideShell, guideMetadata } from "@/app/guides/guide-shell";
+
+const SLUG = "music-quiz-round-ideas";
+
+export const metadata: Metadata = guideMetadata(SLUG);
+
+export default function Page() {
+  return (
+    <GuideShell slug={SLUG}>
+      <p>
+        A music quiz made entirely of “name that tune” rounds is the same round played
+        eight times. It works for about twenty-five minutes. After that the room has
+        learned everything the format can teach them, the same two people are winning, and
+        the night is running on politeness.
+      </p>
+      <p>
+        What fixes it is not harder songs. It is rounds that ask a different question, so
+        that being good at one of them does not predict being good at the next. Here are
+        twelve that need nothing but a playlist and a host, sorted by what they do to the
+        room rather than by theme.
+      </p>
+
+      <h2>Rounds that change what is being tested</h2>
+
+      <h3>1. Intros only</h3>
+      <p>
+        Two or three seconds, nothing more. This is not a harder version of the normal
+        round — it is a different skill. Very short clips reward production detail: a drum
+        sound, a synth patch, the exact reverb on a snare. The person who wins it is
+        frequently not the person who knows the most music, which is the entire point of
+        putting it in the middle of a night somebody is running away with.
+      </p>
+
+      <h3>2. Finish the lyric</h3>
+      <p>
+        Cut the clip mid-line and let the room complete it. Lyric recall and title recall
+        live in different parts of people’s memory, and the gap between them is wide.
+        Expect at least one person who has scored nothing all night to win this outright.
+      </p>
+
+      <h3>3. Blind decade</h3>
+      <p>
+        Nobody names anything. Everyone writes down the year they think the song came out
+        and the closest guess takes the points. The reason to run it is practical: it makes
+        unfamiliar music playable. A playlist that would be dead as a naming round is a
+        perfectly good guessing round, which means you can finally use somebody’s obscure
+        favourites without stranding the rest of the table.
+      </p>
+
+      <h3>4. One-word summary</h3>
+      <p>
+        The host describes the song in exactly one word, before any music plays. The room
+        guesses. If nobody gets it, play the clip. It is a warm-up round rather than a
+        scoring one, and it is the single best way to open a night with a group that does
+        not know each other, because the laugh comes from the host’s word rather than from
+        anyone’s ignorance.
+      </p>
+
+      <h3>5. The cover version</h3>
+      <p>
+        Play a cover and ask for the original artist. Two things make this good: covers
+        are usually recognisable to people who do not know the original, and the answer
+        rewards a completely different kind of knowledge. Be careful with the search — a
+        lot of what is filed as a cover on streaming services is a soundalike recording by
+        a tribute act, which is not the same round.
+      </p>
+
+      <h2>Rounds that change who can win</h2>
+
+      <h3>6. Whose playlist is it?</h3>
+      <p>
+        Everyone submits their own music, it is shuffled into one pool, and the question is
+        not what the song is but which person in the room put it there. The best round in
+        this list, and the only one where knowing less about music is close to costless.
+        The reasoning behind it, and what to do with the results, is in{" "}
+        <a href="/guides/mixed-playlist-mode-guide">the Mixed Playlist Mode guide</a>.
+      </p>
+
+      <h3>7. Handicap round</h3>
+      <p>
+        Whoever is leading answers last. They get the same clip and the same question, but
+        only after everyone else has had a go. Brutally effective, mildly humiliating, and
+        far better received than any of the polite alternatives — the room enjoys watching
+        the leader squirm much more than it enjoys a scoring adjustment nobody can follow.
+      </p>
+
+      <h3>8. Pairs</h3>
+      <p>
+        Split into pairs for one round, deliberately mismatched: the person who knows the
+        most music with the person who knows the least. Answers only count if the pair
+        agrees. It is a conversation round disguised as a quiz round, and it is the fastest
+        way to get a group who arrived separately talking to each other.
+      </p>
+
+      <h3>9. Steal</h3>
+      <p>
+        If nobody gets a song within the clip, it goes to whoever is in last place for a
+        free attempt with a longer clip. Costs nothing, takes ten seconds, and gives the
+        bottom of the table a reason to still be listening in the second half.
+      </p>
+
+      <h2>Rounds that change the tempo</h2>
+
+      <h3>10. Speed round</h3>
+      <p>
+        Six to ten songs back to back. Short clips, no album points, no discussion, next
+        song the moment someone is right or five seconds have passed. Run it as the finale.
+        The purpose is not difficulty — it is that the last ten minutes of the night should
+        not feel like the middle forty.
+      </p>
+
+      <h3>11. Sing-along round</h3>
+      <p>
+        Thirty-second clips, everything obvious, scoring almost incidental. Somewhere
+        around twenty seconds a room stops competing and starts singing, and that is a
+        feature if you deploy it on purpose. Put one in the middle when energy dips, and
+        one at the end if the group is more party than quiz.{" "}
+        <a href="/guides/clip-length-and-difficulty">
+          Why clip length changes the activity and not just the difficulty.
+        </a>
+      </p>
+
+      <h3>12. The wildcard</h3>
+      <p>
+        One song, announced in advance, worth triple. Players nominate before it plays
+        whether they are in — and a wrong answer on a wildcard costs points. It is the only
+        round on this list where someone can lose ground, which is exactly why it works as
+        a closer: a night that was decided twenty minutes ago becomes live again.
+      </p>
+
+      <div className="callout">
+        <p className="callout-title">A running order that works</p>
+        <p>
+          One-word summary to open, three normal rounds, finish the lyric, whose playlist
+          is it, a sing-along when energy dips, intros only, then a speed round and the
+          wildcard. Roughly ninety minutes for eight to twelve people, and the shape of it
+          — easy, competitive, social, hard, fast — matters more than any individual
+          round.
+        </p>
+      </div>
+
+      <h2>Two rules for assembling a night</h2>
+      <p>
+        <strong>Never run two rounds of the same kind back to back.</strong> Two hard
+        rounds in a row reads to the room as “this game got worse”, even though each one
+        would have been fine on its own. Alternate what is being tested and the same
+        material feels varied.
+      </p>
+      <p>
+        <strong>Announce the round before the music, every time.</strong> A round whose
+        rules arrive after the first clip has already cost somebody the answer they were
+        about to give, and that is the one thing a room genuinely resents. Twenty seconds
+        of explanation is not dead air — it is the part where everyone gets to decide how
+        hard they are about to try.
+      </p>
+      <p>
+        The rest of the mechanics — where people sit, what to do about the person who
+        knows everything, how long the whole thing should run — are in{" "}
+        <a href="/guides/how-to-host-a-music-quiz-night">how to host a music quiz night</a>
+        . If your group is bigger than about fifteen, read{" "}
+        <a href="/guides/music-quiz-for-large-groups">the large-group guide</a> first,
+        because several of these rounds need reworking before they survive a crowd.
+      </p>
+    </GuideShell>
+  );
+}

--- a/app/guides/songs-with-no-preview-clip/page.tsx
+++ b/app/guides/songs-with-no-preview-clip/page.tsx
@@ -1,0 +1,174 @@
+import type { Metadata } from "next";
+import { GuideShell, guideMetadata } from "@/app/guides/guide-shell";
+
+const SLUG = "songs-with-no-preview-clip";
+
+export const metadata: Metadata = guideMetadata(SLUG);
+
+export default function Page() {
+  return (
+    <GuideShell slug={SLUG}>
+      <p>
+        Forty-nine songs in a playlist play fine and one is silent. It looks like a bug in
+        whatever you are using, and occasionally it is — but far more often it is a
+        structural fact about where preview clips come from, and it is worth understanding
+        because it tells you which songs to expect trouble from before you sit down to
+        play.
+      </p>
+      <p>
+        This is written from building one of these games. The specifics below are things
+        we hit and had to fix, not general advice.
+      </p>
+
+      <h2>The clip does not come from Spotify</h2>
+      <p>
+        Start here, because everything else follows from it. Spotify’s API used to hand
+        out a thirty-second <code>preview_url</code> for most tracks. In late 2024 it
+        stopped doing so for new applications, and on the credentials a small
+        no-login app can obtain, the field now comes back empty for effectively
+        everything — we measured zero previews across twenty tracks in four different
+        markets before accepting that it was not a configuration mistake.
+      </p>
+      <p>
+        So a Spotify-based guessing game reads the <em>track list</em> from Spotify and
+        then goes somewhere else entirely for the audio — in our case the iTunes Search
+        API first, then Deezer. Which means the question is never “does Spotify have this
+        song”. It is <strong>“can a second catalogue be made to agree that its recording
+        is the same recording”</strong>, and that is a much harder question.{" "}
+        <a href="/guides/why-spotify-previews-disappeared">
+          The full account of what changed and what it broke.
+        </a>
+      </p>
+
+      <h2>Five reasons a specific song has no clip</h2>
+
+      <h3>1. It genuinely is not in the other catalogue</h3>
+      <p>
+        Self-released tracks, small-label material, regional releases, podcast episodes
+        filed as music, and a surprising amount of very new music. Spotify’s catalogue and
+        iTunes’ catalogue are large and overlapping, not identical. Nothing can be done
+        about this one.
+      </p>
+
+      <h3>2. The title does not match, because of a qualifier</h3>
+      <p>
+        Spotify stores <code>Karma Police - Remastered 2011</code>. iTunes has the same
+        recording as plain <code>Karma Police</code>. An exact comparison matches neither
+        thing, so the lookup either fails or — worse — falls through to a looser rule and
+        picks a different song by the same artist. This is one of the most common causes
+        and it is invisible from the outside: the song is right there in both catalogues,
+        under two names.
+      </p>
+      <p>
+        Live versions, radio edits, extended mixes, deluxe-edition re-recordings and
+        “(feat.)” credits that one platform includes and the other does not all do the same
+        thing.
+      </p>
+
+      <h3>3. The artist is credited differently</h3>
+      <p>
+        Non-Latin catalogues are where this really bites. Spotify credits 小幸運 to 田馥甄;
+        iTunes returns it as “A Little Happiness” by “Hebe Tien”. Both are correct, neither
+        matches the other, and any matcher strict enough to reject wrong answers will
+        reject this one too. Collaborations are the same story in a smaller way — “The
+        Beatles” against “Beatles”, or one platform listing three featured artists where
+        the other lists one.
+      </p>
+
+      <h3>4. There was a clip, and the URL rotted</h3>
+      <p>
+        Preview clips are files on a content delivery network, and those addresses rotate.
+        A song that played last month can be silent today with nothing about the song
+        having changed. This is why a well-built game stores enough to re-resolve a clip
+        rather than just caching the address — but if you are using something that does
+        not, an old cached answer is a permanent one.
+      </p>
+
+      <h3>5. Nothing is wrong and you are being rate limited</h3>
+      <p>
+        The one that matters most and looks least like itself. Clip lookups are per track
+        rather than per playlist, so a fifty-song game is fifty separate requests to a
+        third-party service — and hosted apps share their outbound addresses, so from the
+        catalogue’s side an entire user base looks like one very noisy client.
+      </p>
+      <p>
+        A throttled request and a song with no clip look identical unless the app is
+        careful to tell them apart. We shipped a version that did not: every failure was
+        cached as “this song has no preview” for a week, so one throttled minute at peak
+        marked a slice of the catalogue silent for seven days. It never reproduced in
+        testing, because a laptop’s own address is never the one being throttled.
+      </p>
+
+      <div className="callout">
+        <p className="callout-title">How to tell cause five from the others</p>
+        <p>
+          If several songs in a row go quiet, it is throttling or a network problem, not
+          the catalogue. Catalogue gaps are scattered. A run of consecutive failures is
+          almost always the app being refused. Wait a couple of minutes and try again.
+        </p>
+      </div>
+
+      <h2>The failure that is worse than silence</h2>
+      <p>
+        A missing clip is obvious and mildly annoying. The genuinely damaging failure is
+        the <em>wrong</em> clip — the audio plays, everybody guesses, and the answer card
+        says something else.
+      </p>
+      <p>
+        It happens because a search that cannot find an exact match gets progressively
+        looser, and the loosest question — the title with no artist attached — is answered
+        by popularity. Ask iTunes for “Hello” with no other constraint and you can get
+        Pinkfong’s nursery rhyme. Ask for “Alone” and you get Heart. Ask for “Hello Adele”
+        and the second result is a tribute act whose track is titled exactly right, which
+        is precisely what a popularity-ranked search surfaces.
+      </p>
+      <p>
+        The defence is to require any loosely-matched candidate to agree with the original
+        on something the search did not supply — the running time, or a credit that names
+        the same acts. A candidate whose duration is fifty seconds off the Spotify track is
+        a cover, and the recording you wanted is the one whose clock agrees.
+      </p>
+      <p>
+        If you are playing and a clip clearly does not match the answer, that is what
+        happened. Skip it rather than arguing about it, and do not award points for the
+        song that actually played.
+      </p>
+
+      <h2>What to do as a host</h2>
+      <ol>
+        <li>
+          <strong>Skip and move on.</strong> One silent track costs you fifteen seconds.
+          Debugging it mid-party costs you the room.
+        </li>
+        <li>
+          <strong>Try the playlist once before people arrive.</strong> Not the whole thing
+          — start a game, click through eight or ten songs, and see whether the silences
+          are scattered or clustered. Two minutes, and it tells you which playlist to use.
+        </li>
+        <li>
+          <strong>Prefer well-known studio recordings.</strong> Not for musical reasons:
+          they are the recordings most likely to exist in both catalogues under compatible
+          names. Remaster-heavy back catalogues, live albums and regional releases are
+          where the gaps concentrate.{" "}
+          <a href="/guides/best-playlists-for-a-guess-the-song-game">
+            More on choosing a playlist that plays well.
+          </a>
+        </li>
+        <li>
+          <strong>Have a second playlist ready.</strong> The cheapest insurance there is.
+          If the first one turns out to be half silent, you switch instead of ending the
+          night.
+        </li>
+      </ol>
+      <p>
+        If it is the whole playlist failing rather than individual songs, that is a
+        different problem with four common causes, and three of them you can fix from the
+        page you are on:{" "}
+        <a href="/guides/spotify-playlist-not-working">
+          why your Spotify playlist will not load
+        </a>
+        .
+      </p>
+    </GuideShell>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -90,11 +90,15 @@ async function settleWithConcurrency<T, R>(
 
 // Rendered on the page *and* emitted as FAQPage JSON-LD below — keep the two
 // in sync, Google penalises schema that doesn't match visible content.
-// The three guides linked from the homepage. Resolved through getGuide rather
-// than retyped so the titles here cannot drift from the articles themselves;
-// filtered so a retired slug costs a card instead of crashing the homepage.
+// The handful of guides linked from the homepage. Resolved through getGuide
+// rather than retyped so the titles here cannot drift from the articles
+// themselves; filtered so a retired slug costs a card instead of crashing the
+// homepage. This is also the only inbound link a new guide gets from the
+// highest-authority page on the site, which is what gets it crawled — so a
+// newly published article is worth putting here for a while.
 const HOME_GUIDES = [
   "how-to-host-a-music-quiz-night",
+  "guess-the-song-game-rules",
   "best-playlists-for-a-guess-the-song-game",
   "spotify-playlist-not-working",
 ]
@@ -1411,9 +1415,11 @@ export default function SetupPage() {
             </div>
           </section>
 
-          {/* Three of the guides, not all eight — this is a teaser under a form,
-              not a second index. HOME_GUIDES names which three; the copy comes
-              from lib/guides.ts so a retitled guide is retitled here too. */}
+          {/* A few of the guides, deliberately not all of them — this is a
+              teaser under a form, not a second index. HOME_GUIDES names which;
+              the copy comes from lib/guides.ts so a retitled guide is retitled
+              here too. (The count used to be written into this comment, and it
+              went stale the first time a guide was added.) */}
           <section className="seo-section">
             <h2 className="seo-h2">Guides</h2>
             <p className="seo-p">

--- a/lib/changelog.ts
+++ b/lib/changelog.ts
@@ -49,6 +49,46 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "1.8.0",
+    date: "2026-08-30",
+    headline:
+      "Six new guides — quiz round ideas, running one for a big group, playing over a video call, and what to do when a single song has no clip.",
+    headlineZh:
+      "新增六篇指南：各種猜歌回合的玩法、人多的時候怎麼帶、用視訊通話怎麼玩，還有某一首歌播不出聲音時該怎麼辦。",
+    changes: [
+      {
+        kind: "new",
+        text: "Twelve music quiz round formats, sorted by what each one does to a room — which ones let a quieter player win, and where each belongs in a running order.",
+        textZh: "十二種猜歌回合的玩法，照「會讓現場氣氛怎麼變」來分類：哪一種能讓比較安靜的人有機會贏，還有整晚的順序怎麼排。",
+      },
+      {
+        kind: "new",
+        text: "A guide to running a quiz for twenty people or more: the three things that break at that size, and why teams fix all of them at once.",
+        textZh: "一篇專門講二十人以上怎麼玩的指南：人一多會壞掉的三件事，以及為什麼分組一次就能解決全部。",
+      },
+      {
+        kind: "new",
+        text: "How to run one over Zoom, Meet or Discord — the exact audio setting to turn on for each, and the one rule you have to drop because everyone hears the clip at a different moment.",
+        textZh: "怎麼用 Zoom、Meet 或 Discord 玩：每個平台要打開哪個聲音設定，還有一條一定要放棄的規則，因為每個人聽到片段的時間都不一樣。",
+      },
+      {
+        kind: "new",
+        text: "Why one song can be silent when the rest of the playlist plays fine, and how to tell a genuine catalogue gap from us being temporarily rate limited.",
+        textZh: "為什麼歌單其他歌都正常，卻只有一首沒有聲音；以及怎麼分辨是那首歌真的找不到片段，還是我們暫時被對方限流了。",
+      },
+      {
+        kind: "new",
+        text: "The rules of guess the song written out properly, with nine variants and the four house rules worth agreeing before you start.",
+        textZh: "把猜歌遊戲的規則好好寫了一遍，附九種變化玩法，還有開場前值得先講好的四條自訂規則。",
+      },
+      {
+        kind: "new",
+        text: "A plain-language look at music licensing for quiz nights: when it applies, who normally already holds the licence, and what a thirty-second preview clip does and does not cover.",
+        textZh: "用白話講猜歌之夜的音樂授權：什麼情況下才需要、通常是場地方早就處理好了，以及三十秒試聽片段涵蓋與不涵蓋的範圍。",
+      },
+    ],
+  },
+  {
     version: "1.7.5",
     date: "2026-08-25",
     headline:

--- a/lib/guides.ts
+++ b/lib/guides.ts
@@ -55,9 +55,9 @@ export const GUIDES: Guide[] = [
     published: "2026-08-21",
     minutes: 8,
     related: [
+      "music-quiz-round-ideas",
       "music-quiz-scoring-rules",
       "best-playlists-for-a-guess-the-song-game",
-      "clip-length-and-difficulty",
     ],
   },
   {
@@ -72,7 +72,7 @@ export const GUIDES: Guide[] = [
     minutes: 7,
     related: [
       "clip-length-and-difficulty",
-      "how-to-host-a-music-quiz-night",
+      "guess-the-song-game-rules",
       "spotify-playlist-not-working",
     ],
   },
@@ -88,8 +88,8 @@ export const GUIDES: Guide[] = [
     minutes: 6,
     related: [
       "music-quiz-scoring-rules",
+      "guess-the-song-game-rules",
       "best-playlists-for-a-guess-the-song-game",
-      "how-to-host-a-music-quiz-night",
     ],
   },
   {
@@ -103,9 +103,9 @@ export const GUIDES: Guide[] = [
     published: "2026-08-21",
     minutes: 7,
     related: [
+      "guess-the-song-game-rules",
       "how-to-host-a-music-quiz-night",
       "clip-length-and-difficulty",
-      "mixed-playlist-mode-guide",
     ],
   },
   {
@@ -119,8 +119,8 @@ export const GUIDES: Guide[] = [
     published: "2026-08-21",
     minutes: 7,
     related: [
+      "music-quiz-for-large-groups",
       "music-quiz-scoring-rules",
-      "how-to-host-a-music-quiz-night",
       "party-games-for-small-groups",
     ],
   },
@@ -135,9 +135,9 @@ export const GUIDES: Guide[] = [
     published: "2026-08-21",
     minutes: 7,
     related: [
+      "songs-with-no-preview-clip",
       "why-spotify-previews-disappeared",
       "best-playlists-for-a-guess-the-song-game",
-      "how-to-host-a-music-quiz-night",
     ],
   },
   {
@@ -151,9 +151,9 @@ export const GUIDES: Guide[] = [
     published: "2026-08-21",
     minutes: 8,
     related: [
+      "songs-with-no-preview-clip",
+      "music-quiz-licensing-and-previews",
       "spotify-playlist-not-working",
-      "best-playlists-for-a-guess-the-song-game",
-      "clip-length-and-difficulty",
     ],
   },
   {
@@ -167,9 +167,105 @@ export const GUIDES: Guide[] = [
     published: "2026-08-21",
     minutes: 7,
     related: [
+      "music-quiz-for-large-groups",
       "how-to-host-a-music-quiz-night",
       "mixed-playlist-mode-guide",
+    ],
+  },
+  {
+    slug: "guess-the-song-game-rules",
+    title: "Guess the Song: The Rules, and Nine Variants Worth Knowing",
+    navTitle: "Guess the song: rules and variants",
+    description:
+      "The base rules of a guess the song game written out properly, nine variants that each change one thing about it, and the four house rules that stop the arguments before they start.",
+    lede: "Every argument at a quiz night is really about one of three questions: who may answer, when, and what counts as an answer.",
+    category: "Playing",
+    published: "2026-08-30",
+    minutes: 8,
+    related: [
       "music-quiz-scoring-rules",
+      "clip-length-and-difficulty",
+      "music-quiz-round-ideas",
+    ],
+  },
+  {
+    slug: "music-quiz-round-ideas",
+    title: "Twelve Music Quiz Rounds That Are Not “Name That Tune”",
+    navTitle: "Music quiz round ideas",
+    description:
+      "Twelve rounds that need nothing but a playlist and a host, sorted by what they do to a room: what each one tests, who it lets win, and where it belongs in a running order.",
+    lede: "A quiz made entirely of name-that-tune rounds is one round played eight times. It works for about twenty-five minutes.",
+    category: "Hosting",
+    published: "2026-08-30",
+    minutes: 7,
+    related: [
+      "how-to-host-a-music-quiz-night",
+      "guess-the-song-game-rules",
+      "music-quiz-for-large-groups",
+    ],
+  },
+  {
+    slug: "music-quiz-over-video-call",
+    title: "Running a Music Quiz Over Zoom, Meet or Discord",
+    navTitle: "Music quiz over video call",
+    description:
+      "Why music sounds destroyed over a video call, the exact setting to enable on each platform, and the one rule of the in-person game that has to be thrown away because audio delay makes it meaningless.",
+    lede: "A remote music quiz fails in a specific, predictable way, and it is almost never the quiz’s fault. It is the audio.",
+    category: "Hosting",
+    published: "2026-08-30",
+    minutes: 6,
+    related: [
+      "how-to-host-a-music-quiz-night",
+      "songs-with-no-preview-clip",
+      "music-quiz-round-ideas",
+    ],
+  },
+  {
+    slug: "music-quiz-for-large-groups",
+    title: "Running a Music Quiz for Twenty People or More",
+    navTitle: "Music quiz for large groups",
+    description:
+      "A quiz built for eight does not scale to thirty by adding chairs. The three things that break at size, why teams fix all of them at once, and which rounds survive a crowd.",
+    lede: "At twenty-five people the same six confident players take everything and the rest are an audience. That is structural, not a matter of trying harder.",
+    category: "Hosting",
+    published: "2026-08-30",
+    minutes: 7,
+    related: [
+      "how-to-host-a-music-quiz-night",
+      "party-games-for-small-groups",
+      "music-quiz-scoring-rules",
+    ],
+  },
+  {
+    slug: "songs-with-no-preview-clip",
+    title: "Why One Song Has No Clip When the Rest of the Playlist Does",
+    navTitle: "When a song has no clip",
+    description:
+      "Five reasons a single track goes silent in a Spotify-based music game — remaster suffixes, differently credited artists, rotated URLs, catalogue gaps and throttling — and how to tell which one you are looking at.",
+    lede: "Forty-nine songs play and one is silent. It looks like a bug, and it is usually a structural fact about where preview clips come from.",
+    category: "Troubleshooting",
+    published: "2026-08-30",
+    minutes: 6,
+    related: [
+      "why-spotify-previews-disappeared",
+      "spotify-playlist-not-working",
+      "best-playlists-for-a-guess-the-song-game",
+    ],
+  },
+  {
+    slug: "music-quiz-licensing-and-previews",
+    title: "Music Licensing and Quiz Nights: What Actually Applies",
+    navTitle: "Licensing and quiz nights",
+    description:
+      "The three separate questions people collapse into one: whether it is a public performance, who already holds the licence, and what a thirty-second preview clip does and does not permit.",
+    lede: "Nobody running a quiz in their living room needs this page. Anyone running one in a pub, a school or a hired hall probably does.",
+    category: "Troubleshooting",
+    published: "2026-08-30",
+    minutes: 6,
+    related: [
+      "why-spotify-previews-disappeared",
+      "music-quiz-over-video-call",
+      "how-to-host-a-music-quiz-night",
     ],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guesssong",
-  "version": "1.7.5",
+  "version": "1.8.0",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -114,6 +114,38 @@ describe("guides index", () => {
   });
 });
 
+describe("homepage guide teaser", () => {
+  // app/page.tsx picks a few slugs by hand and resolves them through getGuide,
+  // filtering out anything that does not resolve. That filter is deliberate —
+  // a retired guide should cost a card rather than crash the homepage — but it
+  // makes a *typo* silent in exactly the same way, and the homepage is the one
+  // inbound link that reliably gets a new guide crawled. Read as source text
+  // because the suite cannot import a .tsx module here; same technique as
+  // "wires each page to its own slug" above.
+  const source = readFileSync(join(process.cwd(), "app/page.tsx"), "utf8");
+
+  function homeGuideSlugs(): string[] {
+    const match = source.match(/const HOME_GUIDES = \[([\s\S]*?)\]/);
+    expect(match, "HOME_GUIDES array not found in app/page.tsx").toBeTruthy();
+    return Array.from(match![1].matchAll(/"([^"]+)"/g)).map((m) => m[1]);
+  }
+
+  it("names at least one guide", () => {
+    expect(homeGuideSlugs().length).toBeGreaterThan(0);
+  });
+
+  it("resolves every slug it names", () => {
+    for (const slug of homeGuideSlugs()) {
+      expect(getGuide(slug), `app/page.tsx links to unknown guide "${slug}"`).toBeDefined();
+    }
+  });
+
+  it("names each guide at most once", () => {
+    const slugs = homeGuideSlugs();
+    expect(new Set(slugs).size, "a guide is listed twice on the homepage").toBe(slugs.length);
+  });
+});
+
 describe("guide lookups", () => {
   // The happy paths are covered above by the directory/slug joins. These are
   // the branches those never reach — the ones that only run once a guide is


### PR DESCRIPTION
## Why

AdSense refused the site a **second** time under 缺乏價值的內容 (Low value content) — the same code as 2026-08-21, but this time with the 1.7.0 compliance work already live. So compliance was never the gap.

The live site was measured rather than assumed, and it is fine:

| Check | State |
|---|---|
| Indexable URLs | 17 |
| Guide length (rendered) | 1,132–1,477 words |
| Policy pages | Live, footer-linked on every page via `components/site-footer.tsx` |
| `ads.txt` | Present, publisher id matches `NEXT_PUBLIC_ADSENSE_CLIENT_ID` |
| Canonicals + `Article` JSON-LD | Present |
| `robots.ts` | Nothing content-shaped disallowed |

None of that was worth redoing. What is short is **editorial volume**, measured against the bar for *tool* sites rather than blogs: a reviewer samples the tool page and will not accept UI as the site, so the tool has to carry its own supporting library. Published guidance puts that band at 10–20 supporting articles of 800–1,200+ words. Eight sits below it. Fourteen is inside it.

## What changed

Six guides, 1,045–1,373 words of source prose each, declared once in `lib/guides.ts` so the route, the `/guides` index, `app/sitemap.ts` and the sibling "read next" links all derive from the entry.

| Slug | Category |
|---|---|
| `guess-the-song-game-rules` | Playing |
| `music-quiz-round-ideas` | Hosting |
| `music-quiz-over-video-call` | Hosting |
| `music-quiz-for-large-groups` | Hosting |
| `songs-with-no-preview-clip` | Troubleshooting |
| `music-quiz-licensing-and-previews` | Troubleshooting |

The rejection is about *information gain*, not word count — an article 100,000 other sites already have is thin no matter how long it is. So two of the six are the ones this project can write and nobody else can:

- **`songs-with-no-preview-clip`** is `lib/preview-cache.ts`'s hazard list turned outward — the remaster suffix, the differently-credited artist (小幸運/田馥甄 vs "A Little Happiness"/"Hebe Tien"), the rotated CDN URL, and the `absent`/`unavailable` collapse that marked a slice of the catalogue silent for a week — written for the host who sees one quiet track and assumes a bug.
- **`music-quiz-over-video-call`** states the audio problem properly: voice processing dismantles music by design, and network delay makes first-to-answer a measurement of connection quality, which *retires* the base game's central rule rather than merely inconveniencing it.

### Internal linking

The eight existing guides' `related` arrays are rewired so each new article has an inbound link from an **established** page. `tests/guides.test.ts` only asserts a guide has *an* inbound link, which the six would have satisfied by pointing at each other — and that is exactly the shape Google reaches last. Count stays at three per guide, so nothing about the rendered block changes.

### New test

`HOME_GUIDES` in `app/page.tsx` had **no coverage**, and its `.filter(Boolean)` makes a typo indistinguishable from a deliberately retired guide: the card just stops rendering. That is the silent-drift class every other assertion in `tests/guides.test.ts` exists to catch, sitting on the one link that reliably gets a new article crawled. Now pinned — read as source text, because the suite cannot import a `.tsx` module here, which is the technique the "wires each page to its own slug" assertion already uses.

## Verification

- **594 tests pass** (32 files), up from 591 — the three new ones are the `HOME_GUIDES` pins.
- **Lint clean.**
- **Build route table checked** per `CLAUDE.md`: all 14 guides `○`, `/icon` and `/opengraph-image` `○`, `/icons/[size]` `●` with its three sizes. No `ƒ` regression.

### One thing worth knowing about the test run

The first evidence-wrapped run failed 12 tests in `tests/kv.test.ts` and `tests/room.test.ts`. Not a regression, and worth recording: **`gstack-evidence` is a bun script, and Bun auto-loads `.env` into `process.env`.** This repo's `.env` holds real `UPSTASH_REDIS_REST_*`, so those got inherited by the spawned test process, `hasUpstash()` returned true, and the "in-memory fallback" tests ran against **production Redis** (39.8s with 661ms/1869ms network waits, versus 1.6s clean).

Re-run as `env -u UPSTASH_REDIS_REST_URL -u UPSTASH_REDIS_REST_TOKEN npm test` it is green. `npm test` as documented in CLAUDE.md was green throughout — nothing in this diff goes near `lib/kv.ts` or `lib/room.ts`.

The live site does currently show `spotify_budget_low`, and that is **organic, not caused by the stray run**: `npm run stats` reports 1,722 upstream loads in the rolling 24h against the 2,000 ceiling — 86%, past the 0.8 warn ratio — on a normal evening-peak histogram.

## Do not file the appeal when this deploys

Every source on this is consistent: publishing and applying the same day is its own failure mode, and that is what happened with 1.7.0. A `site:guessong.app` query today returns only `/` and `/about` — not authoritative on its own, but it is the one signal that would explain refusing a site whose content is genuinely there.

Deploy, wait ~2 weeks, then open **Search Console → Pages** and confirm the guides are *indexed*, not merely submitted. Two appeals are spent; treat the next as the last cheap one.

The homepage was deliberately left alone. If a third refusal arrives with fourteen *indexed* guides behind it, that is the next lever — `/` renders ~750 words plus an FAQ, which is adequate rather than strong. More articles at that point would be the thin filler the policy is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQzzozuCiKk5kdUodDB5Wq
